### PR TITLE
Public landing page and live plan content updates (CIRCLE-49, CIRCLE-50)

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2520,3 +2520,156 @@ body:not(:has(.comment-toolbar)) .web-push-banner {
     flex: 1;
   }
 }
+
+/* Landing page (rendered at "/" for users with no plans, and at "/welcome") */
+.landing {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg);
+}
+
+.landing__hero {
+  text-align: center;
+  margin-bottom: var(--space-2xl);
+}
+
+.landing__title {
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 var(--space-md);
+  color: var(--color-text);
+}
+
+.landing__lede {
+  font-size: var(--text-lg);
+  line-height: 1.6;
+  color: var(--color-text-muted);
+  max-width: 40rem;
+  margin: 0 auto var(--space-xl);
+}
+
+.landing__cta-row {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.landing__section-title {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  margin: 0 0 var(--space-lg);
+  color: var(--color-text);
+}
+
+.landing__how {
+  margin-bottom: var(--space-2xl);
+}
+
+.landing__steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: var(--space-lg);
+}
+
+.landing__step {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-lg);
+}
+
+.landing__step h3 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin: var(--space-sm) 0;
+  color: var(--color-text);
+}
+
+.landing__step p {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+
+.landing__step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  font-weight: 600;
+  font-size: var(--text-sm);
+}
+
+.landing__agents {
+  background: var(--color-bg-muted);
+  border-radius: var(--radius);
+  padding: var(--space-xl);
+  margin-bottom: var(--space-xl);
+}
+
+.landing__agents p {
+  margin: 0;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.landing__inline-link {
+  color: var(--color-primary);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.landing__footer {
+  text-align: center;
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .landing {
+    padding: var(--space-xl) var(--space-md);
+  }
+
+  .landing__title {
+    font-size: 1.75rem;
+  }
+}
+
+/* Stale-content banner — shown when the plan body was updated in another tab
+   but the local tab has a dirty draft (textarea/contenteditable). User can't
+   safely auto-swap, so we warn them and offer a reload button. */
+.plan-stale-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin: 0 0 var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-warning-soft);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  position: sticky;
+  top: var(--space-sm);
+  z-index: 5;
+}
+
+.plan-stale-banner__message {
+  flex: 1;
+  line-height: 1.5;
+}
+
+.plan-stale-banner__reload {
+  flex-shrink: 0;
+}

--- a/engine/app/controllers/coplan/api/v1/operations_controller.rb
+++ b/engine/app/controllers/coplan/api/v1/operations_controller.rb
@@ -329,6 +329,7 @@ module CoPlan
             partial: "coplan/plans/header",
             locals: { plan: @plan }
           )
+          Broadcaster.replace_plan_content(@plan)
         end
       end
     end

--- a/engine/app/controllers/coplan/dashboard_controller.rb
+++ b/engine/app/controllers/coplan/dashboard_controller.rb
@@ -1,6 +1,0 @@
-module CoPlan
-  class DashboardController < ApplicationController
-    def show
-    end
-  end
-end

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -124,6 +124,7 @@ module CoPlan
       end
 
       broadcast_plan_update(@plan)
+      Broadcaster.replace_plan_content(@plan)
       render json: { revision: @plan.current_revision }
     rescue Plans::OperationError => e
       render json: { error: e.message }, status: :unprocessable_content

--- a/engine/app/controllers/coplan/welcome_controller.rb
+++ b/engine/app/controllers/coplan/welcome_controller.rb
@@ -1,0 +1,39 @@
+module CoPlan
+  # Renders the public landing page (mounted at "/welcome" and at "/").
+  #
+  # Behavior at "/" (root):
+  # * Signed-in users who already have at least one plan are redirected to the
+  #   plans index — they know what CoPlan is and don't need the intro.
+  # * Everyone else (signed-in users with no plans yet, or anyone hitting the
+  #   page anonymously) sees the landing partial configured via
+  #   `CoPlan.configuration.landing_page_partial`.
+  #
+  # Hosts can override the partial to inject deployment-specific copy (e.g.
+  # coplan-square renders a Square-flavored landing that mentions
+  # `sq agents skills add coplan`).
+  class WelcomeController < ApplicationController
+    # The landing page is intentionally public — it's the "what is this thing"
+    # page that needs to work for first-time visitors. We replace the engine's
+    # required-auth `before_action` with a softer version that resolves the
+    # current user when present (so we can personalize CTAs and redirect
+    # established users to /plans) but doesn't reject anonymous visitors.
+    # Hosts that gate the whole app at the perimeter (BeyondCorp, OIDC) will
+    # still enforce sign-in upstream.
+    skip_before_action :authenticate_coplan_user!
+    before_action :resolve_optional_coplan_user
+
+    def show
+      if signed_in? && current_user.created_plans.exists? && params[:force].blank?
+        redirect_to plans_path and return
+      end
+
+      @landing_partial = CoPlan.configuration.landing_page_partial
+    end
+
+    private
+
+    def resolve_optional_coplan_user
+      @current_coplan_user = CoPlan::Authentication.user_from_request(request)
+    end
+  end
+end

--- a/engine/app/javascript/controllers/coplan/live_update_controller.js
+++ b/engine/app/javascript/controllers/coplan/live_update_controller.js
@@ -1,0 +1,124 @@
+import { Controller } from "@hotwired/stimulus"
+
+/*
+ * coplan--live-update
+ *
+ * Listens for the custom <turbo-stream action="coplan-replace-if-clean">
+ * payloads broadcast by Broadcaster#replace_plan_content. When an agent
+ * (or anyone) commits a new revision elsewhere, the server pushes the new
+ * rendered body to every open tab. This controller decides what to do:
+ *
+ *   * If the user has no unsaved drafts → swap the body in place. Existing
+ *     Stimulus controllers reconnect over the new DOM, comment highlights
+ *     re-attach.
+ *
+ *   * If the user is mid-edit (any textarea on the page has non-empty,
+ *     non-trim-blank text) → DON'T blow away their typing. Instead, show
+ *     a sticky banner above the content: "This plan was updated to
+ *     revision N. Reload to see the latest." with a button that reloads.
+ *
+ * The custom Turbo Stream action is registered exactly once per page —
+ * we use a window-level flag so multiple live-update controllers (one per
+ * plan body) don't fight each other.
+ */
+export default class extends Controller {
+  static values = {
+    revision: Number
+  }
+
+  connect() {
+    this.constructor.registerStreamAction()
+  }
+
+  static registerStreamAction() {
+    if (typeof window === "undefined") return
+    if (window.__coplanLiveUpdateRegistered) return
+    if (typeof window.Turbo === "undefined" || !window.Turbo.StreamActions) {
+      // Turbo not ready yet — try again once it loads.
+      document.addEventListener("turbo:load", () => this.registerStreamAction(), { once: true })
+      return
+    }
+
+    window.Turbo.StreamActions["coplan-replace-if-clean"] = function () {
+      // `this` is the <turbo-stream> element. Standard Turbo API.
+      const targetId = this.getAttribute("target")
+      const incomingRevision = parseInt(this.getAttribute("data-revision"), 10) || null
+      const target = document.getElementById(targetId)
+      if (!target) return
+
+      // If the local DOM is already at this revision (or newer), skip — this
+      // tab is the one that issued the edit, no need to re-render.
+      const currentRevision = parseInt(target.getAttribute("data-coplan--live-update-revision-value"), 10) || 0
+      if (incomingRevision && currentRevision >= incomingRevision) return
+
+      // `templateContent` is a DocumentFragment — it has no `innerHTML`.
+      // Use replaceChildren(fragment) to swap the contents of target in one
+      // shot. Stimulus controllers inside target will disconnect + reconnect.
+      const fragment = this.templateContent
+
+      if (hasDirtyDrafts()) {
+        showStaleBanner(target, incomingRevision)
+      } else {
+        target.replaceChildren(fragment)
+        if (incomingRevision) {
+          target.setAttribute("data-coplan--live-update-revision-value", String(incomingRevision))
+        }
+        clearStaleBanner()
+      }
+    }
+
+    window.__coplanLiveUpdateRegistered = true
+  }
+}
+
+/*
+ * Returns true if ANY textarea or contenteditable on the page contains
+ * user-typed text. Used to decide whether it's safe to blow away the
+ * rendered body. We're conservative: if even one textarea has trimmed
+ * non-empty text, we treat the page as dirty.
+ */
+function hasDirtyDrafts() {
+  const textareas = document.querySelectorAll("textarea")
+  for (const ta of textareas) {
+    if (ta.value && ta.value.trim().length > 0) return true
+  }
+  const editables = document.querySelectorAll("[contenteditable='true']")
+  for (const el of editables) {
+    if (el.textContent && el.textContent.trim().length > 0) return true
+  }
+  return false
+}
+
+function showStaleBanner(targetEl, revision) {
+  let banner = document.getElementById("plan-stale-banner")
+  if (banner) {
+    // Already showing — just bump the revision number.
+    const span = banner.querySelector("[data-revision]")
+    if (span && revision) span.textContent = String(revision)
+    return
+  }
+
+  banner = document.createElement("div")
+  banner.id = "plan-stale-banner"
+  banner.className = "plan-stale-banner"
+  banner.setAttribute("role", "status")
+  banner.setAttribute("aria-live", "polite")
+  banner.innerHTML = `
+    <div class="plan-stale-banner__message">
+      ⚠️ This plan was updated${revision ? ` (now at revision <strong data-revision>${revision}</strong>)` : ""}.
+      Your draft is preserved here — reload to see the latest version.
+    </div>
+    <button type="button" class="btn btn--primary btn--sm plan-stale-banner__reload">Reload</button>
+  `
+  banner.querySelector(".plan-stale-banner__reload").addEventListener("click", () => {
+    window.location.reload()
+  })
+
+  // Insert directly above the stale content so the connection is visually obvious.
+  targetEl.parentNode.insertBefore(banner, targetEl)
+}
+
+function clearStaleBanner() {
+  const banner = document.getElementById("plan-stale-banner")
+  if (banner) banner.remove()
+}

--- a/engine/app/services/coplan/broadcaster.rb
+++ b/engine/app/services/coplan/broadcaster.rb
@@ -22,6 +22,35 @@ module CoPlan
         Turbo::StreamsChannel.broadcast_remove_to(streamable, target: target)
       end
 
+      # Broadcasts a custom turbo-stream action that the client may apply
+      # conditionally. Used by live-content-update: the client checks for
+      # unsaved drafts before swapping the body, otherwise shows a "reload"
+      # banner so the user doesn't lose typed-but-unsent text.
+      #
+      # We don't go through Turbo::StreamsChannel's helpers because they
+      # only emit the built-in actions (replace/update/append/etc.); a custom
+      # action requires building the <turbo-stream> element ourselves.
+      def custom_action_to(streamable, action:, target:, html:, attrs: {})
+        attr_string = attrs.map { |k, v| %( #{k}="#{ERB::Util.html_escape(v)}") }.join
+        stream = %(<turbo-stream action="#{action}" target="#{target}"#{attr_string}><template>#{html}</template></turbo-stream>)
+        Turbo::StreamsChannel.broadcast_stream_to(streamable, content: stream.html_safe)
+      end
+
+      # Convenience wrapper for the most common content-mutation broadcast:
+      # push the freshly rendered plan body to every open tab, letting the
+      # client decide whether to apply it (clean) or show a stale-revision
+      # banner (dirty draft in progress).
+      def replace_plan_content(plan)
+        html = render(partial: "coplan/plans/content_body", locals: { plan: plan })
+        custom_action_to(
+          plan,
+          action: "coplan-replace-if-clean",
+          target: "plan-content-body",
+          html: html,
+          attrs: { "data-revision" => plan.current_revision }
+        )
+      end
+
       private
 
       def render(partial:, locals:)

--- a/engine/app/services/coplan/plans/commit_session.rb
+++ b/engine/app/services/coplan/plans/commit_session.rb
@@ -144,6 +144,7 @@ module CoPlan
             partial: "coplan/plans/header",
             locals: { plan: plan }
           )
+          Broadcaster.replace_plan_content(plan)
 
           { session: @session, version: version }
         end

--- a/engine/app/services/coplan/plans/replace_content.rb
+++ b/engine/app/services/coplan/plans/replace_content.rb
@@ -121,6 +121,7 @@ module CoPlan
             partial: "coplan/plans/header",
             locals: { plan: @plan }
           )
+          Broadcaster.replace_plan_content(@plan)
 
           { version: version, plan: @plan, applied: result[:applied].length, no_op: false }
         end

--- a/engine/app/views/coplan/dashboard/show.html.erb
+++ b/engine/app/views/coplan/dashboard/show.html.erb
@@ -1,8 +1,0 @@
-<div class="page-header">
-  <h1>Dashboard</h1>
-</div>
-
-<div class="empty-state card">
-  <p>Welcome to <strong>CoPlan</strong>.</p>
-  <p class="text-muted text-sm">Plans and collaboration tools will appear here once set up.</p>
-</div>

--- a/engine/app/views/coplan/plans/_content_body.html.erb
+++ b/engine/app/views/coplan/plans/_content_body.html.erb
@@ -1,0 +1,4 @@
+<%# Rendered plan markdown. Lives inside #plan-content-body so it can be
+    swapped wholesale by live-update broadcasts when an agent (or anyone)
+    commits a new revision in another tab. -%>
+<%= render_markdown(plan.current_content) %>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -36,7 +36,11 @@
         <button type="button" class="content-nav-show-btn" data-action="coplan--content-nav#toggle" data-coplan--content-nav-target="showBtn" title="Show table of contents (])">☰ <kbd>]</kbd></button>
 
         <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content">
-          <%= render_markdown(@plan.current_content) %>
+          <div id="plan-content-body"
+               data-controller="coplan--live-update"
+               data-coplan--live-update-revision-value="<%= @plan.current_revision %>">
+            <%= render partial: "coplan/plans/content_body", locals: { plan: @plan } %>
+          </div>
 
           <div class="comment-popover" data-coplan--text-selection-target="popover" style="display: none;">
             <button type="button" class="btn btn--primary btn--sm" data-action="coplan--text-selection#openCommentForm">

--- a/engine/app/views/coplan/welcome/_default_agents.html.erb
+++ b/engine/app/views/coplan/welcome/_default_agents.html.erb
@@ -1,0 +1,9 @@
+<section class="landing__agents">
+  <h2 class="landing__section-title">Built for any AI agent</h2>
+  <p>
+    CoPlan exposes a self-describing REST API at
+    <%= link_to "/agent-instructions", agent_instructions_path, class: "landing__inline-link" %>.
+    Point any AI agent — Amp, Claude Code, Cursor, your own — at it and it can create plans,
+    apply edits, and leave review comments on your behalf.
+  </p>
+</section>

--- a/engine/app/views/coplan/welcome/_default_landing.html.erb
+++ b/engine/app/views/coplan/welcome/_default_landing.html.erb
@@ -1,0 +1,72 @@
+<div class="landing">
+  <header class="landing__hero">
+    <h1 class="landing__title">Design docs, built for AI-assisted planning.</h1>
+    <p class="landing__lede">
+      CoPlan is where engineers and AI agents collaborate on plans together.
+      Humans leave inline feedback. AI agents respond to that feedback and apply edits automatically.
+      Every change is versioned with full provenance.
+    </p>
+
+    <div class="landing__cta-row">
+      <% if signed_in? %>
+        <%= link_to "Browse plans", plans_path, class: "btn btn--primary" %>
+      <% end %>
+      <%= link_to "Read the agent API", agent_instructions_path, class: "btn btn--secondary" %>
+    </div>
+  </header>
+
+  <section class="landing__how">
+    <h2 class="landing__section-title">How it works</h2>
+
+    <div class="landing__steps">
+      <div class="landing__step">
+        <div class="landing__step-number">1</div>
+        <h3>Write a plan</h3>
+        <p>
+          A plan is a Markdown design doc. Author it yourself, or have an AI agent draft one
+          for you using the API. Plans live through a clear lifecycle: brainstorm → considering
+          → developing → live.
+        </p>
+      </div>
+
+      <div class="landing__step">
+        <div class="landing__step-number">2</div>
+        <h3>Get inline feedback</h3>
+        <p>
+          Domain experts highlight any sentence and leave a comment. Threads stay anchored to the
+          exact text they reference, so context never gets lost. Mention people with
+          <code>@username</code> to pull them in.
+        </p>
+      </div>
+
+      <div class="landing__step">
+        <div class="landing__step-number">3</div>
+        <h3>Agents apply the edits</h3>
+        <p>
+          AI agents read the comments, apply targeted edits to the plan, and resolve the threads.
+          Every edit creates a new immutable version with full attribution — you can see exactly
+          who (or what) changed what, and why.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="landing__agents">
+    <h2 class="landing__section-title">Built for any AI agent</h2>
+    <p>
+      CoPlan exposes a self-describing REST API at
+      <%= link_to "/agent-instructions", agent_instructions_path, class: "landing__inline-link" %>.
+      Point any AI agent — Amp, Claude Code, Cursor, your own — at it and it can create plans,
+      apply edits, and leave review comments on your behalf.
+    </p>
+  </section>
+
+  <% if signed_in? %>
+    <footer class="landing__footer">
+      <p>
+        Signed in as <strong><%= current_user.name %></strong>.
+        <%= link_to "Browse all plans →", plans_path, class: "landing__inline-link" %>
+      </p>
+    </footer>
+  <% end %>
+</div>

--- a/engine/app/views/coplan/welcome/_default_landing.html.erb
+++ b/engine/app/views/coplan/welcome/_default_landing.html.erb
@@ -51,15 +51,13 @@
     </div>
   </section>
 
-  <section class="landing__agents">
-    <h2 class="landing__section-title">Built for any AI agent</h2>
-    <p>
-      CoPlan exposes a self-describing REST API at
-      <%= link_to "/agent-instructions", agent_instructions_path, class: "landing__inline-link" %>.
-      Point any AI agent — Amp, Claude Code, Cursor, your own — at it and it can create plans,
-      apply edits, and leave review comments on your behalf.
-    </p>
-  </section>
+  <%# The agents section is the one piece of the landing page hosts most often
+      need to customize — generic CoPlan points at /agent-instructions, while
+      a deployment like coplan-square wants to tell its users to run
+      `sq agents skills add coplan` instead. Renders via configuration so a
+      host can swap this single section without forking the whole landing
+      page. See `CoPlan.configuration.landing_agents_partial`. %>
+  <%= render CoPlan.configuration.landing_agents_partial %>
 
   <% if signed_in? %>
     <footer class="landing__footer">

--- a/engine/app/views/coplan/welcome/show.html.erb
+++ b/engine/app/views/coplan/welcome/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Welcome to CoPlan" %>
+
+<%= render @landing_partial %>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -82,5 +82,7 @@ CoPlan::Engine.routes.draw do
     get "devices", to: "subscriptions#devices", as: :devices
   end
 
-  root "plans#index"
+  get "welcome", to: "welcome#show", as: :welcome
+
+  root "welcome#show"
 end

--- a/engine/lib/coplan/configuration.rb
+++ b/engine/lib/coplan/configuration.rb
@@ -18,6 +18,19 @@ module CoPlan
     # The engine ships a generic default at "coplan/welcome/default_landing".
     attr_accessor :landing_page_partial
 
+    # Partial used to render the "Built for any AI agent" section of the
+    # landing page. This is the single piece of the landing page that hosts
+    # most often need to customize: the generic engine partial points users
+    # at `/agent-instructions`, while a deployment like coplan-square wants
+    # to tell its users to run `sq agents skills add coplan` instead.
+    #
+    # Swapping just this partial (rather than the whole landing page) lets
+    # hosts customize the agents callout without duplicating the hero, the
+    # how-it-works steps, or the CSS.
+    #
+    # The engine ships a generic default at "coplan/welcome/default_agents".
+    attr_accessor :landing_agents_partial
+
     # VAPID (Voluntary Application Server Identification) keys for Web Push.
     # Generate once with `bundle exec rails coplan:web_push:generate_keys`.
     # Public key is shared with the browser; private key signs push messages.
@@ -49,6 +62,7 @@ module CoPlan
       @agent_curl_prefix = 'curl -s -H "Authorization: Bearer $TOKEN"'
       @seed_plan_types = []
       @landing_page_partial = "coplan/welcome/default_landing"
+      @landing_agents_partial = "coplan/welcome/default_agents"
       @agent_auth_instructions = <<~MARKDOWN
         ## Authentication
 

--- a/engine/lib/coplan/configuration.rb
+++ b/engine/lib/coplan/configuration.rb
@@ -9,6 +9,15 @@ module CoPlan
     attr_accessor :agent_curl_prefix
     attr_accessor :seed_plan_types
 
+    # Path to the partial rendered as the public landing page at "/welcome"
+    # (and at "/" for users who haven't created any plans yet). Hosts override
+    # this to inject deployment-specific copy, install commands, screenshots,
+    # etc. — e.g. coplan-square renders a Square-flavored landing that mentions
+    # `sq agents skills add coplan`.
+    #
+    # The engine ships a generic default at "coplan/welcome/default_landing".
+    attr_accessor :landing_page_partial
+
     # VAPID (Voluntary Application Server Identification) keys for Web Push.
     # Generate once with `bundle exec rails coplan:web_push:generate_keys`.
     # Public key is shared with the browser; private key signs push messages.
@@ -39,6 +48,7 @@ module CoPlan
       @onboarding_banner = 'Want to upload Agentic plans? Give your agent <a href="/agent-instructions">these instructions</a>.'
       @agent_curl_prefix = 'curl -s -H "Authorization: Bearer $TOKEN"'
       @seed_plan_types = []
+      @landing_page_partial = "coplan/welcome/default_landing"
       @agent_auth_instructions = <<~MARKDOWN
         ## Authentication
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -29,12 +29,20 @@ RSpec.describe "Sessions", type: :request do
     delete sign_out_path
     expect(response).to redirect_to(sign_in_path)
 
-    get root_path
+    # /plans is auth-gated; / (welcome) is intentionally public per CIRCLE-49.
+    get plans_path
     expect(response).to redirect_to(sign_in_path)
   end
 
-  it "unauthenticated access redirects to sign in" do
-    get root_path
+  it "unauthenticated access to a protected page redirects to sign in" do
+    # /plans requires authentication; / (welcome) is the public landing page.
+    get plans_path
     expect(response).to redirect_to(sign_in_path)
+  end
+
+  it "unauthenticated access to / renders the public landing page" do
+    get root_path
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Design docs, built for AI-assisted planning")
   end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -88,4 +88,50 @@ RSpec.describe "Welcome", type: :request do
       expect(response.body).not_to include("Design docs, built for AI-assisted planning")
     end
   end
+
+  describe "landing_agents_partial configuration override" do
+    # The agents section is the one piece of the landing page we expect hosts
+    # to most often swap out (generic /agent-instructions vs deployment-
+    # specific install commands like `sq agents skills add coplan`). Verify
+    # the swap happens *and* that the rest of the landing page is untouched.
+
+    before { sign_in_as(bob) }
+
+    context "with the default partial" do
+      it "renders the generic agents section pointing at /agent-instructions" do
+        get welcome_path
+        expect(response.body).to include("Built for any AI agent")
+        expect(response.body).to include("/agent-instructions")
+      end
+    end
+
+    context "with a host-configured override" do
+      around do |ex|
+        original = CoPlan.configuration.landing_agents_partial
+        CoPlan.configuration.landing_agents_partial = "coplan/welcome/test_agents_override"
+        ex.run
+        CoPlan.configuration.landing_agents_partial = original
+      end
+
+      before do
+        view_path = CoPlan::Engine.root.join("app/views/coplan/welcome/_test_agents_override.html.erb")
+        File.write(view_path, "<section class=\"host-agents\">sq agents skills add coplan</section>\n")
+        @tmp_view = view_path
+      end
+
+      after { File.delete(@tmp_view) if @tmp_view&.exist? }
+
+      it "swaps the agents section while keeping the rest of the landing page" do
+        get welcome_path
+
+        # The host's agents copy is rendered…
+        expect(response.body).to include("sq agents skills add coplan")
+        # …the default agents copy is gone…
+        expect(response.body).not_to include("Built for any AI agent")
+        # …but the hero and how-it-works steps are still the engine defaults.
+        expect(response.body).to include("Design docs, built for AI-assisted planning")
+        expect(response.body).to include("How it works")
+      end
+    end
+  end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "Welcome", type: :request do
+  let(:alice) { create(:coplan_user) }
+  let(:bob) { create(:coplan_user) }
+
+  describe "GET /" do
+    context "signed-in user with no plans" do
+      before { sign_in_as(bob) }
+
+      it "renders the landing page" do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Design docs, built for AI-assisted planning")
+      end
+
+      it "shows a 'Browse plans' CTA for signed-in users" do
+        get root_path
+        expect(response.body).to include("Browse plans")
+      end
+    end
+
+    context "signed-in user with at least one plan" do
+      before do
+        sign_in_as(alice)
+        create(:plan, :considering, created_by_user: alice)
+      end
+
+      it "redirects to the plans index" do
+        get root_path
+        expect(response).to redirect_to(plans_path)
+      end
+
+      it "renders the landing page when force=1 is passed (escape hatch)" do
+        get root_path(force: 1)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Design docs, built for AI-assisted planning")
+      end
+    end
+  end
+
+  describe "GET /welcome" do
+    context "signed-in user with plans" do
+      before do
+        sign_in_as(alice)
+        create(:plan, :considering, created_by_user: alice)
+      end
+
+      it "redirects to the plans index just like /" do
+        get welcome_path
+        expect(response).to redirect_to(plans_path)
+      end
+    end
+
+    context "signed-in user without plans" do
+      before { sign_in_as(bob) }
+
+      it "renders the landing page" do
+        get welcome_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Design docs, built for AI-assisted planning")
+      end
+    end
+  end
+
+  describe "landing_page_partial configuration override" do
+    around do |ex|
+      original = CoPlan.configuration.landing_page_partial
+      CoPlan.configuration.landing_page_partial = "coplan/welcome/test_landing_override"
+      ex.run
+      CoPlan.configuration.landing_page_partial = original
+    end
+
+    before do
+      sign_in_as(bob)
+      # Create a temporary partial under engine view paths so we can verify the
+      # configured partial is what gets rendered. Cleaned up in `after`.
+      view_path = CoPlan::Engine.root.join("app/views/coplan/welcome/_test_landing_override.html.erb")
+      File.write(view_path, "<div class=\"custom-host-landing\">Square-flavored landing</div>\n")
+      @tmp_view = view_path
+    end
+
+    after { File.delete(@tmp_view) if @tmp_view&.exist? }
+
+    it "renders the host-configured partial instead of the default" do
+      get welcome_path
+      expect(response.body).to include("Square-flavored landing")
+      expect(response.body).not_to include("Design docs, built for AI-assisted planning")
+    end
+  end
+end

--- a/spec/services/broadcaster_spec.rb
+++ b/spec/services/broadcaster_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::Broadcaster do
+  let(:author) { create(:coplan_user) }
+  let(:plan) do
+    p = CoPlan::Plan.create!(title: "Test Plan", created_by_user: author)
+    version = CoPlan::PlanVersion.create!(
+      plan: p, revision: 1,
+      content_markdown: "# Hello world\n\nSome content here.",
+      actor_type: "human", actor_id: author.id
+    )
+    p.update!(current_plan_version: version, current_revision: 1)
+    p
+  end
+
+  describe ".replace_plan_content" do
+    # Ensure plan is built BEFORE we start spying, so setup-time broadcasts
+    # (from CoPlan::Plan.create! / CoPlan::PlanVersion.create!) don't pollute
+    # the captured payloads.
+    before { plan }
+
+    it "broadcasts a custom turbo-stream action targeting #plan-content-body" do
+      payloads = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to) do |_streamable, content:|
+        payloads << content.to_s
+      end
+
+      described_class.replace_plan_content(plan)
+
+      expect(payloads.size).to eq(1)
+      expect(payloads.first).to include('action="coplan-replace-if-clean"')
+      expect(payloads.first).to include('target="plan-content-body"')
+      expect(payloads.first).to include('data-revision="1"')
+      # The fresh markdown render is wrapped in a <template>
+      expect(payloads.first).to include("<template>")
+      expect(payloads.first).to include("Hello world")
+    end
+
+    it "reflects the latest revision so stale-tab clients can ignore self-broadcasts" do
+      version2 = CoPlan::PlanVersion.create!(
+        plan: plan, revision: 2,
+        content_markdown: "# Updated\n\nMore content.",
+        actor_type: "local_agent", actor_id: author.id
+      )
+      plan.update!(current_plan_version: version2, current_revision: 2)
+
+      payloads = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to) do |_, content:|
+        payloads << content.to_s
+      end
+
+      described_class.replace_plan_content(plan.reload)
+
+      expect(payloads.first).to include('data-revision="2"')
+      expect(payloads.first).to include("Updated")
+    end
+  end
+end

--- a/spec/services/plans/replace_content_spec.rb
+++ b/spec/services/plans/replace_content_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe CoPlan::Plans::ReplaceContent do
     plan
   end
 
+  describe "broadcasts" do
+    let(:new_content) { initial_content.sub("unit tests", "integration tests") }
+
+    it "broadcasts the new content body so other tabs live-update" do
+      expect(CoPlan::Broadcaster).to receive(:replace_plan_content).with(plan).and_call_original
+      allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to)
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+
+      described_class.call(
+        plan: plan,
+        new_content: new_content,
+        base_revision: 1,
+        actor_type: "local_agent",
+        actor_id: user.id
+      )
+    end
+  end
+
   describe "happy path" do
     let(:new_content) { initial_content.sub("unit tests", "integration tests") }
 


### PR DESCRIPTION
## Why

Two product-facing problems we kept hitting:

1. **People who land on the CoPlan root URL see a wall of unfamiliar plans with zero context** about what the site is for. We need a real landing page (COPLAN-2).
2. **Plan content does not live-update in open tabs when an agent (or another user) edits a plan elsewhere.** I had a tab open, an agent edited the doc, and my tab silently stayed stale. We also need to be careful not to clobber an in-progress comment draft when we do start live-updating (COPLAN-1).

## What

### COPLAN-2 — Public welcome / landing page
- New `GET /welcome` route that always shows a real landing page (hero, three-step workflow, agents section).
- `/` now routes to `WelcomeController`:
  - signed-in users with plans → redirected to `/plans`
  - anonymous visitors and signed-in users with no plans → see the landing page
  - `?force=1` escape hatch always renders the landing page
- New `CoPlan.configuration.landing_page_partial` so a host app (e.g. `coplan-square`) can override the copy with its own partial. Default engine partial ships generic copy.
- Removed dead `DashboardController` + view that was no longer routed.
- Session specs updated because `/` is intentionally public now; auth-gated redirect assertions point at `/plans`.

### COPLAN-1 — Live plan content updates with dirty-draft protection
- Root cause: every plan mutation path only broadcast header updates over Turbo Streams, so the document body never updated in open tabs.
- Extracted the rendered plan markdown into `_content_body.html.erb`, wrapped in `#plan-content-body` so Turbo can target it.
- Custom Turbo Stream action `coplan-replace-if-clean`:
  - replaces the body live when the local tab has no dirty draft
  - otherwise leaves the body alone and shows a sticky warning banner with a reload button, so an unsaved comment / reply does not get clobbered
- Wired all mutation paths to broadcast the new body partial:
  - `Plans::ReplaceContent`
  - `Plans::CommitSession`
  - `Api::V1::OperationsController#broadcast_plan_update`
  - `PlansController#toggle_checkbox`
- Dirty-state detection is intentionally conservative: any `<textarea>` or `[contenteditable="true"]` with trimmed non-empty text counts as dirty, which covers new-comment and reply forms without per-form wiring.

## Testing

- `bundle exec rspec` → **845 examples, 0 failures**
- Manually verified locally:
  - API-driven edit propagates into an open tab without reload
  - With text typed into a reply textarea, the body stays stale and the warning banner appears; typed text is preserved

## References
- [COPLAN-2](https://linear.app/squareup/issue/COPLAN-2)
- [COPLAN-1](https://linear.app/squareup/issue/COPLAN-1)

---
🤖 Generated with [Amp](https://ampcode.com)

