### PR TITLE
Web push: dev-only VAPID fallback + restore Intel macOS in lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     commonmarker (2.6.3-aarch64-linux)
     commonmarker (2.6.3-arm-linux)
     commonmarker (2.6.3-arm64-darwin)
+    commonmarker (2.6.3-x86_64-darwin)
     commonmarker (2.6.3-x86_64-linux)
     commonmarker (2.6.3-x86_64-linux-musl)
     concurrent-ruby (1.3.6)
@@ -173,6 +174,7 @@ GEM
     ffi (1.17.3-arm-linux-gnu)
     ffi (1.17.3-arm-linux-musl)
     ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
     formtastic (6.0.0)
@@ -287,6 +289,8 @@ GEM
     nokogiri (1.19.1-arm-linux-musl)
       racc (~> 1.4)
     nokogiri (1.19.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -469,6 +473,7 @@ GEM
     thruster (0.1.18)
     thruster (0.1.18-aarch64-linux)
     thruster (0.1.18-arm64-darwin)
+    thruster (0.1.18-x86_64-darwin)
     thruster (0.1.18-x86_64-linux)
     timeout (0.6.0)
     tsort (0.2.0)
@@ -505,7 +510,9 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin
   arm64-darwin-25
+  x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -575,6 +582,7 @@ CHECKSUMS
   commonmarker (2.6.3-aarch64-linux) sha256=73795e80ab5ef1e4b5b83ada6f082bccb0ed7eae0b910232e13af1b2d71b14d6
   commonmarker (2.6.3-arm-linux) sha256=62b9f32d7d3f85d47988a4a98a2e66e60ca42b894687047db8332f1e80caff7b
   commonmarker (2.6.3-arm64-darwin) sha256=d6c1e4955619da3f68fed22de99dec49a24925611770c039bf870823846c8b21
+  commonmarker (2.6.3-x86_64-darwin) sha256=cd8ab974bb24f675a250ea91a811b3ff70405be1c219f0052446995db6ca90c6
   commonmarker (2.6.3-x86_64-linux) sha256=e861ba1812721113725ebd8e46e4fee20dc732842f5555db2cfb8dcd74056583
   commonmarker (2.6.3-x86_64-linux-musl) sha256=2c62d2dc0d5c4efc6dde39bc5c5fac292169206601a3daf75e562d70b795d49e
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
@@ -604,6 +612,7 @@ CHECKSUMS
   ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
   ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   formtastic (6.0.0) sha256=c398906b65978fec3d045d6792f82cf9641f086ac9f17357b2b382f723126165
@@ -654,6 +663,7 @@ CHECKSUMS
   nokogiri (1.19.1-arm-linux-gnu) sha256=0a39ed59abe3bf279fab9dd4c6db6fe8af01af0608f6e1f08b8ffa4e5d407fa3
   nokogiri (1.19.1-arm-linux-musl) sha256=3a18e559ee499b064aac6562d98daab3d39ba6cbb4074a1542781b2f556db47d
   nokogiri (1.19.1-arm64-darwin) sha256=dfe2d337e6700eac47290407c289d56bcf85805d128c1b5a6434ddb79731cb9e
+  nokogiri (1.19.1-x86_64-darwin) sha256=7093896778cc03efb74b85f915a775862730e887f2e58d6921e3fa3d981e68bf
   nokogiri (1.19.1-x86_64-linux-gnu) sha256=1a4902842a186b4f901078e692d12257678e6133858d0566152fe29cdb98456a
   nokogiri (1.19.1-x86_64-linux-musl) sha256=4267f38ad4fc7e52a2e7ee28ed494e8f9d8eb4f4b3320901d55981c7b995fc23
   openssl (4.0.1) sha256=e27974136b7b02894a1bce46c5397ee889afafe704a839446b54dc81cb9c5f7d
@@ -713,6 +723,7 @@ CHECKSUMS
   thruster (0.1.18) sha256=f025103bc7c8e6747436bb9de058c366840d2871560574ea7070a9bc8608a889
   thruster (0.1.18-aarch64-linux) sha256=16f3d49468d76a9a5de86b7bdedf535b7b80da7c16495ca8ec96cfdc256870e2
   thruster (0.1.18-arm64-darwin) sha256=8b297797a354ec6a81ea156b44279b66bff8da2404112f70f4ec515c2f276cc2
+  thruster (0.1.18-x86_64-darwin) sha256=355b6c0ee30ead7f7096448de4f0f9e8acc8454d2ef24b2d54965c5d813f1c67
   thruster (0.1.18-x86_64-linux) sha256=0ec1ff5f12289c1ac10cf8e28ce6b5266f4e73416b34a664b79d037c7d955c40
   timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/config/initializers/coplan.rb
+++ b/config/initializers/coplan.rb
@@ -32,11 +32,23 @@ CoPlan.configure do |config|
     end
   }
 
-  # Web Push (VAPID) keys for browser notifications. For local dev these are
-  # checked in; in production they should come from Rails encrypted credentials
-  # or your secrets manager. Generate fresh keys with:
+  # Web Push (VAPID) keys for browser notifications. Always read from ENV (or
+  # Rails encrypted credentials in real deployments). When unset, web push is
+  # simply disabled (CoPlan.configuration.web_push_configured? returns false
+  # and the Settings UI / subscription endpoints stay quiet).
+  #
+  # Generate fresh keys with:
   #   bundle exec rake coplan:web_push:generate_keys
-  config.vapid_public_key  = ENV["COPLAN_VAPID_PUBLIC_KEY"]  || "BPY5NsdGJ4vEmHHNz3SqK2XsmV93j-iR3-kqN-RMbl4JRd9jnKpzunwdXDwFwlzbRlPErn3x379e6Cz7DfdSS6o="
-  config.vapid_private_key = ENV["COPLAN_VAPID_PRIVATE_KEY"] || "1HoYR1d8QIlf8RYTfugJQFTyLlBat3zd-EFkj5dO9WQ="
-  config.vapid_subject     = ENV["COPLAN_VAPID_SUBJECT"]     || "mailto:dev@coplan.local"
+  config.vapid_public_key  = ENV["COPLAN_VAPID_PUBLIC_KEY"]
+  config.vapid_private_key = ENV["COPLAN_VAPID_PRIVATE_KEY"]
+  config.vapid_subject     = ENV["COPLAN_VAPID_SUBJECT"]
+
+  # In development only, fall back to a checked-in throwaway keypair so the
+  # Settings UI is testable out-of-the-box. Never used outside development —
+  # production must set COPLAN_VAPID_* env vars (or wire credentials in).
+  if Rails.env.development?
+    config.vapid_public_key  ||= "BP7TzhJX7-UzFR0TRI9onFdILyvEto7fpK0NA9aagCXxSCoA4t6RBMD5zaugFetaq6zrxkEGY4ji49T7P7YNrV0="
+    config.vapid_private_key ||= "96blWvgu38KWqP3Sa7Uiuohzoz-X32936ZtgIT7e0Tg="
+    config.vapid_subject     ||= "mailto:dev@coplan.local"
+  end
 end


### PR DESCRIPTION
Follow-up to #107 — addresses two Codex findings that didn't make it into the merge.

## P1 (security): VAPID fallback key is dev-only

#107 landed with `ENV["COPLAN_VAPID_PRIVATE_KEY"] || "<hardcoded key>"`. That means any deployment that forgets to set the env var silently signs push messages with a key that's now in the public commit history — anyone who learns a subscription endpoint could forge push notifications that appear to come from the app.

Fix: fallback only applies in `Rails.env.development?`. In any other env, missing `COPLAN_VAPID_*` leaves the config nil and `web_push_configured?` returns false — so the meta tags, subscription endpoints, and Settings card all stay quiet rather than running with a public key.

Also rotated the dev fallback to a fresh keypair since the prior values are in commit history.

> ⚠️ **Operators**: if you've deployed `main` from #107 without setting `COPLAN_VAPID_*`, your production app is currently signing with the publicly-known key. Set your own VAPID keypair (generate with `bundle exec rake coplan:web_push:generate_keys`) and merge this PR to make the fallback dev-only.

## P2: Restore Intel macOS in Gemfile.lock

#107 dropped `arm64-darwin` and `x86_64-darwin` (an artifact of `bundle install` running on this `arm64-darwin-25` machine), which breaks frozen `bundle install` for Intel macOS contributors and CI.

Fix: `bundle lock --add-platform x86_64-darwin arm64-darwin` — both back in the lockfile.

## Verification

- `bundle exec rspec` → 814 examples, 0 failures.

Generated with Amp
