### PR TITLE
Fix "Mark all read" in inbox dropdown to not navigate

### DIFF
--- a/engine/app/controllers/coplan/notifications_controller.rb
+++ b/engine/app/controllers/coplan/notifications_controller.rb
@@ -45,7 +45,20 @@ module CoPlan
 
       broadcast_badge_update
 
-      redirect_to notifications_path, notice: "All notifications marked as read."
+      respond_to do |format|
+        format.turbo_stream {
+          @notifications = current_user.notifications
+            .includes(:plan, :comment, comment_thread: [:created_by_user])
+            .newest_first
+            .unread
+          @unread_count = 0
+          render turbo_stream: [
+            turbo_stream.update("inbox-badge", "0"),
+            turbo_stream.replace("inbox-panel", partial: "coplan/notifications/panel")
+          ]
+        }
+        format.html { redirect_to notifications_path, notice: "All notifications marked as read." }
+      end
     end
 
     private

--- a/engine/app/views/coplan/notifications/_panel.html.erb
+++ b/engine/app/views/coplan/notifications/_panel.html.erb
@@ -2,7 +2,7 @@
 <div class="inbox-panel__header">
   <span class="inbox-panel__title">Inbox</span>
   <% if @unread_count > 0 %>
-    <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, class: "btn btn--secondary btn--sm", data: { turbo: false } %>
+    <%= button_to "Mark all read", mark_all_read_notifications_path, method: :post, class: "btn btn--secondary btn--sm", form: { data: { turbo_stream: true } } %>
   <% end %>
 </div>
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -84,5 +84,19 @@ RSpec.describe "Notifications", type: :request do
       post mark_all_read_notifications_path
       expect(other_notification.reload.read_at).to be_nil
     end
+
+    it "responds with a turbo_stream that updates the badge and replaces the inbox panel" do
+      create(:notification, user: user, plan: plan, comment_thread: thread)
+
+      post mark_all_read_notifications_path, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq(Mime[:turbo_stream])
+      expect(response.body).to include('target="inbox-badge"')
+      expect(response.body).to include('action="update"')
+      expect(response.body).to include('target="inbox-panel"')
+      expect(response.body).to include('action="replace"')
+      expect(user.notifications.unread.count).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
## Summary

The inbox dropdown's "Mark all read" button was a regular form POST with `data: { turbo: false }`, which redirected to `/notifications` and forced a full page navigation away from whatever page the user was on. This made the action feel heavyweight — clicking it pulled you out of the current plan/page.

This change makes it fire-and-forget: click → unread count goes to 0 → dropdown stays open showing the empty state → user remains on the page they were viewing.

## Approach

Per AGENTS.md ("Prefer server-rendered HTML with standard Stimulus bindings"), this uses Turbo Streams rather than client-side JS clearing.

- **View** (`engine/app/views/coplan/notifications/_panel.html.erb`): swap `data: { turbo: false }` → `form: { data: { turbo_stream: true } }` so `button_to` submits with a turbo-stream Accept header.
- **Controller** (`engine/app/controllers/coplan/notifications_controller.rb#mark_all_read`): add `respond_to` with `format.turbo_stream` that returns two streams:
  - `turbo_stream.update` of `#inbox-badge` → `"0"`
  - `turbo_stream.replace` of `#inbox-panel` with the refreshed panel partial (which renders the empty state since there are no unread notifications)
- The existing `format.html { redirect_to notifications_path }` is preserved for the index page's "Mark all read" button.

## Verification

- `bundle exec rspec` — all 791 examples pass, including a new spec for the turbo_stream response.
- The new spec asserts the response is `text/vnd.turbo-stream.html`, contains an `update` action targeting `inbox-badge`, and a `replace` action targeting `inbox-panel`.

Generated with Amp