### PR TITLE
Add resolve/dismiss API endpoints for comment threads

### DIFF
--- a/.agents/skills/planning-department/SKILL.md
+++ b/.agents/skills/planning-department/SKILL.md
@@ -190,6 +190,26 @@ curl -s -X POST \
   "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID/comments/$THREAD_ID/reply" | jq .
 ```
 
+### Resolve Thread
+
+Mark a comment thread as resolved (addressed by the plan author or thread creator).
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $PLANNING_API_TOKEN" \
+  "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID/comments/$THREAD_ID/resolve" | jq .
+```
+
+### Dismiss Thread
+
+Dismiss a comment thread (plan author only — for comments that are out of scope or not applicable).
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $PLANNING_API_TOKEN" \
+  "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID/comments/$THREAD_ID/dismiss" | jq .
+```
+
 ## Typical Workflow
 
 1. **Read** the plan: `GET /api/v1/plans/:id`
@@ -203,6 +223,7 @@ curl -s -X POST \
 | Code | Meaning |
 |------|---------|
 | 401 | Invalid or expired API token |
+| 403 | Not authorized for this action |
 | 404 | Plan not found (or no access) |
 | 409 | Edit lease conflict or stale revision |
 | 422 | Validation error or operation failed |

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -36,6 +36,44 @@ module Api
         render json: { error: e.message }, status: :unprocessable_entity
       end
 
+      def resolve
+        thread = @plan.comment_threads.find_by(id: params[:id])
+        unless thread
+          render json: { error: "Comment thread not found" }, status: :not_found
+          return
+        end
+
+        policy = CommentThreadPolicy.new(current_user, thread)
+        unless policy.resolve?
+          render json: { error: "Not authorized" }, status: :forbidden
+          return
+        end
+
+        thread.resolve!(current_user)
+        broadcast_thread_update(thread)
+
+        render json: { thread_id: thread.id, status: thread.status }
+      end
+
+      def dismiss
+        thread = @plan.comment_threads.find_by(id: params[:id])
+        unless thread
+          render json: { error: "Comment thread not found" }, status: :not_found
+          return
+        end
+
+        policy = CommentThreadPolicy.new(current_user, thread)
+        unless policy.dismiss?
+          render json: { error: "Not authorized" }, status: :forbidden
+          return
+        end
+
+        thread.dismiss!(current_user)
+        broadcast_thread_update(thread)
+
+        render json: { thread_id: thread.id, status: thread.status }
+      end
+
       def reply
         thread = @plan.comment_threads.find_by(id: params[:id])
         unless thread
@@ -68,6 +106,15 @@ module Api
         Turbo::StreamsChannel.broadcast_prepend_to(
           @plan,
           target: "comment-threads",
+          partial: "comment_threads/thread",
+          locals: { thread: thread, plan: @plan }
+        )
+      end
+
+      def broadcast_thread_update(thread)
+        Turbo::StreamsChannel.broadcast_replace_to(
+          @plan,
+          target: ActionView::RecordIdentifier.dom_id(thread),
           partial: "comment_threads/thread",
           locals: { thread: thread, plan: @plan }
         )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
         resources :operations, only: [:create]
         resources :comments, only: [:create], controller: "comments" do
           post :reply, on: :member
+          patch :resolve, on: :member
+          patch :dismiss, on: :member
         end
       end
     end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -59,6 +59,55 @@ RSpec.describe "Api::V1::Comments", type: :request do
     expect(response).to have_http_status(:not_found)
   end
 
+  describe "PATCH resolve" do
+    it "resolves a thread" do
+      patch resolve_api_v1_plan_comment_path(plan, thread_record),
+        headers: headers,
+        as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("resolved")
+      expect(thread_record.reload.status).to eq("resolved")
+    end
+
+    it "returns 404 for nonexistent thread" do
+      patch resolve_api_v1_plan_comment_path(plan, "nonexistent-id"),
+        headers: headers,
+        as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH dismiss" do
+    it "dismisses a thread" do
+      patch dismiss_api_v1_plan_comment_path(plan, thread_record),
+        headers: headers,
+        as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("dismissed")
+      expect(thread_record.reload.status).to eq("dismissed")
+    end
+
+    it "returns 404 for nonexistent thread" do
+      patch dismiss_api_v1_plan_comment_path(plan, "nonexistent-id"),
+        headers: headers,
+        as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 403 when user is not the plan author" do
+      bob = create(:user, organization: org)
+      bob_token = create(:api_token, organization: org, user: bob, raw_token: "test-token-bob")
+      bob_headers = { "Authorization" => "Bearer test-token-bob" }
+
+      patch dismiss_api_v1_plan_comment_path(plan, thread_record),
+        headers: bob_headers,
+        as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   it "create comment requires auth" do
     post api_v1_plan_comments_path(plan),
       params: { body_markdown: "No auth" },


### PR DESCRIPTION
Adds two new API endpoints for managing comment thread lifecycle:

- `PATCH /api/v1/plans/:plan_id/comments/:id/resolve` — mark a thread as resolved (plan author or thread creator)
- `PATCH /api/v1/plans/:plan_id/comments/:id/dismiss` — dismiss a thread as not applicable (plan author only)

Both endpoints enforce authorization via `CommentThreadPolicy` and broadcast Turbo Stream updates so the web UI stays in sync.

### Changes
- `config/routes.rb` — added resolve/dismiss member routes
- `Api::V1::CommentsController` — added resolve/dismiss actions with broadcast
- `spec/requests/api/v1/comments_spec.rb` — 5 new specs (happy path, 404, 403)
- `SKILL.md` — documented new endpoints and added 403 error code

All 10 comment specs pass.