### PR TITLE
Rename project from Planning Department to CoPlan

### DIFF
--- a/.agents/skills/coplan/SKILL.md
+++ b/.agents/skills/coplan/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: planning-department
-description: "Upload, edit, and comment on plans via the Planning Department API. Use when asked to create plans, edit plan documents, manage edit leases, or leave review comments on plans."
+name: coplan
+description: "Upload, edit, and comment on plans via the CoPlan API. Use when asked to create plans, edit plan documents, manage edit leases, or leave review comments on plans."
 ---
 
-# Planning Department API
+# CoPlan API
 
-Interact with the Planning Department app to create, read, edit, and comment on plan documents.
+Interact with the CoPlan app to create, read, edit, and comment on plan documents.
 
 ## Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# Planning Department — Agent Guidelines
+# CoPlan — Agent Guidelines
 
 ## What This Is
 
-A Rails app for managing engineering design doc review, purpose-built for AI-generated plans. Humans comment, AI agents edit. Local agents interact via the REST API using skills (see `planning-department` skill) and future CLIs.
+A Rails app for managing engineering design doc review, purpose-built for AI-generated plans. Humans comment, AI agents edit. Local agents interact via the REST API using skills (see `coplan` skill) and future CLIs.
 
 ## Tech Stack & Philosophy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # check=error=true
 
 # This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
-# docker build -t planning_department .
-# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name planning_department planning_department
+# docker build -t coplan .
+# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name coplan coplan
 
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Planning Department
+# CoPlan
 
 A collaborative planning tool where humans and AI agents co-author living documents. Built with Rails 8, Hotwire, and a semantic operations API.
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,4 +1,4 @@
-/* Planning Department — Design Tokens + Base Styles */
+/* CoPlan — Design Tokens + Base Styles */
 
 :root {
   /* Colors */

--- a/app/views/api_tokens/index.html.erb
+++ b/app/views/api_tokens/index.html.erb
@@ -1,6 +1,6 @@
 <div class="page-header">
   <h1>API Tokens</h1>
-  <p class="page-header__subtitle">Manage tokens for agent access to the Planning Department API.</p>
+  <p class="page-header__subtitle">Manage tokens for agent access to the CoPlan API.</p>
 </div>
 
 <% if @raw_token.present? %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,6 +3,6 @@
 </div>
 
 <div class="empty-state card">
-  <p>Welcome to <strong>Planning Department</strong>.</p>
+  <p>Welcome to <strong>CoPlan</strong>.</p>
   <p class="text-muted text-sm">Plans and collaboration tools will appear here once set up.</p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Planning Department" %></title>
+    <title><%= content_for(:title) || "CoPlan" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Planning Department">
+    <meta name="application-name" content="CoPlan">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -22,7 +22,7 @@
   <body>
     <nav class="site-nav">
       <div class="site-nav__inner">
-        <%= link_to "📋 Planning Department", root_path, class: "site-nav__brand" %>
+        <%= link_to "📋 CoPlan", root_path, class: "site-nav__brand" %>
 
         <ul class="site-nav__links">
           <% if signed_in? %>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "PlanningDepartment",
+  "name": "CoPlan",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "PlanningDepartment.",
+  "description": "CoPlan.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,8 +1,8 @@
-<% content_for(:title) { "Sign In — Planning Department" } %>
+<% content_for(:title) { "Sign In — CoPlan" } %>
 
 <div class="sign-in-page">
   <div class="sign-in-card card">
-    <h1>Planning Department</h1>
+    <h1>CoPlan</h1>
     <p class="text-muted text-sm">Sign in with your work email</p>
 
     <div style="background: #fff3cd; border: 1px solid #ffecb5; border-radius: 6px; padding: 0.5rem 0.75rem; margin-top: 1rem; font-size: 0.8rem; color: #664d03; text-align: left;">

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module PlanningDepartment
+module CoPlan
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: planning_department_development
+  database: coplan_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: planning_department_test
+  database: coplan_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -57,18 +57,18 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: planning_department_production
-    username: planning_department
-    password: <%= ENV["PLANNING_DEPARTMENT_DATABASE_PASSWORD"] %>
+    database: coplan_production
+    username: coplan
+    password: <%= ENV["COPLAN_DATABASE_PASSWORD"] %>
   cache:
     <<: *primary_production
-    database: planning_department_production_cache
+    database: coplan_production_cache
     migrations_paths: db/cache_migrate
   queue:
     <<: *primary_production
-    database: planning_department_production_queue
+    database: coplan_production_queue
     migrations_paths: db/queue_migrate
   cable:
     <<: *primary_production
-    database: planning_department_production_cable
+    database: coplan_production_cable
     migrations_paths: db/cable_migrate

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,8 +1,8 @@
 # Name of your application. Used to uniquely configure containers.
-service: planning_department
+service: coplan
 
 # Name of the container image (use your-user/app-name on external registries).
-image: planning_department
+image: coplan
 
 # Deploy to these servers.
 servers:
@@ -52,7 +52,7 @@ env:
     # WEB_CONCURRENCY: 2
 
     # Match this to any external database server to configure Active Record correctly
-    # Use planning_department-db for a db accessory server on same machine via local kamal docker network.
+    # Use coplan-db for a db accessory server on same machine via local kamal docker network.
     # DB_HOST: 192.168.0.2
 
     # Log everything from Rails
@@ -69,7 +69,7 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "planning_department_storage:/rails/storage"
+  - "coplan_storage:/rails/storage"
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -6,7 +6,7 @@ ActiveAdmin.setup do |config|
   # by extracting the _site_header partial into your project
   # to use your own logo, styles, etc.
   #
-  config.site_title = "Planning Department"
+  config.site_title = "CoPlan"
 
   # == Load Paths
   #

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,11 +1,11 @@
 ---
-title: Planning Department — Detailed Implementation Plan
+title: CoPlan — Detailed Implementation Plan
 description: Full data models, API design, operations engine, and phased build order
 author: Hampton Lintorn-Catlin
 date: 2026-02-20
 ---
 
-# Planning Department — Implementation Plan
+# CoPlan — Implementation Plan
 
 > Status: **Developing** — Phases 0–6 complete, 143 tests passing
 > Parent: [CONCEPT.md](./CONCEPT.md)

--- a/plans/CONCEPT.md
+++ b/plans/CONCEPT.md
@@ -1,8 +1,8 @@
-# Planning Department — Concept
+# CoPlan — Concept
 
 ## What Is This?
 
-Planning Department is an open-source Rails application for managing the **Plan** phase of AI-assisted development workflows. When engineers use the Research → Plan → Implement (RPI) method with AI agents, the Plan phase produces Markdown documents — often living only on a local machine. Planning Department gives those documents a home where teammates can review them, leave inline feedback, and iterate on them with AI assistance.
+CoPlan is an open-source Rails application for managing the **Plan** phase of AI-assisted development workflows. When engineers use the Research → Plan → Implement (RPI) method with AI agents, the Plan phase produces Markdown documents — often living only on a local machine. CoPlan gives those documents a home where teammates can review them, leave inline feedback, and iterate on them with AI assistance.
 
 Think of it as **engineering design doc review, but purpose-built for AI-generated plans**.
 
@@ -64,7 +64,7 @@ Status transitions are decided by the Author (+ their agent). No formal approval
 
 ## Core Workflow
 
-1. **Create a Plan** — Author (often assisted by a local AI agent) writes a Markdown plan and uploads it to Planning Department
+1. **Create a Plan** — Author (often assisted by a local AI agent) writes a Markdown plan and uploads it to CoPlan
 2. **Request Review** — Author invites teammates to review the plan
 3. **Inline Feedback** — Reviewers leave line-level comments on any part of the document, threaded discussions develop
 4. **Agent Assistance** — AI agents can:
@@ -204,7 +204,7 @@ Authenticated via API tokens scoped to a user. Stateless request/response — ag
 ## Notifications
 
 - **Slack** — Primary notification channel (new comments, status changes, review requests)
-- **In-app** — Notification feed within Planning Department
+- **In-app** — Notification feed within CoPlan
 - Email is not planned for v1
 
 ## Decided

--- a/plans/PLAN.md
+++ b/plans/PLAN.md
@@ -1,4 +1,4 @@
-# Planning Department — Implementation Plan
+# CoPlan — Implementation Plan
 
 > Status: **Brainstorm**
 > Parent: [CONCEPT.md](./CONCEPT.md)

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Not Found — Planning Department</title>
+  <title>Not Found — CoPlan</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     body {

--- a/public/422.html
+++ b/public/422.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Unprocessable — Planning Department</title>
+  <title>Unprocessable — CoPlan</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     body {

--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Server Error — Planning Department</title>
+  <title>Server Error — CoPlan</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     body {


### PR DESCRIPTION
## What

Renames the project from "Planning Department" to **CoPlan** across all references:

- Rails module (`PlanningDepartment` → `CoPlan`)
- Database names (`planning_department_*` → `coplan_*`)
- Deploy config (service, image, volumes)
- Views, layouts, error pages, PWA manifest
- Docs, plans, AGENTS.md, README
- Dockerfile comments
- Skill directory (`.agents/skills/planning-department/` → `.agents/skills/coplan/`)

## After merging

Existing developers need to rename their local databases (preserving data):

```bash
mysqldump -u root planning_department_development | mysql -u root -e "CREATE DATABASE IF NOT EXISTS coplan_development" && mysql -u root coplan_development
mysqldump -u root planning_department_test | mysql -u root -e "CREATE DATABASE IF NOT EXISTS coplan_test" && mysql -u root coplan_test
```

Or if you don't care about local data, just re-setup:

```bash
bin/rails db:create db:migrate db:seed
```