### PR TITLE
Include anchor_text in API comments response

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -99,6 +99,7 @@ module Api
         {
           id: thread.id,
           status: thread.status,
+          anchor_text: thread.anchor_text,
           start_line: thread.start_line,
           end_line: thread.end_line,
           out_of_date: thread.out_of_date,

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -144,10 +144,14 @@ RSpec.describe "Api::V1::Plans", type: :request do
     expect(versions.any? { |v| v["revision"] == 1 }).to be true
   end
 
-  it "comments returns thread list" do
+  it "comments returns thread list with anchor_text" do
+    thread = create(:comment_thread, :with_anchor, plan: plan, organization: org,
+      plan_version: plan.current_plan_version, created_by_user: alice, anchor_text: "original roadmap text")
     get comments_api_v1_plan_path(plan), headers: headers
     expect(response).to have_http_status(:success)
     threads = JSON.parse(response.body)
     expect(threads).to be_a(Array)
+    matching = threads.find { |t| t["id"] == thread.id }
+    expect(matching["anchor_text"]).to eq("original roadmap text")
   end
 end


### PR DESCRIPTION
The comments endpoint (`GET /api/v1/plans/:id/comments`) was missing the `anchor_text` field from the thread JSON, making it impossible for API consumers (agents, skills) to know what section of the plan each comment thread is anchored to.

**Changes:**
- Add `anchor_text` to `thread_json` in `Api::V1::PlansController`
- Update spec to verify `anchor_text` is returned