### PR TITLE
Add PATCH /api/v1/plans/:id for updating plan metadata

### DIFF
--- a/.agents/skills/coplan/SKILL.md
+++ b/.agents/skills/coplan/SKILL.md
@@ -48,6 +48,20 @@ curl -s -X POST \
   "$PLANNING_BASE_URL/api/v1/plans" | jq .
 ```
 
+### Update Plan
+
+Update plan metadata (title, status, tags). Only fields included in the request body are changed.
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $PLANNING_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "considering"}' \
+  "$PLANNING_BASE_URL/api/v1/plans/$PLAN_ID" | jq .
+```
+
+Allowed fields: `title` (string), `status` (string — one of `brainstorm`, `considering`, `developing`, `live`, `abandoned`), `tags` (array of strings).
+
 ### Get Versions
 
 ```bash

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class PlansController < BaseController
-      before_action :set_plan, only: [:show, :versions, :comments]
-      before_action :authorize_plan_access!, only: [:show, :versions, :comments]
+      before_action :set_plan, only: [:show, :update, :versions, :comments]
+      before_action :authorize_plan_access!, only: [:show, :update, :versions, :comments]
 
       def index
         plans = current_organization.plans
@@ -32,6 +32,31 @@ module Api
         ), status: :created
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      def update
+        policy = PlanPolicy.new(current_user, @plan)
+        unless policy.update?
+          return render json: { error: "Not authorized" }, status: :forbidden
+        end
+
+        permitted = {}
+        permitted[:title] = params[:title] if params.key?(:title)
+        permitted[:status] = params[:status] if params.key?(:status)
+        permitted[:tags] = params[:tags] if params.key?(:tags)
+
+        @plan.update!(permitted)
+
+        if permitted.key?(:status) && @plan.saved_change_to_status?
+          Plans::TriggerAutomatedReviews.call(plan: @plan, new_status: permitted[:status], triggered_by: current_user)
+        end
+
+        render json: plan_json(@plan).merge(
+          current_content: @plan.current_content,
+          current_revision: @plan.current_revision
+        )
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
       end
 
       def versions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :plans, only: [:index, :show, :create] do
+      resources :plans, only: [:index, :show, :create, :update] do
         get :versions, on: :member
         get :comments, on: :member
         resource :lease, only: [:create, :update, :destroy], controller: "leases"

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -72,6 +72,71 @@ RSpec.describe "Api::V1::Plans", type: :request do
     expect(response).to have_http_status(:unprocessable_entity)
   end
 
+  describe "PATCH /api/v1/plans/:id" do
+    it "updates plan title" do
+      patch api_v1_plan_path(plan), params: { title: "New Title" }, headers: headers, as: :json
+      expect(response).to have_http_status(:success)
+      body = JSON.parse(response.body)
+      expect(body["title"]).to eq("New Title")
+      expect(plan.reload.title).to eq("New Title")
+    end
+
+    it "updates plan status" do
+      patch api_v1_plan_path(plan), params: { status: "developing" }, headers: headers, as: :json
+      expect(response).to have_http_status(:success)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("developing")
+      expect(plan.reload.status).to eq("developing")
+    end
+
+    it "updates plan tags" do
+      patch api_v1_plan_path(plan), params: { tags: ["infra", "api"] }, headers: headers, as: :json
+      expect(response).to have_http_status(:success)
+      body = JSON.parse(response.body)
+      expect(body["tags"]).to eq(["infra", "api"])
+      expect(plan.reload.tags).to eq(["infra", "api"])
+    end
+
+    it "updates multiple fields at once" do
+      patch api_v1_plan_path(plan), params: { title: "Updated", status: "developing", tags: ["v2"] }, headers: headers, as: :json
+      expect(response).to have_http_status(:success)
+      body = JSON.parse(response.body)
+      expect(body["title"]).to eq("Updated")
+      expect(body["status"]).to eq("developing")
+      expect(body["tags"]).to eq(["v2"])
+    end
+
+    it "leaves unchanged fields alone" do
+      original_title = plan.title
+      patch api_v1_plan_path(plan), params: { tags: ["new-tag"] }, headers: headers, as: :json
+      expect(response).to have_http_status(:success)
+      expect(plan.reload.title).to eq(original_title)
+    end
+
+    it "rejects invalid status" do
+      patch api_v1_plan_path(plan), params: { status: "invalid" }, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 404 for other org plan" do
+      carol_token
+      patch api_v1_plan_path(plan), params: { title: "Hacked" }, headers: { "Authorization" => "Bearer test-token-carol" }, as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 403 for non-author" do
+      bob = create(:user, organization: org)
+      bob_token = create(:api_token, organization: org, user: bob, raw_token: "test-token-bob")
+      patch api_v1_plan_path(plan), params: { title: "Nope" }, headers: { "Authorization" => "Bearer test-token-bob" }, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "requires auth" do
+      patch api_v1_plan_path(plan), params: { title: "No Auth" }, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   it "versions returns version list" do
     get versions_api_v1_plan_path(plan), headers: headers
     expect(response).to have_http_status(:success)


### PR DESCRIPTION
## What

Adds a `PATCH /api/v1/plans/:id` endpoint that allows updating plan metadata via the API:

- **title** (string)
- **status** (string — triggers automated reviewers on status change)
- **tags** (array of strings)

Only included fields are updated; omitted fields are left unchanged.

## Changes

- `app/controllers/api/v1/plans_controller.rb` — new `update` action with author-only authorization
- `config/routes.rb` — added `:update` to API plans resource
- `spec/requests/api/v1/plans_spec.rb` — 9 new specs covering happy path, partial updates, validation, auth
- `.agents/skills/planning-department/SKILL.md` — documented the new endpoint