### PR TITLE
Paginate plans index with Turbo Frame infinite scroll

### DIFF
--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -8,7 +8,7 @@ module CoPlan
       plans = Plan.includes(:plan_type, :tags, :created_by_user)
         .where.not(status: "brainstorm")
         .or(Plan.where(created_by_user: current_user))
-        .order(updated_at: :desc)
+        .order(updated_at: :desc, id: :desc)
       plans = plans.where(status: params[:status]) if params[:status].present?
       plans = plans.where(created_by_user: current_user) if params[:scope] == "mine"
       plans = plans.where(plan_type_id: params[:plan_type]) if params[:plan_type].present?

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -2,25 +2,35 @@ module CoPlan
   class PlansController < ApplicationController
     before_action :set_plan, only: [:show, :edit, :update, :update_status, :toggle_checkbox, :history]
 
+    PER_PAGE = 20
+
     def index
-      @plans = Plan.includes(:plan_type, :tags)
+      plans = Plan.includes(:plan_type, :tags, :created_by_user)
         .where.not(status: "brainstorm")
         .or(Plan.where(created_by_user: current_user))
         .order(updated_at: :desc)
-      @plans = @plans.where(status: params[:status]) if params[:status].present?
-      @plans = @plans.where(created_by_user: current_user) if params[:scope] == "mine"
-      @plans = @plans.where(plan_type_id: params[:plan_type]) if params[:plan_type].present?
-      @plans = @plans.with_tag(params[:tag]) if params[:tag].present?
+      plans = plans.where(status: params[:status]) if params[:status].present?
+      plans = plans.where(created_by_user: current_user) if params[:scope] == "mine"
+      plans = plans.where(plan_type_id: params[:plan_type]) if params[:plan_type].present?
+      plans = plans.with_tag(params[:tag]) if params[:tag].present?
 
-      @plan_types = PlanType.order(:name)
+      @page = (params[:page] || 1).to_i
+      @plans = plans.limit(PER_PAGE + 1).offset((@page - 1) * PER_PAGE)
+      @has_next_page = @plans.size > PER_PAGE
+      @plans = @plans.first(PER_PAGE)
 
       @plan_unread_counts = current_user.notifications.unread
-        .where(plan_id: @plans.select(:id))
+        .where(plan_id: @plans.map(&:id))
         .group(:plan_id)
         .count
 
-      @show_onboarding_banner = CoPlan.configuration.onboarding_banner.present? &&
-        !current_user.created_plans.exists?
+      if turbo_frame_request?
+        render partial: "coplan/plans/plan_page", locals: { plans: @plans, plan_unread_counts: @plan_unread_counts, page: @page, has_next_page: @has_next_page }, layout: false
+      else
+        @plan_types = PlanType.order(:name)
+        @show_onboarding_banner = CoPlan.configuration.onboarding_banner.present? &&
+          !current_user.created_plans.exists?
+      end
     end
 
     def show

--- a/engine/app/views/coplan/plans/_plan_page.html.erb
+++ b/engine/app/views/coplan/plans/_plan_page.html.erb
@@ -1,0 +1,33 @@
+<%= turbo_frame_tag "plans-page-#{page}" do %>
+  <% plans.each do |plan| %>
+    <div class="card plans-list__item">
+      <div class="plans-list__header">
+        <%= link_to plan.title, plan_path(plan), class: "plans-list__title", data: { turbo_frame: "_top" } %>
+        <span class="badge badge--<%= plan.status %>"><%= plan.status %></span>
+        <% if plan.plan_type %>
+          <span class="badge badge--type"><%= plan.plan_type.name %></span>
+        <% end %>
+        <% plan_unread = plan_unread_counts[plan.id] || 0 %>
+        <% if plan_unread > 0 %>
+          <span class="inbox-badge"><%= plan_unread %></span>
+        <% end %>
+      </div>
+      <% if plan.tags.any? %>
+        <div class="plans-list__tags">
+          <% plan.tags.each do |tag| %>
+            <%= link_to tag.name, plans_path(params.permit(:scope, :status, :plan_type).merge(tag: tag.name)), class: "badge badge--tag #{'badge--tag-active' if params[:tag] == tag.name}", data: { turbo_frame: "_top" } %>
+          <% end %>
+        </div>
+      <% end %>
+      <div class="plans-list__meta text-sm text-muted">
+        <%= user_avatar(plan.created_by_user) %> <%= plan.created_by_user.name %> · v<%= plan.current_revision %> · updated <%= time_ago_in_words(plan.updated_at) %> ago
+      </div>
+    </div>
+  <% end %>
+
+  <% if has_next_page %>
+    <%= turbo_frame_tag "plans-page-#{page + 1}", src: plans_path(params.permit(:scope, :status, :plan_type, :tag).merge(page: page + 1)), loading: :lazy do %>
+      <div class="plans-list__loading text-muted text-sm">Loading more plans…</div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/engine/app/views/coplan/plans/index.html.erb
+++ b/engine/app/views/coplan/plans/index.html.erb
@@ -32,31 +32,7 @@
 
 <% if @plans.any? %>
   <div class="plans-list">
-    <% @plans.each do |plan| %>
-      <div class="card plans-list__item">
-        <div class="plans-list__header">
-          <%= link_to plan.title, plan_path(plan), class: "plans-list__title" %>
-          <span class="badge badge--<%= plan.status %>"><%= plan.status %></span>
-          <% if plan.plan_type %>
-            <span class="badge badge--type"><%= plan.plan_type.name %></span>
-          <% end %>
-          <% plan_unread = @plan_unread_counts[plan.id] || 0 %>
-          <% if plan_unread > 0 %>
-            <span class="inbox-badge"><%= plan_unread %></span>
-          <% end %>
-        </div>
-        <% if plan.tags.any? %>
-          <div class="plans-list__tags">
-            <% plan.tags.each do |tag| %>
-              <%= link_to tag.name, plans_path(params.permit(:scope, :status, :plan_type).merge(tag: tag.name)), class: "badge badge--tag #{'badge--tag-active' if params[:tag] == tag.name}" %>
-            <% end %>
-          </div>
-        <% end %>
-        <div class="plans-list__meta text-sm text-muted">
-          <%= user_avatar(plan.created_by_user) %> <%= plan.created_by_user.name %> · v<%= plan.current_revision %> · updated <%= time_ago_in_words(plan.updated_at) %> ago
-        </div>
-      </div>
-    <% end %>
+    <%= render partial: "coplan/plans/plan_page", locals: { plans: @plans, plan_unread_counts: @plan_unread_counts, page: @page, has_next_page: @has_next_page } %>
   </div>
 <% else %>
   <div class="empty-state card">


### PR DESCRIPTION
## Problem

The plans index loads all plans in a single request with no pagination. With ~6,500+ users and growing plan counts, this causes:
- **537ms** page loads (338ms view rendering alone)
- N+1 queries on `created_by_user` (missing from `includes`)
- Subquery for unread counts re-executing the full plans query

## Changes

- **Fix N+1**: Add `:created_by_user` to `includes()`
- **Fix unread counts**: Use `.map(&:id)` on loaded records instead of `.select(:id)` subquery
- **Infinite scroll**: Paginate at 20 plans per page using Turbo Frames with `loading: :lazy`
  - Extracts plan items into `_plan_page` partial
  - Each page renders a lazy Turbo Frame pointing to the next page
  - Turbo Frame requests skip filter UI queries (`@plan_types`, onboarding banner)
  - Uses the same Turbo Frame pattern as the existing inbox panel and history views

## Testing

- All 24 existing plans request specs pass
- Tested locally with 200+ plans — pages load progressively on scroll