### PR TITLE
Add agent_name to comments for API attribution

### DIFF
--- a/.agents/skills/planning-department/SKILL.md
+++ b/.agents/skills/planning-department/SKILL.md
@@ -172,13 +172,15 @@ curl -s -X POST \
   -H "Content-Type: application/json" \
   -d '{
     "body_markdown": "This section needs more detail.",
-    "anchor_text": "the exact text you are commenting on"
+    "anchor_text": "the exact text you are commenting on",
+    "agent_name": "Amp"
   }' \
   "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID/comments" | jq .
 ```
 
 - `anchor_text`: the exact text from the plan content that this comment is about. It will be highlighted in the UI and the comment will be anchored to it.
 - Omit `anchor_text` for a general (non-anchored) comment.
+- `agent_name`: optional identifier for the agent (e.g., `"Amp"`, `"Claude"`). Displayed in the UI as "User Name (Agent Name)".
 
 ### Reply to Thread
 
@@ -186,7 +188,7 @@ curl -s -X POST \
 curl -s -X POST \
   -H "Authorization: Bearer $PLANNING_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"body_markdown": "Good point, I will address this."}' \
+  -d '{"body_markdown": "Good point, I will address this.", "agent_name": "Amp"}' \
   "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID/comments/$THREAD_ID/reply" | jq .
 ```
 

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -20,7 +20,8 @@ module Api
           organization: current_organization,
           author_type: ApiToken::HOLDER_TYPE,
           author_id: @api_token.id,
-          body_markdown: params[:body_markdown]
+          body_markdown: params[:body_markdown],
+          agent_name: params[:agent_name]
         )
 
         broadcast_new_thread(thread)
@@ -85,7 +86,8 @@ module Api
           organization: current_organization,
           author_type: ApiToken::HOLDER_TYPE,
           author_id: @api_token.id,
-          body_markdown: params[:body_markdown]
+          body_markdown: params[:body_markdown],
+          agent_name: params[:agent_name]
         )
 
         broadcast_new_comment(thread, comment)

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -83,6 +83,7 @@ module Api
             {
               id: c.id,
               author_type: c.author_type,
+              agent_name: c.agent_name,
               body_markdown: c.body_markdown,
               created_at: c.created_at
             }

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,15 @@
+module CommentsHelper
+  def comment_author_name(comment)
+    case comment.author_type
+    when "human"
+      User.find_by(id: comment.author_id)&.name || "Unknown"
+    when "local_agent"
+      user_name = User.joins(:api_tokens).where(api_tokens: { id: comment.author_id }).pick(:name) || "Agent"
+      comment.agent_name.present? ? "#{user_name} (#{comment.agent_name})" : user_name
+    when "cloud_persona"
+      AutomatedPlanReviewer.find_by(id: comment.author_id)&.name || "Reviewer"
+    else
+      comment.author_type
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,4 +6,6 @@ class Comment < ApplicationRecord
 
   validates :body_markdown, presence: true
   validates :author_type, presence: true, inclusion: { in: AUTHOR_TYPES }
+  validates :agent_name, presence: { message: "is required for agent comments" }, if: -> { author_type == "local_agent" }
+  validates :agent_name, length: { maximum: 20 }, allow_nil: true
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <div class="comment" id="<%= dom_id(comment) %>">
   <div class="comment__header text-sm text-muted">
-    <strong><%= comment.author_type == "human" ? User.find_by(id: comment.author_id)&.name || "Unknown" : comment.author_type %></strong>
+    <strong><%= comment_author_name(comment) %></strong>
     · <%= time_ago_in_words(comment.created_at) %> ago
   </div>
   <div class="comment__body">

--- a/db/migrate/20260224191500_add_agent_name_to_comments.rb
+++ b/db/migrate/20260224191500_add_agent_name_to_comments.rb
@@ -1,0 +1,5 @@
+class AddAgentNameToComments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :comments, :agent_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_23_185619) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_24_191500) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_185619) do
   end
 
   create_table "comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "agent_name"
     t.string "author_id", limit: 36
     t.string "author_type", null: false
     t.text "body_markdown", null: false

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Api::V1::Comments", type: :request do
       post api_v1_plan_comments_path(plan),
         params: {
           body_markdown: "API comment here",
+          agent_name: "Amp",
           start_line: 1,
           end_line: 3
         },
@@ -32,7 +33,7 @@ RSpec.describe "Api::V1::Comments", type: :request do
   it "create general comment thread" do
     expect {
       post api_v1_plan_comments_path(plan),
-        params: { body_markdown: "General API feedback" },
+        params: { body_markdown: "General API feedback", agent_name: "Amp" },
         headers: headers,
         as: :json
     }.to change(CommentThread, :count).by(1)
@@ -42,7 +43,7 @@ RSpec.describe "Api::V1::Comments", type: :request do
   it "reply to thread" do
     expect {
       post reply_api_v1_plan_comment_path(plan, thread_record),
-        params: { body_markdown: "API reply" },
+        params: { body_markdown: "API reply", agent_name: "Amp" },
         headers: headers,
         as: :json
     }.to change(Comment, :count).by(1)
@@ -106,6 +107,26 @@ RSpec.describe "Api::V1::Comments", type: :request do
         as: :json
       expect(response).to have_http_status(:forbidden)
     end
+  end
+
+  it "rejects comment without agent_name" do
+    post api_v1_plan_comments_path(plan),
+      params: { body_markdown: "Missing agent name" },
+      headers: headers,
+      as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+    body = JSON.parse(response.body)
+    expect(body["error"]).to include("Agent name")
+  end
+
+  it "rejects reply without agent_name" do
+    post reply_api_v1_plan_comment_path(plan, thread_record),
+      params: { body_markdown: "Missing agent name" },
+      headers: headers,
+      as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+    body = JSON.parse(response.body)
+    expect(body["error"]).to include("Agent name")
   end
 
   it "create comment requires auth" do


### PR DESCRIPTION
API callers can now pass an optional `agent_name` param when creating comments or replies. This identifies the agent (e.g., "Amp", "Claude") and displays in the UI as **"Hampton (Amp)"** instead of a generic label.

### Changes
- Migration: `agent_name` string column on `comments`
- `CommentsHelper#comment_author_name` — handles display for human, local_agent (with optional agent name), and cloud_persona author types
- `Api::V1::CommentsController` — accepts `agent_name` on create and reply
- `Api::V1::PlansController` — includes `agent_name` in comments list response
- Skill docs updated with `agent_name` in examples

213 specs pass.