### PR TITLE
Replace prompt_path with prompt_text and require organization

### DIFF
--- a/app/admin/automated_plan_reviewers.rb
+++ b/app/admin/automated_plan_reviewers.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register AutomatedPlanReviewer do
-  permit_params :organization_id, :key, :name, :prompt_path, :enabled, :ai_provider, :ai_model, trigger_statuses: []
+  permit_params :organization_id, :key, :name, :prompt_text, :enabled, :ai_provider, :ai_model, trigger_statuses: []
 
   index do
     selectable_column
@@ -21,7 +21,7 @@ ActiveAdmin.register AutomatedPlanReviewer do
       row :key
       row :name
       row :organization
-      row :prompt_path
+      row :prompt_text
       row :enabled
       row :ai_provider
       row :ai_model

--- a/app/models/automated_plan_reviewer.rb
+++ b/app/models/automated_plan_reviewer.rb
@@ -1,7 +1,16 @@
 class AutomatedPlanReviewer < ApplicationRecord
   ACTOR_TYPE = "cloud_persona"
 
-  belongs_to :organization, optional: true
+  DEFAULT_REVIEWERS = [
+    { key: "security-reviewer", name: "Security Reviewer", prompt_file: "prompts/reviewers/security.md",
+      trigger_statuses: [ "considering" ], ai_model: "gpt-4o" },
+    { key: "scalability-reviewer", name: "Scalability Reviewer", prompt_file: "prompts/reviewers/scalability.md",
+      trigger_statuses: [ "considering", "developing" ], ai_model: "gpt-4o" },
+    { key: "routing-reviewer", name: "Routing Reviewer", prompt_file: "prompts/reviewers/routing.md",
+      trigger_statuses: [], ai_model: "gpt-4o" }
+  ].freeze
+
+  belongs_to :organization
 
   after_initialize { self.trigger_statuses ||= [] }
 
@@ -9,36 +18,32 @@ class AutomatedPlanReviewer < ApplicationRecord
     format: { with: /\A[a-z0-9-]+\z/, message: "only allows lowercase letters, numbers, and hyphens" }
   validates :key, uniqueness: { scope: :organization_id }
   validates :name, presence: true
-  validates :prompt_path, presence: true
+  validates :prompt_text, presence: true
   validates :ai_provider, presence: true
   validates :ai_model, presence: true
 
-  validate :prompt_file_exists
-
   scope :enabled, -> { where(enabled: true) }
 
+  def self.create_defaults_for(organization)
+    DEFAULT_REVIEWERS.each do |template|
+      organization.automated_plan_reviewers.find_or_create_by!(key: template[:key]) do |r|
+        r.name = template[:name]
+        r.prompt_text = File.read(Rails.root.join(template[:prompt_file]))
+        r.trigger_statuses = template[:trigger_statuses]
+        r.ai_model = template[:ai_model]
+      end
+    end
+  end
+
   def self.ransackable_attributes(auth_object = nil)
-    %w[id key name prompt_path enabled ai_provider ai_model organization_id created_at updated_at]
+    %w[id key name enabled ai_provider ai_model organization_id created_at updated_at]
   end
 
   def self.ransackable_associations(auth_object = nil)
     %w[organization]
   end
 
-  def prompt_content
-    File.read(Rails.root.join(prompt_path))
-  end
-
   def triggers_on_status?(status)
     trigger_statuses.include?(status.to_s)
-  end
-
-  private
-
-  def prompt_file_exists
-    return if prompt_path.blank?
-    unless File.exist?(Rails.root.join(prompt_path))
-      errors.add(:prompt_path, "file does not exist: #{prompt_path}")
-    end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,6 +6,7 @@ class Organization < ApplicationRecord
   has_many :automated_plan_reviewers, dependent: :destroy
 
   after_initialize { self.allowed_email_domains ||= [] }
+  after_create { AutomatedPlanReviewer.create_defaults_for(self) }
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true,

--- a/db/migrate/20260223185619_replace_prompt_path_with_prompt_text_and_require_organization.rb
+++ b/db/migrate/20260223185619_replace_prompt_path_with_prompt_text_and_require_organization.rb
@@ -1,0 +1,26 @@
+class ReplacePromptPathWithPromptTextAndRequireOrganization < ActiveRecord::Migration[8.1]
+  def up
+    add_column :automated_plan_reviewers, :prompt_text, :text, null: true
+
+    # Migrate existing prompt_path data to prompt_text by reading file contents
+    AutomatedPlanReviewer.reset_column_information
+    AutomatedPlanReviewer.find_each do |reviewer|
+      file_path = Rails.root.join(reviewer.prompt_path)
+      if File.exist?(file_path)
+        reviewer.update_column(:prompt_text, File.read(file_path))
+      end
+    end
+
+    change_column_null :automated_plan_reviewers, :prompt_text, false
+    remove_column :automated_plan_reviewers, :prompt_path
+
+    # Make organization_id required
+    change_column_null :automated_plan_reviewers, :organization_id, false
+  end
+
+  def down
+    add_column :automated_plan_reviewers, :prompt_path, :string, null: true
+    change_column_null :automated_plan_reviewers, :organization_id, true
+    remove_column :automated_plan_reviewers, :prompt_text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_22_154928) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_23_185619) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -47,8 +47,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_22_154928) do
     t.boolean "enabled", default: true, null: false
     t.string "key", null: false
     t.string "name", null: false
-    t.string "organization_id", limit: 36
-    t.string "prompt_path", null: false
+    t.string "organization_id", limit: 36, null: false
+    t.text "prompt_text", null: false
     t.json "trigger_statuses", null: false
     t.datetime "updated_at", null: false
     t.index ["organization_id", "key"], name: "index_automated_plan_reviewers_on_organization_id_and_key", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,31 +73,6 @@ if ApiToken.count == 0
 end
 
 puts "Seeding automated plan reviewers..."
-if AutomatedPlanReviewer.count == 0
-  AutomatedPlanReviewer.create!(
-    organization: square,
-    key: "security-reviewer",
-    name: "Security Reviewer",
-    prompt_path: "prompts/reviewers/security.md",
-    trigger_statuses: [ "considering" ],
-    ai_model: "gpt-4o"
-  )
-  AutomatedPlanReviewer.create!(
-    organization: square,
-    key: "scalability-reviewer",
-    name: "Scalability Reviewer",
-    prompt_path: "prompts/reviewers/scalability.md",
-    trigger_statuses: [ "considering", "developing" ],
-    ai_model: "gpt-4o"
-  )
-  AutomatedPlanReviewer.create!(
-    organization: square,
-    key: "routing-reviewer",
-    name: "Routing Reviewer",
-    prompt_path: "prompts/reviewers/routing.md",
-    trigger_statuses: [],
-    ai_model: "gpt-4o"
-  )
-end
+AutomatedPlanReviewer.create_defaults_for(square)
 
 puts "Done! #{Organization.count} orgs, #{User.count} users, #{Plan.count} plans, #{CommentThread.count} threads, #{Comment.count} comments, #{ApiToken.count} API tokens, #{AutomatedPlanReviewer.count} reviewers."

--- a/test/fixtures/automated_plan_reviewers.yml
+++ b/test/fixtures/automated_plan_reviewers.yml
@@ -3,7 +3,21 @@ security_reviewer:
   organization_id: "00000000-0000-0000-0000-000000000001"
   key: "security-reviewer"
   name: "Security Reviewer"
-  prompt_path: "prompts/reviewers/security.md"
+  prompt_text: |
+    You are a security reviewer for technical plans and proposals.
+
+    Review the following plan for security concerns. Focus on:
+
+    - Authentication and authorization gaps
+    - Data exposure or leakage risks
+    - Input validation and injection vulnerabilities
+    - Secrets management issues
+    - Network and infrastructure security
+    - Compliance considerations
+
+    Be specific. Reference the relevant sections of the plan. Suggest concrete improvements where possible.
+
+    Respond in Markdown. Keep your review concise and actionable.
   enabled: true
   trigger_statuses: <%= ["considering"].to_json %>
   ai_provider: "openai"
@@ -14,7 +28,21 @@ scalability_reviewer:
   organization_id: "00000000-0000-0000-0000-000000000001"
   key: "scalability-reviewer"
   name: "Scalability Reviewer"
-  prompt_path: "prompts/reviewers/scalability.md"
+  prompt_text: |
+    You are a scalability reviewer for technical plans and proposals.
+
+    Review the following plan for scalability concerns. Focus on:
+
+    - Database query patterns and indexing strategies
+    - Caching opportunities and cache invalidation
+    - Background job volume and queue contention
+    - API rate limits and throughput bottlenecks
+    - Data growth projections and storage implications
+    - Horizontal vs vertical scaling considerations
+
+    Be specific. Reference the relevant sections of the plan. Suggest concrete improvements where possible.
+
+    Respond in Markdown. Keep your review concise and actionable.
   enabled: true
   trigger_statuses: <%= ["considering", "developing"].to_json %>
   ai_provider: "openai"
@@ -25,18 +53,9 @@ disabled_reviewer:
   organization_id: "00000000-0000-0000-0000-000000000001"
   key: "disabled-reviewer"
   name: "Disabled Reviewer"
-  prompt_path: "prompts/reviewers/routing.md"
+  prompt_text: |
+    You are a test reviewer. This reviewer is disabled.
   enabled: false
-  trigger_statuses: <%= [].to_json %>
-  ai_provider: "openai"
-  ai_model: "gpt-4o"
-
-global_reviewer:
-  id: "00000000-0000-0000-0000-000000000084"
-  key: "routing-reviewer"
-  name: "Routing Reviewer"
-  prompt_path: "prompts/reviewers/routing.md"
-  enabled: true
   trigger_statuses: <%= [].to_json %>
   ai_provider: "openai"
   ai_model: "gpt-4o"

--- a/test/models/automated_plan_reviewer_test.rb
+++ b/test/models/automated_plan_reviewer_test.rb
@@ -7,28 +7,39 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
   end
 
   test "requires key" do
-    reviewer = AutomatedPlanReviewer.new(name: "Test", prompt_path: "prompts/reviewers/security.md", ai_model: "gpt-4o")
+    reviewer = AutomatedPlanReviewer.new(name: "Test", prompt_text: "Review this plan.", ai_model: "gpt-4o")
     assert_not reviewer.valid?
     assert_includes reviewer.errors[:key], "can't be blank"
   end
 
   test "requires name" do
-    reviewer = AutomatedPlanReviewer.new(key: "test", prompt_path: "prompts/reviewers/security.md", ai_model: "gpt-4o")
+    reviewer = AutomatedPlanReviewer.new(key: "test", prompt_text: "Review this plan.", ai_model: "gpt-4o")
     assert_not reviewer.valid?
     assert_includes reviewer.errors[:name], "can't be blank"
   end
 
-  test "requires prompt_path" do
+  test "requires prompt_text" do
     reviewer = AutomatedPlanReviewer.new(key: "test", name: "Test", ai_model: "gpt-4o")
     assert_not reviewer.valid?
-    assert_includes reviewer.errors[:prompt_path], "can't be blank"
+    assert_includes reviewer.errors[:prompt_text], "can't be blank"
   end
 
   test "requires ai_model" do
-    reviewer = AutomatedPlanReviewer.new(key: "test", name: "Test", prompt_path: "prompts/reviewers/security.md")
+    reviewer = AutomatedPlanReviewer.new(key: "test", name: "Test", prompt_text: "Review this plan.")
     reviewer.ai_model = nil
     assert_not reviewer.valid?
     assert_includes reviewer.errors[:ai_model], "can't be blank"
+  end
+
+  test "requires organization" do
+    reviewer = AutomatedPlanReviewer.new(
+      key: "test",
+      name: "Test",
+      prompt_text: "Review this plan.",
+      ai_model: "gpt-4o"
+    )
+    assert_not reviewer.valid?
+    assert_includes reviewer.errors[:organization], "must exist"
   end
 
   test "key format only allows lowercase letters, numbers, and hyphens" do
@@ -44,7 +55,7 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
       organization: existing.organization,
       key: existing.key,
       name: "Duplicate",
-      prompt_path: "prompts/reviewers/security.md",
+      prompt_text: "Review this plan.",
       ai_model: "gpt-4o"
     )
     assert_not duplicate.valid?
@@ -56,27 +67,15 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
       organization: organizations(:widgets),
       key: "security-reviewer",
       name: "Security Reviewer",
-      prompt_path: "prompts/reviewers/security.md",
+      prompt_text: "Review this plan.",
       ai_model: "gpt-4o"
     )
     assert reviewer.valid?
   end
 
-  test "validates prompt file exists" do
-    reviewer = AutomatedPlanReviewer.new(
-      key: "test",
-      name: "Test",
-      prompt_path: "prompts/reviewers/nonexistent.md",
-      ai_model: "gpt-4o"
-    )
-    assert_not reviewer.valid?
-    assert reviewer.errors[:prompt_path].any? { |e| e.include?("does not exist") }
-  end
-
-  test "prompt_content reads the prompt file" do
+  test "prompt_text stores the prompt content" do
     reviewer = automated_plan_reviewers(:security_reviewer)
-    content = reviewer.prompt_content
-    assert_includes content, "security"
+    assert_includes reviewer.prompt_text, "security"
   end
 
   test "triggers_on_status? returns true for matching status" do
@@ -95,12 +94,6 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
     assert_not enabled.include?(automated_plan_reviewers(:disabled_reviewer))
   end
 
-  test "organization is optional (global reviewers)" do
-    reviewer = automated_plan_reviewers(:global_reviewer)
-    assert_nil reviewer.organization_id
-    assert reviewer.valid?
-  end
-
   test "defaults ai_provider to openai" do
     reviewer = AutomatedPlanReviewer.new
     assert_equal "openai", reviewer.ai_provider
@@ -114,5 +107,24 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
   test "defaults enabled to true" do
     reviewer = AutomatedPlanReviewer.new
     assert_equal true, reviewer.enabled
+  end
+
+  test "create_defaults_for creates default reviewers for an organization" do
+    org = Organization.create!(name: "Test Org", slug: "test-defaults-org")
+    reviewers = org.automated_plan_reviewers
+    assert_equal 3, reviewers.count
+    assert_equal %w[routing-reviewer scalability-reviewer security-reviewer], reviewers.pluck(:key).sort
+    reviewers.each do |r|
+      assert r.prompt_text.present?
+      assert r.ai_model.present?
+    end
+  end
+
+  test "create_defaults_for is idempotent" do
+    org = organizations(:acme)
+    AutomatedPlanReviewer.create_defaults_for(org)
+    initial_count = org.automated_plan_reviewers.count
+    AutomatedPlanReviewer.create_defaults_for(org)
+    assert_equal initial_count, org.automated_plan_reviewers.count
   end
 end


### PR DESCRIPTION
## What

Addresses two design issues from the [PR #5 review](https://github.com/block/planning-department/pull/5):

### 1. Replace `prompt_path` with `prompt_text` (Critical: LFI fix)

`prompt_path` was an admin-editable file path used in `File.read(Rails.root.join(prompt_path))`, creating a **path traversal / local file inclusion vulnerability**. An admin could set it to `../../config/master.key` or `/etc/passwd`.

Now the prompt content is stored directly in the database as a `text` column. The markdown files in `prompts/reviewers/` remain as **default templates** — they're read during seeding to populate initial reviewers, but at runtime the app only reads from the DB. This also makes prompts customizable per-org without deploying code changes.

### 2. Make `organization_id` non-nullable

The nullable `organization_id` (for "global reviewers") was half-baked — no code consumed it, and it caused a **MySQL NULL uniqueness bug** where the unique index on `[:organization_id, :key]` wouldn't prevent duplicate keys when `organization_id` is NULL.

Removed the concept entirely. Every reviewer belongs to an organization.

### Also fixed
- Seeds now use `find_or_create_by!` instead of the brittle `count == 0` guard
- Removed `prompt_file_exists` validation and `prompt_content` method (no longer needed)
- Updated fixtures, tests, and ActiveAdmin

## Tests

All 168 tests pass.