### PR TITLE
Expand plan_versions.diff_unified to mediumtext

### DIFF
--- a/db/migrate/20260429191637_expand_plan_version_diff_unified.co_plan.rb
+++ b/db/migrate/20260429191637_expand_plan_version_diff_unified.co_plan.rb
@@ -1,0 +1,12 @@
+# This migration comes from co_plan (originally 20260429000000)
+class ExpandPlanVersionDiffUnified < ActiveRecord::Migration[8.0]
+  # The default `text` column tops out at ~64KB on MySQL, which we hit
+  # whenever a PlanVersion's unified diff exceeds that — easy with the
+  # PUT /api/v1/plans/:id/content endpoint, where agents can submit
+  # whole-file rewrites of large plans. content_markdown is already
+  # mediumtext (~16MB); diff_unified should match so any persistable
+  # content can also persist its diff.
+  def change
+    change_column :coplan_plan_versions, :diff_unified, :text, limit: 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_202551) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_191637) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -180,7 +180,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_202551) do
     t.text "content_markdown", size: :medium, null: false
     t.string "content_sha256", null: false
     t.timestamp "created_at", null: false
-    t.text "diff_unified"
+    t.text "diff_unified", size: :medium
     t.json "operations_json"
     t.string "plan_id", limit: 36, null: false
     t.text "prompt_excerpt"

--- a/engine/db/migrate/20260429000000_expand_plan_version_diff_unified.rb
+++ b/engine/db/migrate/20260429000000_expand_plan_version_diff_unified.rb
@@ -1,0 +1,11 @@
+class ExpandPlanVersionDiffUnified < ActiveRecord::Migration[8.0]
+  # The default `text` column tops out at ~64KB on MySQL, which we hit
+  # whenever a PlanVersion's unified diff exceeds that — easy with the
+  # PUT /api/v1/plans/:id/content endpoint, where agents can submit
+  # whole-file rewrites of large plans. content_markdown is already
+  # mediumtext (~16MB); diff_unified should match so any persistable
+  # content can also persist its diff.
+  def change
+    change_column :coplan_plan_versions, :diff_unified, :text, limit: 16.megabytes - 1
+  end
+end


### PR DESCRIPTION
## What

Bumps `coplan_plan_versions.diff_unified` from `text` (≈64KB MySQL limit) to `mediumtext` (≈16MB), matching `content_markdown`.

## Why

Found while smoke-testing the new `PUT /api/v1/plans/:id/content` endpoint (#101) on a 5,000-line / 189KB plan with 10 scattered edits. The whole-file rewrite produced a unified diff > 64KB and the version insert blew up with:

```
ActiveRecord::ValueTooLong: Mysql2::Error: Data too long for column 'diff_unified' at row 1
```

This is a **pre-existing** schema limit affecting all four PlanVersion write paths (`operations_controller`, `commit_session`, `plans_controller`, `replace_content`) — the new endpoint just makes it trivially reachable since agents are encouraged to PUT entire files.

## Verification

After applying the migration locally, the same 5,000-line PUT returns `201` in ~390ms with `applied: 10` and exact roundtrip on `current_content`.

Full test suite still green: `765 examples, 0 failures`.
