### PR TITLE
Fix ActionCable auth fallback + unblock deploy (diff-lcs)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     coplan-engine (0.4.0)
       commonmarker
+      diff-lcs
       diffy
       importmap-rails
       jbuilder

--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -2,25 +2,26 @@ module CoPlan
   class PlanPresenceChannel < ActionCable::Channel::Base
     def subscribed
       @plan = Plan.find_by(id: params[:plan_id])
-      policy = @plan && PlanPolicy.new(current_user, @plan)
-      unless @plan && policy.show?
+      @current_user = resolve_current_user
+      policy = @plan && @current_user && PlanPolicy.new(@current_user, @plan)
+      unless @plan && policy&.show?
         reject
         return
       end
 
-      PlanViewer.track(plan: @plan, user: current_user)
+      PlanViewer.track(plan: @plan, user: @current_user)
       broadcast_viewers
     end
 
     def unsubscribed
-      return unless @plan
+      return unless @plan && current_user
 
       PlanViewer.expire(plan: @plan, user: current_user)
       broadcast_viewers
     end
 
     def ping
-      return unless @plan
+      return unless @plan && current_user
 
       PlanViewer.track(plan: @plan, user: current_user)
       broadcast_viewers
@@ -29,7 +30,13 @@ module CoPlan
     private
 
     def current_user
-      connection.current_user
+      @current_user ||= resolve_current_user
+    end
+
+    def resolve_current_user
+      return connection.current_user if connection.respond_to?(:current_user) && connection.current_user
+
+      CoPlan::Authentication.user_from_request(connection.request)
     end
 
     def broadcast_viewers

--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -1,20 +1,19 @@
 module CoPlan
   class PlanPresenceChannel < ActionCable::Channel::Base
     def subscribed
-      @current_user = resolve_current_user
-      unless @current_user
+      unless current_user
         reject
         return
       end
 
       @plan = Plan.find_by(id: params[:plan_id])
-      policy = @plan && PlanPolicy.new(@current_user, @plan)
+      policy = @plan && PlanPolicy.new(current_user, @plan)
       unless @plan && policy&.show?
         reject
         return
       end
 
-      PlanViewer.track(plan: @plan, user: @current_user)
+      PlanViewer.track(plan: @plan, user: current_user)
       broadcast_viewers
     end
 

--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -1,9 +1,14 @@
 module CoPlan
   class PlanPresenceChannel < ActionCable::Channel::Base
     def subscribed
-      @plan = Plan.find_by(id: params[:plan_id])
       @current_user = resolve_current_user
-      policy = @plan && @current_user && PlanPolicy.new(@current_user, @plan)
+      unless @current_user
+        reject
+        return
+      end
+
+      @plan = Plan.find_by(id: params[:plan_id])
+      policy = @plan && PlanPolicy.new(@current_user, @plan)
       unless @plan && policy&.show?
         reject
         return
@@ -14,14 +19,14 @@ module CoPlan
     end
 
     def unsubscribed
-      return unless @plan && current_user
+      return unless @plan
 
       PlanViewer.expire(plan: @plan, user: current_user)
       broadcast_viewers
     end
 
     def ping
-      return unless @plan && current_user
+      return unless @plan
 
       PlanViewer.track(plan: @plan, user: current_user)
       broadcast_viewers

--- a/engine/app/controllers/coplan/application_controller.rb
+++ b/engine/app/controllers/coplan/application_controller.rb
@@ -38,13 +38,8 @@ module CoPlan
     end
 
     def authenticate_coplan_user!
-      callback = CoPlan.configuration.authenticate
-      unless callback
-        raise "CoPlan.configure { |c| c.authenticate = ->(request) { ... } } is required"
-      end
-
-      attrs = callback.call(request)
-      unless attrs && attrs[:external_id].present?
+      @current_coplan_user = CoPlan::Authentication.user_from_request(request)
+      unless @current_coplan_user
         if agent_request?
           render plain: agent_redirect_instructions, content_type: "text/markdown", status: :unauthorized
         elsif CoPlan.configuration.sign_in_path
@@ -52,26 +47,6 @@ module CoPlan
         else
           head :unauthorized
         end
-        return
-      end
-
-      external_id = attrs[:external_id].to_s
-      @current_coplan_user = CoPlan::User.find_or_initialize_by(external_id: external_id)
-      sync_user_attrs(@current_coplan_user, attrs)
-      if @current_coplan_user.new_record? || @current_coplan_user.changed?
-        @current_coplan_user.save!
-      end
-    rescue ActiveRecord::RecordNotUnique
-      @current_coplan_user = CoPlan::User.find_by!(external_id: external_id)
-      sync_user_attrs(@current_coplan_user, attrs)
-      @current_coplan_user.save! if @current_coplan_user.changed?
-    end
-
-    def sync_user_attrs(user, attrs)
-      safe_attrs = attrs.slice(:name, :username, :admin, :avatar_url, :title, :team).compact
-      user.assign_attributes(safe_attrs)
-      if attrs.key?(:metadata) && attrs[:metadata].is_a?(Hash)
-        user.metadata = (user.metadata || {}).merge(attrs[:metadata])
       end
     end
 

--- a/engine/app/services/coplan/authentication.rb
+++ b/engine/app/services/coplan/authentication.rb
@@ -1,0 +1,37 @@
+module CoPlan
+  module Authentication
+    MISSING_AUTHENTICATE_MESSAGE = "CoPlan.configure { |c| c.authenticate = ->(request) { ... } } is required"
+
+    module_function
+
+    def user_from_request(request, callback: CoPlan.configuration.authenticate)
+      raise MISSING_AUTHENTICATE_MESSAGE unless callback
+
+      attrs = callback.call(request)
+      return nil unless attrs && attrs[:external_id].present?
+
+      provision_user!(attrs)
+    end
+
+    def provision_user!(attrs)
+      external_id = attrs[:external_id].to_s
+      user = CoPlan::User.find_or_initialize_by(external_id: external_id)
+      sync_user_attrs(user, attrs)
+      user.save! if user.new_record? || user.changed?
+      user
+    rescue ActiveRecord::RecordNotUnique
+      user = CoPlan::User.find_by!(external_id: external_id)
+      sync_user_attrs(user, attrs)
+      user.save! if user.changed?
+      user
+    end
+
+    def sync_user_attrs(user, attrs)
+      safe_attrs = attrs.slice(:name, :username, :admin, :avatar_url, :title, :team).compact
+      user.assign_attributes(safe_attrs)
+      if attrs.key?(:metadata) && attrs[:metadata].is_a?(Hash)
+        user.metadata = (user.metadata || {}).merge(attrs[:metadata])
+      end
+    end
+  end
+end

--- a/engine/coplan.gemspec
+++ b/engine/coplan.gemspec
@@ -3,7 +3,7 @@ require_relative "lib/coplan/version"
 Gem::Specification.new do |spec|
   spec.name        = "coplan-engine"
   spec.version     = CoPlan::VERSION
-  spec.authors     = ["Block"]
+  spec.authors     = [ "Block" ]
   spec.summary     = "CoPlan — AI-assisted engineering design doc review"
   spec.description = "A Rails Engine for collaborative plan review with AI-powered feedback."
   spec.license     = "Apache-2.0"
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 8.0"
   spec.add_dependency "commonmarker"
+  spec.add_dependency "diff-lcs"
   spec.add_dependency "diffy"
   spec.add_dependency "ruby-openai"
   spec.add_dependency "propshaft"

--- a/spec/channels/coplan/plan_presence_channel_spec.rb
+++ b/spec/channels/coplan/plan_presence_channel_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe CoPlan::PlanPresenceChannel, type: :channel do
       expect(CoPlan::PlanViewer.where(plan: plan, user: user)).to exist
     end
 
+    it "authenticates through the engine callback when the connection has no current_user" do
+      stub_connection(request: ActionDispatch::Request.empty)
+      allow(CoPlan.configuration).to receive(:authenticate).and_return(
+        ->(_request) { { external_id: "websocket-user", name: "Websocket User" } }
+      )
+      plan = create(:plan, created_by_user: user)
+
+      subscribe(plan_id: plan.id)
+
+      websocket_user = CoPlan::User.find_by!(external_id: "websocket-user")
+      expect(subscription).to be_confirmed
+      expect(CoPlan::PlanViewer.where(plan: plan, user: websocket_user)).to exist
+    end
+
     it "rejects when plan does not exist" do
       subscribe(plan_id: "nonexistent")
       expect(subscription).to be_rejected


### PR DESCRIPTION
## Summary
- Unify authentication across HTTP and ActionCable via CoPlan::Authentication
- Fallback to configured authenticate callback when connection.current_user is absent
- Fix deploy failure by adding missing diff-lcs dependency

## Why
- Hosts without ApplicationCable::Connection#current_user were failing websocket auth
- diff_to_operations requires diff/lcs but dependency was missing, breaking deploy

## Changes
- Add engine/app/services/coplan/authentication.rb
- Update PlanPresenceChannel to resolve user via shared auth
- Update ApplicationController to use shared auth
- Add diff-lcs to gemspec
- Add spec for websocket auth fallback

## Verification
- Specs: 83 examples, 0 failures
- Manual: channel fallback resolves user via authenticate callback

## Risk
- Low: consolidates existing auth logic; preserves behavior when current_user exists

## Follow-ups
- Bump coplan-engine in coplan-square after merge and redeploy
