### PR TITLE
Always show API token management UI on settings page

### DIFF
--- a/engine/app/controllers/coplan/settings/settings_controller.rb
+++ b/engine/app/controllers/coplan/settings/settings_controller.rb
@@ -2,7 +2,7 @@ module CoPlan
   module Settings
     class SettingsController < ApplicationController
       def index
-        @api_tokens = current_user.api_tokens.order(created_at: :desc) if show_api_tokens?
+        @api_tokens = current_user.api_tokens.order(created_at: :desc)
       end
     end
   end

--- a/engine/app/controllers/coplan/settings/tokens_controller.rb
+++ b/engine/app/controllers/coplan/settings/tokens_controller.rb
@@ -1,8 +1,6 @@
 module CoPlan
   module Settings
     class TokensController < ApplicationController
-      before_action :require_api_tokens_enabled, only: [:create, :destroy]
-
       def index
         @api_tokens = current_user.api_tokens.order(created_at: :desc)
       end

--- a/engine/app/views/coplan/settings/settings/index.html.erb
+++ b/engine/app/views/coplan/settings/settings/index.html.erb
@@ -2,6 +2,4 @@
   <h1>Settings</h1>
 </div>
 
-<% if show_api_tokens? %>
-  <%= render "coplan/settings/tokens/tokens", api_tokens: @api_tokens %>
-<% end %>
+<%= render "coplan/settings/tokens/tokens", api_tokens: @api_tokens %>

--- a/engine/app/views/coplan/settings/tokens/index.html.erb
+++ b/engine/app/views/coplan/settings/tokens/index.html.erb
@@ -2,8 +2,7 @@
   <h1>Settings</h1>
 </div>
 
-<% if show_api_tokens? %>
-  <p class="settings-section-subtitle">Manage API tokens for agent access</p>
+<p class="settings-section-subtitle">Manage API tokens for agent access</p>
 
   <div id="token-reveal">
     <% if flash[:raw_token].present? %>
@@ -32,4 +31,3 @@
       </tbody>
     </table>
   </div>
-<% end %>

--- a/engine/lib/coplan/configuration.rb
+++ b/engine/lib/coplan/configuration.rb
@@ -55,7 +55,7 @@ module CoPlan
     end
 
     def show_api_tokens?
-      @api_authenticate.nil?
+      true
     end
   end
 end


### PR DESCRIPTION
## Summary

Remove the `show_api_tokens?` conditional that hid the API token management UI when `api_authenticate` was configured. API tokens should always be available since they allow agents to bypass host session/OIDC auth for API requests.

## Changes

- **`Configuration#show_api_tokens?`** — now always returns `true`
- **`TokensController`** — removed `require_api_tokens_enabled` before_action guard
- **`SettingsController#index`** — always loads `@api_tokens` (no conditional)
- **Settings views** — removed `<% if show_api_tokens? %>` wrappers from both `settings/index` and `tokens/index`

## Context

The API auth layer in `Api::V1::BaseController` already inherits from `ActionController::API` (not the host's `ApplicationController`), so bearer token auth is already checked before any host session/OIDC auth. The token UI was the only thing being hidden unnecessarily when `api_authenticate` was set.

## Testing

All existing specs pass (`api_tokens_spec.rb`, `tokens_spec.rb` system tests).