### PR TITLE
Pin @rails/actioncable in engine importmap

### DIFF
--- a/engine/config/importmap.rb
+++ b/engine/config/importmap.rb
@@ -1,1 +1,2 @@
+pin "@rails/actioncable", to: "actioncable.esm.js"
 pin_all_from CoPlan::Engine.root.join("app/javascript/controllers/coplan"), under: "controllers/coplan", preload: true


### PR DESCRIPTION
The presence controller imports `createConsumer` from `@rails/actioncable` but the module was never pinned in any importmap, causing a `TypeError: Failed to resolve module specifier "@rails/actioncable"` in production and preventing ActionCable WebSocket connections from initializing.

This adds the missing pin to the engine's importmap so it's self-contained.