### PR TITLE
Add caution banner to sign-in page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -334,7 +334,7 @@ img, svg {
 }
 
 .sign-in-form {
-  margin-top: var(--space-xl);
+  margin-top: var(--space-sm);
   text-align: left;
 }
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,7 @@
     <h1>Planning Department</h1>
     <p class="text-muted text-sm">Sign in with your work email</p>
 
-    <div class="alert alert--warning" style="background: #fff3cd; border: 1px solid #ffecb5; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.85rem; color: #664d03;">
+    <div style="background: #fff3cd; border: 1px solid #ffecb5; border-radius: 6px; padding: 0.5rem 0.75rem; margin-top: 1rem; font-size: 0.8rem; color: #664d03; text-align: left;">
       ⚠️ During initial development, login is a trust system. Use your <strong>ldap@squareup.com</strong> to sign in.
     </div>
 


### PR DESCRIPTION
Adds a warning banner above the login form reminding users that login is currently a trust system and to use their **ldap@squareup.com** email to sign in.

<img width="546" height="385" alt="image" src="https://github.com/user-attachments/assets/a80c6944-9340-4603-80b1-ee6d8d824f88" />
