### PR TITLE
Extract landing-page agents section into a swappable partial (COPLAN-3)

### DIFF
--- a/engine/app/views/coplan/welcome/_default_agents.html.erb
+++ b/engine/app/views/coplan/welcome/_default_agents.html.erb
@@ -1,0 +1,9 @@
+<section class="landing__agents">
+  <h2 class="landing__section-title">Built for any AI agent</h2>
+  <p>
+    CoPlan exposes a self-describing REST API at
+    <%= link_to "/agent-instructions", agent_instructions_path, class: "landing__inline-link" %>.
+    Point any AI agent — Amp, Claude Code, Cursor, your own — at it and it can create plans,
+    apply edits, and leave review comments on your behalf.
+  </p>
+</section>

--- a/engine/app/views/coplan/welcome/_default_landing.html.erb
+++ b/engine/app/views/coplan/welcome/_default_landing.html.erb
@@ -51,15 +51,13 @@
     </div>
   </section>
 
-  <section class="landing__agents">
-    <h2 class="landing__section-title">Built for any AI agent</h2>
-    <p>
-      CoPlan exposes a self-describing REST API at
-      <%= link_to "/agent-instructions", agent_instructions_path, class: "landing__inline-link" %>.
-      Point any AI agent — Amp, Claude Code, Cursor, your own — at it and it can create plans,
-      apply edits, and leave review comments on your behalf.
-    </p>
-  </section>
+  <%# The agents section is the one piece of the landing page hosts most often
+      need to customize — generic CoPlan points at /agent-instructions, while
+      a deployment like coplan-square wants to tell its users to run
+      `sq agents skills add coplan` instead. Renders via configuration so a
+      host can swap this single section without forking the whole landing
+      page. See `CoPlan.configuration.landing_agents_partial`. %>
+  <%= render CoPlan.configuration.landing_agents_partial %>
 
   <% if signed_in? %>
     <footer class="landing__footer">

--- a/engine/lib/coplan/configuration.rb
+++ b/engine/lib/coplan/configuration.rb
@@ -18,6 +18,19 @@ module CoPlan
     # The engine ships a generic default at "coplan/welcome/default_landing".
     attr_accessor :landing_page_partial
 
+    # Partial used to render the "Built for any AI agent" section of the
+    # landing page. This is the single piece of the landing page that hosts
+    # most often need to customize: the generic engine partial points users
+    # at `/agent-instructions`, while a deployment like coplan-square wants
+    # to tell its users to run `sq agents skills add coplan` instead.
+    #
+    # Swapping just this partial (rather than the whole landing page) lets
+    # hosts customize the agents callout without duplicating the hero, the
+    # how-it-works steps, or the CSS.
+    #
+    # The engine ships a generic default at "coplan/welcome/default_agents".
+    attr_accessor :landing_agents_partial
+
     # VAPID (Voluntary Application Server Identification) keys for Web Push.
     # Generate once with `bundle exec rails coplan:web_push:generate_keys`.
     # Public key is shared with the browser; private key signs push messages.
@@ -49,6 +62,7 @@ module CoPlan
       @agent_curl_prefix = 'curl -s -H "Authorization: Bearer $TOKEN"'
       @seed_plan_types = []
       @landing_page_partial = "coplan/welcome/default_landing"
+      @landing_agents_partial = "coplan/welcome/default_agents"
       @agent_auth_instructions = <<~MARKDOWN
         ## Authentication
 

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -88,4 +88,50 @@ RSpec.describe "Welcome", type: :request do
       expect(response.body).not_to include("Design docs, built for AI-assisted planning")
     end
   end
+
+  describe "landing_agents_partial configuration override" do
+    # The agents section is the one piece of the landing page we expect hosts
+    # to most often swap out (generic /agent-instructions vs deployment-
+    # specific install commands like `sq agents skills add coplan`). Verify
+    # the swap happens *and* that the rest of the landing page is untouched.
+
+    before { sign_in_as(bob) }
+
+    context "with the default partial" do
+      it "renders the generic agents section pointing at /agent-instructions" do
+        get welcome_path
+        expect(response.body).to include("Built for any AI agent")
+        expect(response.body).to include("/agent-instructions")
+      end
+    end
+
+    context "with a host-configured override" do
+      around do |ex|
+        original = CoPlan.configuration.landing_agents_partial
+        CoPlan.configuration.landing_agents_partial = "coplan/welcome/test_agents_override"
+        ex.run
+        CoPlan.configuration.landing_agents_partial = original
+      end
+
+      before do
+        view_path = CoPlan::Engine.root.join("app/views/coplan/welcome/_test_agents_override.html.erb")
+        File.write(view_path, "<section class=\"host-agents\">sq agents skills add coplan</section>\n")
+        @tmp_view = view_path
+      end
+
+      after { File.delete(@tmp_view) if @tmp_view&.exist? }
+
+      it "swaps the agents section while keeping the rest of the landing page" do
+        get welcome_path
+
+        # The host's agents copy is rendered…
+        expect(response.body).to include("sq agents skills add coplan")
+        # …the default agents copy is gone…
+        expect(response.body).not_to include("Built for any AI agent")
+        # …but the hero and how-it-works steps are still the engine defaults.
+        expect(response.body).to include("Design docs, built for AI-assisted planning")
+        expect(response.body).to include("How it works")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why

The landing page from #113 has one section — "Built for any AI agent" — that hosts will almost always want to customize. Generic CoPlan points users at `/agent-instructions`; a deployment like `coplan-square` wants to tell users to run `sq agents skills add coplan` instead.

The existing `landing_page_partial` config lets hosts swap the *entire* landing page, but that forces them to duplicate the hero, the 3-step how-it-works section, and all the CSS just to change one paragraph. Heavy.

This PR exposes a single config knob for just that section, so a host can change the agents callout without forking the rest.

## What

- Extract the agents section into `engine/app/views/coplan/welcome/_default_agents.html.erb`
- Add `CoPlan.configuration.landing_agents_partial`, defaulting to that partial
- `_default_landing.html.erb` renders via the configured partial instead of inline
- Request specs for the default render path and the override path, asserting that swapping only this partial leaves the hero and how-it-works sections untouched

**Behavior unchanged by default** — the engine renders the same paragraph it did before. Host-side change in `coplan-square` to actually use this hook will ship as a follow-up PR.

## Design note: section-level partial swap

There are a handful of ways an engine can let hosts customize views (full partial swap, `content_for` slots, view path prepending, config values, DSL). We considered building a structured slot framework, but the actual delta between generic and Square's landing page is a single paragraph — so a slot framework would be over-engineering.

The pattern this PR lands instead: **section-level partial swap**. One config knob per section that needs customization, added incrementally as real needs appear. If a future section needs to differ (e.g. hero copy on Square's landing), we add `landing_hero_partial` at that point.

## Testing

- `bundle exec rspec` → **847 examples, 0 failures** (added 2 new specs)
- New specs cover both the default rendering and the override path

## References
- [COPLAN-3](https://linear.app/squareup/issue/COPLAN-3)
- Stacked on top of #113

---
🤖 Generated with [Amp](https://ampcode.com)
