### PR TITLE
Switch UUID generation from v4 to v7

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,6 +6,6 @@ class ApplicationRecord < ActiveRecord::Base
   private
 
   def assign_uuid
-    self.id = SecureRandom.uuid
+    self.id = SecureRandom.uuid_v7
   end
 end


### PR DESCRIPTION
## What

Switches `ApplicationRecord#assign_uuid` from `SecureRandom.uuid` (v4, random) to `SecureRandom.uuid_v7` (Ruby 3.4+, time-ordered).

## Why

UUID v4 primary keys sort in random order, which caused comment replies to appear out of order. UUIDv7 embeds a 48-bit millisecond timestamp in the high bits, so PKs naturally sort chronologically.

Bonus: time-ordered UUIDs improve B-tree index locality, reducing page splits and improving query performance.

## Notes

- Existing v4 UUIDs remain valid — they'll just sort before new v7 ones.
- One-line change thanks to Ruby 3.4's built-in `SecureRandom.uuid_v7`.