### PR TITLE
Validate trigger_statuses and ai_provider on AutomatedPlanReviewer

### DIFF
--- a/app/models/automated_plan_reviewer.rb
+++ b/app/models/automated_plan_reviewer.rb
@@ -1,5 +1,6 @@
 class AutomatedPlanReviewer < ApplicationRecord
   ACTOR_TYPE = "cloud_persona"
+  AI_PROVIDERS = %w[openai anthropic].freeze
 
   DEFAULT_REVIEWERS = [
     { key: "security-reviewer", name: "Security Reviewer", prompt_file: "prompts/reviewers/security.md",
@@ -19,8 +20,9 @@ class AutomatedPlanReviewer < ApplicationRecord
   validates :key, uniqueness: { scope: :organization_id }
   validates :name, presence: true
   validates :prompt_text, presence: true
-  validates :ai_provider, presence: true
+  validates :ai_provider, presence: true, inclusion: { in: AI_PROVIDERS }
   validates :ai_model, presence: true
+  validate :validate_trigger_statuses
 
   scope :enabled, -> { where(enabled: true) }
 
@@ -45,5 +47,16 @@ class AutomatedPlanReviewer < ApplicationRecord
 
   def triggers_on_status?(status)
     trigger_statuses.include?(status.to_s)
+  end
+
+  private
+
+  def validate_trigger_statuses
+    return if trigger_statuses.blank?
+
+    invalid = trigger_statuses - Plan::STATUSES
+    if invalid.any?
+      errors.add(:trigger_statuses, "contains invalid status: #{invalid.join(', ')}. Valid statuses are: #{Plan::STATUSES.join(', ')}")
+    end
   end
 end

--- a/test/models/automated_plan_reviewer_test.rb
+++ b/test/models/automated_plan_reviewer_test.rb
@@ -94,9 +94,43 @@ class AutomatedPlanReviewerTest < ActiveSupport::TestCase
     assert_not enabled.include?(automated_plan_reviewers(:disabled_reviewer))
   end
 
+  test "validates ai_provider inclusion" do
+    reviewer = automated_plan_reviewers(:security_reviewer)
+    reviewer.ai_provider = "unknown-provider"
+    assert_not reviewer.valid?
+    assert_includes reviewer.errors[:ai_provider], "is not included in the list"
+  end
+
+  test "accepts valid ai_providers" do
+    reviewer = automated_plan_reviewers(:security_reviewer)
+    AutomatedPlanReviewer::AI_PROVIDERS.each do |provider|
+      reviewer.ai_provider = provider
+      assert reviewer.valid?, "Expected #{provider} to be valid"
+    end
+  end
+
   test "defaults ai_provider to openai" do
     reviewer = AutomatedPlanReviewer.new
     assert_equal "openai", reviewer.ai_provider
+  end
+
+  test "validates trigger_statuses against Plan::STATUSES" do
+    reviewer = automated_plan_reviewers(:security_reviewer)
+    reviewer.trigger_statuses = [ "considering", "invalid-status" ]
+    assert_not reviewer.valid?
+    assert reviewer.errors[:trigger_statuses].any? { |e| e.include?("invalid-status") }
+  end
+
+  test "accepts valid trigger_statuses" do
+    reviewer = automated_plan_reviewers(:security_reviewer)
+    reviewer.trigger_statuses = Plan::STATUSES.dup
+    assert reviewer.valid?
+  end
+
+  test "accepts empty trigger_statuses" do
+    reviewer = automated_plan_reviewers(:security_reviewer)
+    reviewer.trigger_statuses = []
+    assert reviewer.valid?
   end
 
   test "defaults trigger_statuses to empty array" do


### PR DESCRIPTION
## Summary

Addresses issues #4 (MEDIUM) and #5 (LOW) from the code review of PR #5.

### Changes

**`trigger_statuses` validation (issue #4)**
- Adds a custom validation that checks each element in `trigger_statuses` against `Plan::STATUSES` (`brainstorm`, `considering`, `developing`, `live`, `abandoned`)
- Typos like `"considring"` will now produce a clear validation error instead of silently breaking triggering

**`ai_provider` validation (issue #5)**
- Adds `AI_PROVIDERS` constant (`openai`, `anthropic`) with inclusion validation
- Prevents arbitrary strings from being set as the provider

### Tests
- Validates invalid trigger statuses are rejected with descriptive error
- Validates all Plan::STATUSES are accepted
- Validates empty trigger_statuses is accepted
- Validates unknown ai_provider is rejected
- Validates all known AI_PROVIDERS are accepted

All 175 tests pass.