### PR TITLE
Address Copilot review feedback from PR #2

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -664,7 +664,6 @@ img, svg {
   width: 22rem;
 }
 
-/* Responsive adjustments for narrow viewports */
 @media (max-width: 900px) {
   .plan-layout__content {
     max-width: 100%;
@@ -723,10 +722,6 @@ img, svg {
 .comment-tab--active .comment-tab__count {
   background: var(--color-primary);
   color: white;
-}
-
-/* Comment threads list */
-.comment-threads-list {
 }
 
 /* Comment form */

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -10,8 +10,8 @@ class PlansController < ApplicationController
   def show
     authorize!(@plan, :show?)
     threads = @plan.comment_threads.includes(:comments, :created_by_user, :plan_version).order(created_at: :asc)
-    @active_threads = threads.select { |t| t.status == "open" && !t.out_of_date? }
-    @archived_threads = threads.reject { |t| t.status == "open" && !t.out_of_date? }
+    @active_threads = threads.active
+    @archived_threads = threads.archived
   end
 
   def edit

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -22,7 +22,11 @@ class CommentThread < ApplicationRecord
     threads = where(out_of_date: false).where.not(plan_version_id: new_version.id)
     threads.find_each do |thread|
       next unless thread.anchored?
-      next if content.include?(thread.anchor_text)
+      if thread.anchor_context.present?
+        next if content.include?(thread.anchor_context)
+      else
+        next if content.include?(thread.anchor_text)
+      end
 
       thread.update_columns(
         out_of_date: true,


### PR DESCRIPTION
Fixes raised in the Copilot code review on #2:

- **extractContext bug**: Return `""` instead of `selectedText` when text not found
- **DOM offset accuracy**: Replace `preRange.toString().length` with TreeWalker-based `getSelectionOffset()`
- **DB-level filtering**: Use `active`/`archived` scopes instead of Ruby `select`/`reject`
- **Context-aware out-of-date detection**: `mark_out_of_date_for_new_version!` checks `anchor_context` first
- **Empty CSS rule removed**: Duplicate `.comment-threads-list {}`
- **Responsive layout**: Added `@media (max-width: 900px)` breakpoint for sidebar
- **Test coverage**: 9 new tests for scopes and `mark_out_of_date_for_new_version!`

All 152 tests pass.