### PR TITLE
Expand README and AGENTS.md with project goals and how-it-works

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A Rails app for managing engineering design doc review, purpose-built for AI-generated plans. Humans comment, AI agents edit. Local agents interact via the REST API using skills (see `coplan` skill) and future CLIs.
+A Rails app for engineering design doc review, purpose-built for AI-assisted planning. Plans get better through collaboration — domain experts leave inline feedback, AI agents respond to that feedback and apply edits automatically, and every change is versioned with full provenance. Humans comment, AI agents edit. Local agents interact via the REST API using skills (see `coplan` skill) and future CLIs.
 
 ## Tech Stack & Philosophy
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # CoPlan
 
-A collaborative planning tool where humans and AI agents co-author living documents. Built with Rails 8, Hotwire, and a semantic operations API.
+Engineering design doc review, purpose-built for AI-assisted planning. Built with Rails 8, Hotwire, and a semantic operations API.
 
-## What It Does
+## Why CoPlan?
 
-Teams write plans in Markdown. AI agents (local or cloud) review, comment on, and edit those plans through the same API. Every edit is versioned. Comments anchor to selected text (Google Docs-style). Realtime updates via Turbo Streams.
+Plans get better when more eyes see them. An engineer drafts a plan — often with AI help — and CoPlan gives it a home where teammates can review it, leave inline feedback, and iterate. Domain experts catch things the author missed. AI agents respond to feedback and apply edits automatically. The result is higher-quality plans before a single line of code is written.
+
+**The editing model is intentionally asymmetric:** humans comment, AI agents edit. When a reviewer leaves feedback and the author accepts it, an agent applies the change — creating a new immutable version with full provenance (who changed what, why, and which comment triggered it). This keeps the version history clean and auditable.
+
+## How It Works
+
+- **Plans are Markdown documents** that move through a lifecycle: `brainstorm → considering → developing → live` (or `→ abandoned`). Brainstorm plans are private; once a plan moves to *considering*, it's published to the whole org.
+- **Inline commenting** — select any text in the rendered plan to leave a comment, Google Docs-style. Comments are threaded and anchor to the selected text.
+- **AI agents edit via semantic operations** — `replace_exact`, `insert_under_heading`, `delete_paragraph_containing` — not brittle line numbers. Agents acquire an edit lease (one at a time), submit operations against a base revision, and the server creates a new version.
+- **Cloud Personas** — server-side AI reviewers (security, scalability, routing) that automatically review plans when they reach certain statuses, or on demand.
+- **Realtime** — comments, edits, and status changes broadcast instantly to all viewers via Turbo Streams.
+- **Full provenance** — every version records the actor (human, local agent, or cloud persona), the AI model used, the prompt, and which comments triggered the change.
 
 ## Tech Stack
 


### PR DESCRIPTION
Adds **Why CoPlan?** and **How It Works** sections to the README so newcomers understand the project's purpose and core mechanics. Also updates the AGENTS.md opener to capture the collaboration value prop.

### Changes
- **README.md**: New sections covering the collaboration loop (experts + AI making plans better), plan lifecycle, inline commenting, semantic operations, cloud personas, realtime updates, and provenance
- **AGENTS.md**: Expanded opener to explain *why* plans get better through collaboration