### PR TITLE
Sitewide search modal with MySQL FULLTEXT (COPLAN-21)

### DIFF
--- a/db/migrate/20260601202008_add_search_to_coplan_plans.co_plan.rb
+++ b/db/migrate/20260601202008_add_search_to_coplan_plans.co_plan.rb
@@ -1,0 +1,37 @@
+# This migration comes from co_plan (originally 20260601000000)
+class AddSearchToCoplanPlans < ActiveRecord::Migration[8.1]
+  # Adds a denormalized `search_text` column on `coplan_plans` plus a MySQL
+  # FULLTEXT index. This is the one explicit MySQL-ism in the engine; see
+  # AGENTS.md ("Tech Stack & Philosophy"). The schema otherwise stays portable.
+  #
+  # The column is maintained by `Plan#refresh_search_text!`, called from
+  # after-commit hooks on Plan/PlanTag/PlanVersion. See engine/app/models/coplan/plan.rb.
+  def up
+    add_column :coplan_plans, :search_text, :mediumtext
+
+    # Backfill before adding the FULLTEXT index — FULLTEXT building is faster
+    # when the data is already in place, and we want existing plans searchable
+    # the moment the app reboots.
+    CoPlan::Plan.reset_column_information
+    CoPlan::Plan.find_each do |plan|
+      plan.update_columns(search_text: CoPlan::Plan.build_search_text(plan))
+    end
+
+    if mysql?
+      execute "ALTER TABLE coplan_plans ADD FULLTEXT INDEX index_coplan_plans_on_search_text (search_text)"
+    end
+  end
+
+  def down
+    if mysql?
+      execute "ALTER TABLE coplan_plans DROP INDEX index_coplan_plans_on_search_text"
+    end
+    remove_column :coplan_plans, :search_text
+  end
+
+  private
+
+  def mysql?
+    connection.adapter_name.match?(/mysql/i)
+  end
+end

--- a/db/migrate/20260601202009_create_coplan_search_queries.co_plan.rb
+++ b/db/migrate/20260601202009_create_coplan_search_queries.co_plan.rb
@@ -1,0 +1,16 @@
+# This migration comes from co_plan (originally 20260601000001)
+class CreateCoplanSearchQueries < ActiveRecord::Migration[8.1]
+  # Records the search queries each user runs, so the search modal can show a
+  # "Recent searches" list when the input is empty. We only persist queries for
+  # signed-in users; anonymous searches are not logged.
+  def change
+    create_table :coplan_search_queries, id: { type: :string, limit: 36 } do |t|
+      t.string :user_id, limit: 36, null: false
+      t.string :query, null: false, limit: 255
+      t.timestamp :created_at, null: false
+    end
+
+    add_index :coplan_search_queries, [:user_id, :created_at]
+    add_foreign_key :coplan_search_queries, :coplan_users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_011926) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_202009) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -224,12 +224,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_011926) do
     t.integer "current_revision", default: 0, null: false
     t.json "metadata"
     t.string "plan_type_id", limit: 36
+    t.text "search_text", size: :medium
     t.string "status", default: "brainstorm", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_user_id"], name: "index_coplan_plans_on_created_by_user_id"
     t.index ["current_plan_version_id"], name: "fk_rails_c401577583"
     t.index ["plan_type_id"], name: "index_coplan_plans_on_plan_type_id"
+    t.index ["search_text"], name: "index_coplan_plans_on_search_text", type: :fulltext
     t.index ["status"], name: "index_coplan_plans_on_status"
     t.index ["updated_at"], name: "index_coplan_plans_on_updated_at"
   end
@@ -248,6 +250,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_011926) do
     t.index ["plan_id", "url"], name: "index_coplan_references_on_plan_id_and_url", unique: true
     t.index ["source"], name: "index_coplan_references_on_source"
     t.index ["target_plan_id"], name: "index_coplan_references_on_target_plan_id"
+  end
+
+  create_table "coplan_search_queries", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.timestamp "created_at", null: false
+    t.string "query", null: false
+    t.string "user_id", limit: 36, null: false
+    t.index ["user_id", "created_at"], name: "index_coplan_search_queries_on_user_id_and_created_at"
   end
 
   create_table "coplan_tags", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -320,5 +329,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_011926) do
   add_foreign_key "coplan_plans", "coplan_users", column: "created_by_user_id"
   add_foreign_key "coplan_references", "coplan_plans", column: "plan_id"
   add_foreign_key "coplan_references", "coplan_plans", column: "target_plan_id"
+  add_foreign_key "coplan_search_queries", "coplan_users", column: "user_id"
   add_foreign_key "coplan_web_push_subscriptions", "coplan_users", column: "user_id"
 end

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2702,3 +2702,184 @@ body:not(:has(.comment-toolbar)) .web-push-banner {
 .plan-stale-banner__reload {
   flex-shrink: 0;
 }
+
+/* --- Sitewide search (COPLAN-21) -------------------------------------- */
+
+.site-nav__search {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 6px 10px;
+  margin: 0 var(--space-md);
+  flex: 0 1 320px;
+  min-width: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.site-nav__search:hover {
+  border-color: var(--color-text-muted);
+  color: var(--color-text);
+}
+
+.site-nav__search-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.site-nav__search-kbd {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  padding: 1px 6px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-muted);
+}
+
+.search-modal {
+  position: fixed;
+  top: 10vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(640px, 92vw);
+  max-height: 70vh;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-modal::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.search-modal__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.search-modal__input {
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font: inherit;
+  font-size: var(--text-md);
+  color: var(--color-text);
+  padding: 4px 0;
+}
+
+.search-modal__hint {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  padding: 1px 6px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-muted);
+}
+
+.search-modal__body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.search-modal__section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-muted);
+  padding: var(--space-md) var(--space-lg) var(--space-xs);
+}
+
+.search-modal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.search-modal__result {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px var(--space-lg);
+  color: var(--color-text);
+  text-decoration: none;
+  border-left: 3px solid transparent;
+}
+
+.search-modal__result:hover,
+.search-modal__result--selected {
+  background: var(--color-bg);
+  border-left-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.search-modal__result-title {
+  font-weight: 500;
+  font-size: var(--text-md);
+}
+
+.search-modal__result-meta {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.search-modal__status {
+  text-transform: capitalize;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.search-modal__empty {
+  padding: var(--space-xl) var(--space-lg);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.search-page__form {
+  margin-bottom: var(--space-lg);
+}
+
+.search-page__input {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: var(--text-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.search-page__results {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--color-surface);
+}

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2747,6 +2747,9 @@ body:not(:has(.comment-toolbar)) .web-push-banner {
 }
 
 .search-modal {
+  /* Layout for the open state. The user-agent stylesheet keeps
+     `[popover]:not(:popover-open)` hidden by default, but we override
+     `display` here, so re-establish the hidden default explicitly. */
   position: fixed;
   top: 10vh;
   left: 50%;
@@ -2761,8 +2764,15 @@ body:not(:has(.comment-toolbar)) .web-push-banner {
   color: var(--color-text);
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
   overflow: hidden;
-  display: flex;
   flex-direction: column;
+}
+
+.search-modal:not(:popover-open) {
+  display: none;
+}
+
+.search-modal:popover-open {
+  display: flex;
 }
 
 .search-modal::backdrop {

--- a/engine/app/controllers/coplan/search_controller.rb
+++ b/engine/app/controllers/coplan/search_controller.rb
@@ -8,13 +8,10 @@ module CoPlan
   # * `frame=results` query param — just the results list partial, used by
   #   the modal's Turbo Frame to swap in results as the user types.
   #
-  # Anonymous access is allowed — signed-out users see only published plans
-  # (this matches `Plan.search`'s visibility filter). Recent searches are
-  # only persisted for signed-in users.
+  # Sign-in required. Anonymous visitors get the usual redirect to the
+  # sign-in page — we don't want search leaking plan titles or content to
+  # unauthenticated callers.
   class SearchController < ApplicationController
-    skip_before_action :authenticate_coplan_user!
-    before_action :resolve_optional_coplan_user
-
     MAX_RESULTS = 20
 
     def index
@@ -28,11 +25,9 @@ module CoPlan
         []
       end
 
-      if @query.present? && current_user
-        SearchQuery.log!(user: current_user, query: @query)
-      end
+      SearchQuery.log!(user: current_user, query: @query) if @query.present?
 
-      @recent_queries = current_user ? SearchQuery.recent_for(current_user).pluck(:query) : []
+      @recent_queries = SearchQuery.recent_for(current_user).pluck(:query)
 
       if params[:frame] == "results"
         render partial: "coplan/search/results", layout: false, locals: {
@@ -41,12 +36,6 @@ module CoPlan
           recent_queries: @recent_queries
         }
       end
-    end
-
-    private
-
-    def resolve_optional_coplan_user
-      @current_coplan_user = CoPlan::Authentication.user_from_request(request)
     end
   end
 end

--- a/engine/app/controllers/coplan/search_controller.rb
+++ b/engine/app/controllers/coplan/search_controller.rb
@@ -25,7 +25,12 @@ module CoPlan
         []
       end
 
-      SearchQuery.log!(user: current_user, query: @query) if @query.present?
+      # Only persist explicit navigations as recent searches — not every
+      # typeahead `frame=results` request fired on each keystroke. Otherwise
+      # typing "roadmap" would log r, ro, roa, … and evict actual recents.
+      if @query.present? && params[:frame] != "results"
+        SearchQuery.log!(user: current_user, query: @query)
+      end
 
       @recent_queries = SearchQuery.recent_for(current_user).pluck(:query)
 

--- a/engine/app/controllers/coplan/search_controller.rb
+++ b/engine/app/controllers/coplan/search_controller.rb
@@ -1,0 +1,52 @@
+module CoPlan
+  # Sitewide search. Accessible from anywhere via the `/` keyboard shortcut or
+  # the header search bar.
+  #
+  # The endpoint serves two shapes:
+  # * `format=html` (default) — full search results page (used for direct
+  #   navigation, e.g. a bookmarked /search?q=foo).
+  # * `frame=results` query param — just the results list partial, used by
+  #   the modal's Turbo Frame to swap in results as the user types.
+  #
+  # Anonymous access is allowed — signed-out users see only published plans
+  # (this matches `Plan.search`'s visibility filter). Recent searches are
+  # only persisted for signed-in users.
+  class SearchController < ApplicationController
+    skip_before_action :authenticate_coplan_user!
+    before_action :resolve_optional_coplan_user
+
+    MAX_RESULTS = 20
+
+    def index
+      @query = params[:q].to_s.strip
+      @results = if @query.present?
+        Plan.search(@query, user: current_user)
+          .includes(:created_by_user, :tags)
+          .limit(MAX_RESULTS)
+          .to_a
+      else
+        []
+      end
+
+      if @query.present? && current_user
+        SearchQuery.log!(user: current_user, query: @query)
+      end
+
+      @recent_queries = current_user ? SearchQuery.recent_for(current_user).pluck(:query) : []
+
+      if params[:frame] == "results"
+        render partial: "coplan/search/results", layout: false, locals: {
+          query: @query,
+          results: @results,
+          recent_queries: @recent_queries
+        }
+      end
+    end
+
+    private
+
+    def resolve_optional_coplan_user
+      @current_coplan_user = CoPlan::Authentication.user_from_request(request)
+    end
+  end
+end

--- a/engine/app/javascript/controllers/coplan/search_controller.js
+++ b/engine/app/javascript/controllers/coplan/search_controller.js
@@ -1,0 +1,145 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Sitewide search modal controller.
+//
+// Responsibilities:
+//   1. Open the modal on "/" pressed anywhere outside an input/textarea/CE.
+//   2. Debounce input → swap the inner `<turbo-frame id="search-results">`
+//      by setting its `src` attribute, which triggers Turbo to fetch and
+//      replace the frame body.
+//   3. Arrow ↑/↓ moves the "selected" result; Enter activates it; Esc closes
+//      (Esc is also handled natively by `popover="auto"`).
+//
+// The modal element itself is `[popover="auto"]`; we open/close it via
+// element.showPopover() / hidePopover() — the browser handles the backdrop,
+// top-layer, and outside-click dismiss.
+export default class extends Controller {
+  static targets = ["input", "body"]
+  static values = {
+    url: String,
+    debounce: { type: Number, default: 150 }
+  }
+
+  connect() {
+    this._onGlobalKeydown = this._onGlobalKeydown.bind(this)
+    document.addEventListener("keydown", this._onGlobalKeydown)
+    this._selectedIndex = -1
+    this._debounceTimer = null
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this._onGlobalKeydown)
+    if (this._debounceTimer) clearTimeout(this._debounceTimer)
+  }
+
+  // Fires when the popover opens or closes (newState: "open" | "closed").
+  onToggle(event) {
+    if (event.newState === "open") {
+      // Focus the input and clear it so each open starts fresh.
+      requestAnimationFrame(() => {
+        this.inputTarget.focus()
+        this.inputTarget.select()
+      })
+    } else {
+      this._cancelDebounce()
+    }
+  }
+
+  // Debounced input handler — schedules a frame fetch.
+  onInput() {
+    this._cancelDebounce()
+    this._debounceTimer = setTimeout(() => this._fetchResults(), this.debounceValue)
+  }
+
+  // Keyboard nav within the input box.
+  onKeydown(event) {
+    const items = this._resultItems()
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this._moveSelection(1, items)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this._moveSelection(-1, items)
+        break
+      case "Enter":
+        if (this._selectedIndex >= 0 && items[this._selectedIndex]) {
+          event.preventDefault()
+          items[this._selectedIndex].click()
+        }
+        break
+    }
+  }
+
+  // Clicking a recent-search row pre-fills the input and triggers a search.
+  selectRecent(event) {
+    event.preventDefault()
+    const query = event.currentTarget.dataset.searchRecentQuery
+    this.inputTarget.value = query
+    this._cancelDebounce()
+    this._fetchResults()
+  }
+
+  // --- private ---
+
+  _onGlobalKeydown(event) {
+    if (event.key !== "/") return
+    if (event.metaKey || event.ctrlKey || event.altKey) return
+    const t = event.target
+    if (!t) return
+    const tag = t.tagName
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || t.isContentEditable) return
+    event.preventDefault()
+    this.element.showPopover()
+  }
+
+  _cancelDebounce() {
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer)
+      this._debounceTimer = null
+    }
+  }
+
+  _fetchResults() {
+    const query = this.inputTarget.value.trim()
+    const frame = this.bodyTarget.querySelector("turbo-frame#search-results")
+    if (!frame) return
+    const url = new URL(this.urlValue, window.location.origin)
+    url.searchParams.set("q", query)
+    url.searchParams.set("frame", "results")
+    frame.src = url.toString()
+    // Reset selection — the frame is about to be replaced.
+    this._selectedIndex = -1
+    frame.addEventListener("turbo:frame-load", () => this._afterFrameLoad(), { once: true })
+  }
+
+  _afterFrameLoad() {
+    const items = this._resultItems()
+    if (items.length > 0) {
+      this._selectedIndex = 0
+      this._applySelection(items)
+    }
+  }
+
+  _resultItems() {
+    return Array.from(this.bodyTarget.querySelectorAll("[data-search-result]"))
+  }
+
+  _moveSelection(delta, items) {
+    if (items.length === 0) return
+    this._selectedIndex = (this._selectedIndex + delta + items.length) % items.length
+    this._applySelection(items)
+  }
+
+  _applySelection(items) {
+    items.forEach((el, i) => {
+      const selected = i === this._selectedIndex
+      el.classList.toggle("search-modal__result--selected", selected)
+      el.setAttribute("aria-selected", selected ? "true" : "false")
+      if (selected) {
+        el.scrollIntoView({ block: "nearest" })
+      }
+    })
+  }
+}

--- a/engine/app/models/coplan/plan.rb
+++ b/engine/app/models/coplan/plan.rb
@@ -33,19 +33,13 @@ module CoPlan
     # natural-language threshold on small datasets.
     #
     # Visibility: brainstorm plans are hidden from everyone except their
-    # author (signed-out users see only published plans). This matches the
-    # `index` action's filter.
-    scope :search, ->(query, user: nil) {
+    # author — matches the `index` action's filter. `user` is required;
+    # the controller enforces sign-in so we don't have to handle nil here.
+    scope :search, ->(query, user:) {
       term = sanitize_fulltext_term(query)
       return none if term.blank?
 
-      visible = if user
-        where.not(status: "brainstorm").or(where(created_by_user_id: user.id))
-      else
-        where.not(status: "brainstorm")
-      end
-
-      visible
+      where.not(status: "brainstorm").or(where(created_by_user_id: user.id))
         .where("MATCH(search_text) AGAINST (? IN BOOLEAN MODE)", term)
         .order(Arel.sql("MATCH(search_text) AGAINST (#{connection.quote(term)} IN BOOLEAN MODE) DESC"))
     }

--- a/engine/app/models/coplan/plan.rb
+++ b/engine/app/models/coplan/plan.rb
@@ -25,6 +25,71 @@ module CoPlan
 
     scope :with_tag, ->(name) { joins(:tags).where(coplan_tags: { name: name }) }
 
+    after_save_commit :refresh_search_text!, if: :search_text_needs_refresh?
+
+    # Sitewide search over a denormalized `search_text` column maintained by
+    # `refresh_search_text!`. Uses MySQL FULLTEXT in BOOLEAN mode so we can
+    # support prefix matches (`foo*`) and don't trip MySQL's 50%-of-rows
+    # natural-language threshold on small datasets.
+    #
+    # Visibility: brainstorm plans are hidden from everyone except their
+    # author (signed-out users see only published plans). This matches the
+    # `index` action's filter.
+    scope :search, ->(query, user: nil) {
+      term = sanitize_fulltext_term(query)
+      return none if term.blank?
+
+      visible = if user
+        where.not(status: "brainstorm").or(where(created_by_user_id: user.id))
+      else
+        where.not(status: "brainstorm")
+      end
+
+      visible
+        .where("MATCH(search_text) AGAINST (? IN BOOLEAN MODE)", term)
+        .order(Arel.sql("MATCH(search_text) AGAINST (#{connection.quote(term)} IN BOOLEAN MODE) DESC"))
+    }
+
+    def self.sanitize_fulltext_term(query)
+      # FULLTEXT BOOLEAN-mode operators we strip so user input can't break the
+      # query: + - > < ( ) ~ * " @ and stray backslashes. After stripping we
+      # split on whitespace, drop empty tokens, and append `*` to each so
+      # typing "foo bar" matches "foobar baz" mid-stream — important for the
+      # search-as-you-type UX.
+      cleaned = query.to_s.gsub(/[+\-><()~*"@\\]/, " ")
+      tokens = cleaned.split(/\s+/).reject(&:blank?)
+      tokens.map { |t| "#{t}*" }.join(" ")
+    end
+
+    # Recomputes the denormalized `search_text` column from the plan's title,
+    # author name, tag names, and stripped current content. Called from the
+    # after-commit hook above and from the backfill migration.
+    def refresh_search_text!
+      new_text = self.class.build_search_text(self)
+      return if new_text == search_text
+      update_columns(search_text: new_text)
+    end
+
+    # Builds the denormalized search text for a plan. Exposed as a class
+    # method so the backfill migration can call it without instantiating
+    # callbacks.
+    #
+    # Uses `map(&:name)` rather than `pluck(:name)` so callers that preload
+    # `:tags` (e.g. the migration backfill) don't trigger an extra query per
+    # plan.
+    def self.build_search_text(plan)
+      parts = []
+      parts << plan.title.to_s
+      parts << plan.created_by_user&.name.to_s
+      parts << plan.tags.map(&:name).join(" ") if plan.persisted?
+      content = plan.current_plan_version&.content_markdown
+      if content.present?
+        stripped, _ = Plans::MarkdownTextExtractor.call(content)
+        parts << stripped
+      end
+      parts.reject(&:blank?).join(" ")
+    end
+
     def self.ransackable_attributes(auth_object = nil)
       %w[id title status plan_type_id created_by_user_id current_plan_version_id current_revision created_at updated_at]
     end
@@ -71,6 +136,15 @@ module CoPlan
       versions = plan_versions.includes(:actor_user).order(revision: :desc).to_a
       events = plan_events.includes(:actor_user).order(created_at: :desc).to_a
       (versions + events).sort_by { |item| -item.created_at.to_f }
+    end
+
+    private
+
+    # Refresh `search_text` when any of the inputs that feed into it have
+    # changed at the Plan level. Tag and PlanVersion changes call
+    # `refresh_search_text!` directly from their own callbacks.
+    def search_text_needs_refresh?
+      saved_change_to_title? || saved_change_to_current_plan_version_id? || saved_change_to_created_by_user_id?
     end
   end
 end

--- a/engine/app/models/coplan/plan_tag.rb
+++ b/engine/app/models/coplan/plan_tag.rb
@@ -5,12 +5,26 @@ module CoPlan
 
     validates :tag_id, uniqueness: { scope: :plan_id }
 
+    # Plan-level after_save_commit doesn't fire when tags change (the Plan row
+    # itself isn't dirty), so re-denormalize the parent's `search_text` here.
+    after_commit :refresh_plan_search_text, on: [:create, :destroy]
+
     def self.ransackable_attributes(auth_object = nil)
       %w[id plan_id tag_id created_at updated_at]
     end
 
     def self.ransackable_associations(auth_object = nil)
       %w[plan tag]
+    end
+
+    private
+
+    def refresh_plan_search_text
+      # When a Plan is destroyed, ActiveRecord cascades to PlanTag (via
+      # `dependent: :destroy`) and fires this hook. Skip the refresh in that
+      # case — the parent row is gone and `update_columns` would raise.
+      return if plan.nil? || plan.destroyed?
+      plan.refresh_search_text!
     end
   end
 end

--- a/engine/app/models/coplan/search_query.rb
+++ b/engine/app/models/coplan/search_query.rb
@@ -1,0 +1,45 @@
+module CoPlan
+  # A query a user typed into the sitewide search modal. Persisted so the
+  # modal can show a "Recent searches" list when the input is empty.
+  #
+  # We only ever store one row per (user, query) pair — repeating the same
+  # search bumps `created_at` on the existing row instead of growing the
+  # table. Reads are capped at `RECENT_LIMIT`.
+  class SearchQuery < ApplicationRecord
+    RECENT_LIMIT = 10
+
+    self.record_timestamps = false
+
+    belongs_to :user, class_name: "CoPlan::User"
+
+    validates :query, presence: true, length: { maximum: 255 }
+
+    scope :recent_for, ->(user) {
+      where(user: user).order(created_at: :desc).limit(RECENT_LIMIT)
+    }
+
+    def self.log!(user:, query:)
+      return if user.blank?
+      query = query.to_s.strip
+      return if query.blank? || query.length > 255
+
+      existing = where(user: user, query: query).first
+      row = if existing
+        existing.update_column(:created_at, Time.current)
+        existing
+      else
+        create!(user: user, query: query, created_at: Time.current)
+      end
+
+      prune_for(user)
+      row
+    end
+
+    # Keep at most `RECENT_LIMIT` rows per user so search-as-you-type doesn't
+    # grow the table without bound. Cheap because `recent_for` is indexed.
+    def self.prune_for(user)
+      keep_ids = recent_for(user).pluck(:id)
+      where(user: user).where.not(id: keep_ids).delete_all
+    end
+  end
+end

--- a/engine/app/models/coplan/tag.rb
+++ b/engine/app/models/coplan/tag.rb
@@ -5,12 +5,25 @@ module CoPlan
 
     validates :name, presence: true, uniqueness: true
 
+    # Tag names are baked into each plan's denormalized `search_text` (for
+    # FULLTEXT search). When a tag is renamed via ActiveAdmin, every
+    # associated plan still carries the old name in its index and won't
+    # match the new one until something else touches the plan. Re-denormalize
+    # every linked plan whenever `name` changes.
+    after_update_commit :refresh_search_text_for_plans, if: :saved_change_to_name?
+
     def self.ransackable_attributes(auth_object = nil)
       %w[id name plans_count created_at updated_at]
     end
 
     def self.ransackable_associations(auth_object = nil)
       %w[plan_tags plans]
+    end
+
+    private
+
+    def refresh_search_text_for_plans
+      plans.find_each(&:refresh_search_text!)
     end
   end
 end

--- a/engine/app/views/coplan/search/_modal.html.erb
+++ b/engine/app/views/coplan/search/_modal.html.erb
@@ -30,10 +30,12 @@
     <kbd class="search-modal__hint">Esc</kbd>
   </form>
   <div class="search-modal__body" data-coplan--search-target="body">
+    <%# Modal is only rendered for signed-in users (see layout), so the
+        recent-searches lookup here is always safe. %>
     <%= render partial: "coplan/search/results", locals: {
       query: "",
       results: [],
-      recent_queries: signed_in? ? CoPlan::SearchQuery.recent_for(current_user).pluck(:query) : []
+      recent_queries: CoPlan::SearchQuery.recent_for(current_user).pluck(:query)
     } %>
   </div>
 </div>

--- a/engine/app/views/coplan/search/_modal.html.erb
+++ b/engine/app/views/coplan/search/_modal.html.erb
@@ -1,0 +1,39 @@
+<%# Sitewide search modal, rendered once per page in the global layout.
+    Opens via:
+      * Click on the header bar ("Search plans…")
+      * The `/` keyboard shortcut from anywhere outside an input
+
+    Built on the native HTML Popover API (`popover="auto"`) to match the
+    convention used by comment thread popovers — see AGENTS.md. The browser
+    handles backdrop, top-layer rendering, and light-dismiss/Esc-to-close;
+    the Stimulus controller (`coplan--search`) handles input debouncing,
+    keyboard navigation, and `/` shortcut wiring. %>
+<div id="search-modal"
+     popover="auto"
+     class="search-modal"
+     data-controller="coplan--search"
+     data-coplan--search-url-value="<%= coplan.search_path %>"
+     data-coplan--search-debounce-value="150"
+     data-action="toggle->coplan--search#onToggle">
+  <%# Wrapped in a <form> so that hitting Enter before the JS debounce/Turbo
+      response lands still navigates the user to the full /search page (a
+      reliable fallback). The Stimulus controller intercepts Enter when a
+      result is selected and clicks the link instead. %>
+  <form action="<%= coplan.search_path %>" method="get" class="search-modal__header">
+    <input type="search"
+           name="q"
+           class="search-modal__input"
+           placeholder="Search plans…"
+           autocomplete="off"
+           data-coplan--search-target="input"
+           data-action="input->coplan--search#onInput keydown->coplan--search#onKeydown">
+    <kbd class="search-modal__hint">Esc</kbd>
+  </form>
+  <div class="search-modal__body" data-coplan--search-target="body">
+    <%= render partial: "coplan/search/results", locals: {
+      query: "",
+      results: [],
+      recent_queries: signed_in? ? CoPlan::SearchQuery.recent_for(current_user).pluck(:query) : []
+    } %>
+  </div>
+</div>

--- a/engine/app/views/coplan/search/_results.html.erb
+++ b/engine/app/views/coplan/search/_results.html.erb
@@ -8,7 +8,11 @@
     The keyboard-nav Stimulus controller (`coplan--search`) looks for
     `[data-search-result]` items; keep that hook intact when changing markup. %>
 <% frame_id = local_assigns.fetch(:frame_id, "search-results") %>
-<turbo-frame id="<%= frame_id %>">
+<%# `target="_top"` so clicks on result anchors inside this frame navigate
+    the whole page rather than trying to load the plan page into the frame
+    (which would render "Content missing" since no matching frame exists
+    on the target page). %>
+<turbo-frame id="<%= frame_id %>" target="_top">
   <% if query.blank? %>
     <% if recent_queries.any? %>
       <div class="search-modal__section-label">Recent searches</div>

--- a/engine/app/views/coplan/search/_results.html.erb
+++ b/engine/app/views/coplan/search/_results.html.erb
@@ -1,0 +1,60 @@
+<%# Renders the contents of the search results region. Used by:
+    * The search modal — body of `<turbo-frame id="search-results">` that
+      gets re-fetched as the user types.
+    * The full-page /search route — wraps its own frame with a different
+      ID (`search-page-results`) so the layout-rendered modal frame can
+      coexist with the page frame without colliding.
+
+    The keyboard-nav Stimulus controller (`coplan--search`) looks for
+    `[data-search-result]` items; keep that hook intact when changing markup. %>
+<% frame_id = local_assigns.fetch(:frame_id, "search-results") %>
+<turbo-frame id="<%= frame_id %>">
+  <% if query.blank? %>
+    <% if recent_queries.any? %>
+      <div class="search-modal__section-label">Recent searches</div>
+      <ul class="search-modal__list" role="listbox">
+        <% recent_queries.each_with_index do |q, i| %>
+          <li>
+            <a href="<%= coplan.search_path(q: q) %>"
+               class="search-modal__result"
+               data-search-result
+               data-search-recent-query="<%= q %>"
+               data-action="click->coplan--search#selectRecent"
+               role="option"
+               tabindex="-1">
+              <span class="search-modal__result-title"><%= q %></span>
+              <span class="search-modal__result-meta">recent</span>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="search-modal__empty">Type to search plans.</div>
+    <% end %>
+  <% elsif results.empty? %>
+    <div class="search-modal__empty">No plans match “<%= query %>”.</div>
+  <% else %>
+    <ul class="search-modal__list" role="listbox">
+      <% results.each do |plan| %>
+        <li>
+          <a href="<%= coplan.plan_path(plan) %>"
+             class="search-modal__result"
+             data-search-result
+             role="option"
+             tabindex="-1">
+            <span class="search-modal__result-title"><%= plan.title %></span>
+            <span class="search-modal__result-meta">
+              <span class="status-filter--<%= plan.status %> search-modal__status"><%= plan.status %></span>
+              <% if plan.created_by_user %>
+                · <%= plan.created_by_user.name %>
+              <% end %>
+              <% if plan.tags.any? %>
+                · <%= plan.tags.map(&:name).first(3).join(", ") %>
+              <% end %>
+            </span>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</turbo-frame>

--- a/engine/app/views/coplan/search/index.html.erb
+++ b/engine/app/views/coplan/search/index.html.erb
@@ -1,0 +1,22 @@
+<%# Full-page search results, used when /search?q=... is navigated to directly
+    (bookmark, link, or modal-closed-while-typing). The modal fetches the
+    `frame=results` variant instead. %>
+<% content_for :title, @query.present? ? "Search: #{@query}" : "Search" %>
+
+<div class="page-header">
+  <h1>Search</h1>
+</div>
+
+<form action="<%= coplan.search_path %>" method="get" class="search-page__form">
+  <input type="search" name="q" value="<%= @query %>" placeholder="Search plans…" autofocus class="search-page__input">
+</form>
+
+<div class="search-page__results">
+  <%# Distinct frame_id avoids colliding with the layout-rendered modal frame. %>
+  <%= render partial: "coplan/search/results", locals: {
+    query: @query,
+    results: @results,
+    recent_queries: @recent_queries,
+    frame_id: "search-page-results"
+  } %>
+</div>

--- a/engine/app/views/layouts/coplan/application.html.erb
+++ b/engine/app/views/layouts/coplan/application.html.erb
@@ -26,15 +26,15 @@
           CoPlan
           <%= coplan_environment_badge %>
         <% end %>
-        <button type="button"
-                class="site-nav__search"
-                aria-label="Search plans"
-                popovertarget="search-modal">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-          <span class="site-nav__search-label">Search plans…</span>
-          <kbd class="site-nav__search-kbd">/</kbd>
-        </button>
         <% if signed_in? %>
+          <button type="button"
+                  class="site-nav__search"
+                  aria-label="Search plans"
+                  popovertarget="search-modal">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+            <span class="site-nav__search-label">Search plans…</span>
+            <kbd class="site-nav__search-kbd">/</kbd>
+          </button>
           <div class="site-nav__right">
             <%= link_to coplan.settings_root_path, class: "site-nav__icon-link", aria: { label: "Settings" } do %>
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
@@ -75,6 +75,8 @@
       <%= yield %>
     </main>
     <%= render "coplan/shared/web_push_banner" %>
-    <%= render "coplan/search/modal" %>
+    <% if signed_in? %>
+      <%= render "coplan/search/modal" %>
+    <% end %>
   </body>
 </html>

--- a/engine/app/views/layouts/coplan/application.html.erb
+++ b/engine/app/views/layouts/coplan/application.html.erb
@@ -26,6 +26,14 @@
           CoPlan
           <%= coplan_environment_badge %>
         <% end %>
+        <button type="button"
+                class="site-nav__search"
+                aria-label="Search plans"
+                popovertarget="search-modal">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          <span class="site-nav__search-label">Search plans…</span>
+          <kbd class="site-nav__search-kbd">/</kbd>
+        </button>
         <% if signed_in? %>
           <div class="site-nav__right">
             <%= link_to coplan.settings_root_path, class: "site-nav__icon-link", aria: { label: "Settings" } do %>
@@ -67,5 +75,6 @@
       <%= yield %>
     </main>
     <%= render "coplan/shared/web_push_banner" %>
+    <%= render "coplan/search/modal" %>
   </body>
 </html>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -84,5 +84,7 @@ CoPlan::Engine.routes.draw do
 
   get "welcome", to: "welcome#show", as: :welcome
 
+  get "search", to: "search#index", as: :search
+
   root "welcome#show"
 end

--- a/engine/db/migrate/20260601000000_add_search_to_coplan_plans.rb
+++ b/engine/db/migrate/20260601000000_add_search_to_coplan_plans.rb
@@ -1,0 +1,38 @@
+class AddSearchToCoplanPlans < ActiveRecord::Migration[8.1]
+  # Adds a denormalized `search_text` column on `coplan_plans` plus a MySQL
+  # FULLTEXT index. This is the one explicit MySQL-ism in the engine; see
+  # AGENTS.md ("Tech Stack & Philosophy"). The schema otherwise stays portable.
+  #
+  # The column is maintained by `Plan#refresh_search_text!`, called from
+  # after-commit hooks on Plan/PlanTag/PlanVersion. See engine/app/models/coplan/plan.rb.
+  def up
+    add_column :coplan_plans, :search_text, :mediumtext
+
+    # Backfill before adding the FULLTEXT index — FULLTEXT building is faster
+    # when the data is already in place, and we want existing plans searchable
+    # the moment the app reboots.
+    CoPlan::Plan.reset_column_information
+    CoPlan::Plan
+      .includes(:created_by_user, :tags, :current_plan_version)
+      .find_each do |plan|
+        plan.update_columns(search_text: CoPlan::Plan.build_search_text(plan))
+      end
+
+    if mysql?
+      execute "ALTER TABLE coplan_plans ADD FULLTEXT INDEX index_coplan_plans_on_search_text (search_text)"
+    end
+  end
+
+  def down
+    if mysql?
+      execute "ALTER TABLE coplan_plans DROP INDEX index_coplan_plans_on_search_text"
+    end
+    remove_column :coplan_plans, :search_text
+  end
+
+  private
+
+  def mysql?
+    connection.adapter_name.match?(/mysql/i)
+  end
+end

--- a/engine/db/migrate/20260601000001_create_coplan_search_queries.rb
+++ b/engine/db/migrate/20260601000001_create_coplan_search_queries.rb
@@ -1,0 +1,15 @@
+class CreateCoplanSearchQueries < ActiveRecord::Migration[8.1]
+  # Records the search queries each user runs, so the search modal can show a
+  # "Recent searches" list when the input is empty. We only persist queries for
+  # signed-in users; anonymous searches are not logged.
+  def change
+    create_table :coplan_search_queries, id: { type: :string, limit: 36 } do |t|
+      t.string :user_id, limit: 36, null: false
+      t.string :query, null: false, limit: 255
+      t.timestamp :created_at, null: false
+    end
+
+    add_index :coplan_search_queries, [:user_id, :created_at]
+    add_foreign_key :coplan_search_queries, :coplan_users, column: :user_id
+  end
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -139,12 +139,6 @@ RSpec.describe CoPlan::Plan, type: :model do
       expect(results).to include(brainstorm)
     end
 
-    it "hides all brainstorm plans from signed-out visitors" do
-      results = CoPlan::Plan.search("sitewide", user: nil).to_a
-      expect(results).to include(published, other_published)
-      expect(results).not_to include(brainstorm)
-    end
-
     it "returns no results for a blank query" do
       expect(CoPlan::Plan.search("", user: author).to_a).to eq([])
     end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe CoPlan::Plan, type: :model do
       expect(plan.reload.search_text).to include("infrastructure")
     end
 
+    it "refreshes every associated plan when a tag is renamed" do
+      tag = CoPlan::Tag.find_or_create_by!(name: "old-name")
+      plan = create(:plan, :considering)
+      plan.tags = [tag]
+      expect(plan.reload.search_text).to include("old-name")
+
+      tag.update!(name: "new-name")
+
+      expect(plan.reload.search_text).to include("new-name")
+      expect(plan.search_text).not_to include("old-name")
+    end
+
     it "does not crash when the PlanTag callback fires after the parent plan is destroyed" do
       # Simulates the after_commit on PlanTag running when its parent Plan
       # row is already gone — this happens during dependent: :destroy cascade.

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -32,4 +32,127 @@ RSpec.describe CoPlan::Plan, type: :model do
     plan = create(:plan)
     expect(plan.to_param).to eq(plan.id)
   end
+
+  describe "search_text denormalization (COPLAN-21)" do
+    it "is populated from title, author name, tag names, and stripped current content" do
+      author = create(:coplan_user, name: "Carmen Author")
+      plan = create(:plan,
+        :considering,
+        created_by_user: author,
+        title: "Quarterly Strategy Document")
+      plan.tags = [CoPlan::Tag.find_or_create_by!(name: "strategy")]
+      plan.reload
+
+      expect(plan.search_text).to include("Quarterly Strategy Document")
+      expect(plan.search_text).to include("Carmen Author")
+      expect(plan.search_text).to include("strategy")
+      expect(plan.search_text).to include("Plan Content")
+    end
+
+    it "refreshes when the title changes" do
+      plan = create(:plan, :considering, title: "Original Title")
+      plan.update!(title: "Renamed Plan")
+      expect(plan.reload.search_text).to include("Renamed Plan")
+      expect(plan.search_text).not_to include("Original Title")
+    end
+
+    it "refreshes when a tag is added" do
+      plan = create(:plan, :considering)
+      expect(plan.search_text).not_to include("infrastructure")
+      plan.tags = [CoPlan::Tag.find_or_create_by!(name: "infrastructure")]
+      expect(plan.reload.search_text).to include("infrastructure")
+    end
+
+    it "does not crash when the PlanTag callback fires after the parent plan is destroyed" do
+      # Simulates the after_commit on PlanTag running when its parent Plan
+      # row is already gone — this happens during dependent: :destroy cascade.
+      plan = create(:plan, :considering)
+      plan.tags = [CoPlan::Tag.find_or_create_by!(name: "platform")]
+      plan_tag = plan.plan_tags.first
+      allow(plan_tag).to receive(:plan).and_return(plan)
+      allow(plan).to receive(:destroyed?).and_return(true)
+      expect { plan_tag.send(:refresh_plan_search_text) }.not_to raise_error
+    end
+
+    it "refreshes when current_plan_version_id changes (new content version)" do
+      plan = create(:plan, :considering)
+      new_version = create(:plan_version,
+        plan: plan,
+        revision: plan.current_revision + 1,
+        content_markdown: "# Brand new content with marker_word_xyz",
+        actor_id: plan.created_by_user_id)
+      plan.update!(current_plan_version: new_version, current_revision: new_version.revision)
+      expect(plan.reload.search_text).to include("marker_word_xyz")
+    end
+  end
+
+  describe ".search (COPLAN-21)" do
+    # InnoDB FULLTEXT writes are not visible to MATCH … AGAINST inside the
+    # same transaction (the FTS index maintains its own visibility tracking).
+    # The transactional-fixture wrapping would hide every row we insert, so
+    # these examples manage cleanup manually.
+    self.use_transactional_tests = false
+
+    after do
+      ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 0")
+      %w[coplan_plan_tags coplan_tags coplan_plan_versions coplan_plans
+         coplan_search_queries coplan_users].each do |t|
+        ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{t}")
+      end
+      ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
+    end
+
+    let!(:author) { create(:coplan_user, name: "Tessa Engineer") }
+    let!(:other_author) { create(:coplan_user) }
+
+    let!(:published) do
+      create(:plan, :considering, created_by_user: author, title: "Sitewide Search Modal")
+    end
+
+    let!(:other_published) do
+      create(:plan, :considering, created_by_user: other_author, title: "Sitewide Reporting Dashboard")
+    end
+
+    let!(:brainstorm) do
+      create(:plan, :brainstorm, created_by_user: author, title: "Sitewide Brainstorm Notes")
+    end
+
+    it "matches whole words in the title" do
+      results = CoPlan::Plan.search("modal", user: author).to_a
+      expect(results).to include(published)
+      expect(results).not_to include(other_published)
+    end
+
+    it "supports prefix matching for search-as-you-type" do
+      results = CoPlan::Plan.search("repor", user: author).to_a
+      expect(results).to include(other_published)
+    end
+
+    it "hides brainstorm plans from other users" do
+      results = CoPlan::Plan.search("sitewide", user: other_author).to_a
+      expect(results).to include(published, other_published)
+      expect(results).not_to include(brainstorm)
+    end
+
+    it "includes the author's own brainstorm plans" do
+      results = CoPlan::Plan.search("sitewide", user: author).to_a
+      expect(results).to include(brainstorm)
+    end
+
+    it "hides all brainstorm plans from signed-out visitors" do
+      results = CoPlan::Plan.search("sitewide", user: nil).to_a
+      expect(results).to include(published, other_published)
+      expect(results).not_to include(brainstorm)
+    end
+
+    it "returns no results for a blank query" do
+      expect(CoPlan::Plan.search("", user: author).to_a).to eq([])
+    end
+
+    it "ignores FULLTEXT boolean operators in user input" do
+      expect {
+        CoPlan::Plan.search("+modal -reporting", user: author).to_a
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/search_query_spec.rb
+++ b/spec/models/search_query_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::SearchQuery, type: :model do
+  let(:user) { create(:coplan_user) }
+
+  describe ".log!" do
+    it "creates a row for a new query" do
+      expect {
+        described_class.log!(user: user, query: "auth")
+      }.to change { described_class.count }.by(1)
+    end
+
+    it "deduplicates by (user, query) and bumps created_at instead of growing" do
+      old = freeze_time do
+        Time.current.tap { described_class.log!(user: user, query: "auth") }
+      end
+
+      travel 5.minutes do
+        described_class.log!(user: user, query: "auth")
+      end
+
+      rows = described_class.where(user: user, query: "auth")
+      expect(rows.count).to eq(1)
+      expect(rows.first.created_at).to be > old
+    end
+
+    it "ignores blank or whitespace-only queries" do
+      expect {
+        described_class.log!(user: user, query: "   ")
+        described_class.log!(user: user, query: "")
+      }.not_to change { described_class.count }
+    end
+
+    it "ignores logging when user is nil (signed-out searcher)" do
+      expect {
+        described_class.log!(user: nil, query: "auth")
+      }.not_to change { described_class.count }
+    end
+
+    it "ignores queries longer than 255 chars to avoid pathological inputs" do
+      expect {
+        described_class.log!(user: user, query: "x" * 256)
+      }.not_to change { described_class.count }
+    end
+  end
+
+  describe ".recent_for" do
+    it "returns the user's queries newest-first, capped at RECENT_LIMIT" do
+      (described_class::RECENT_LIMIT + 5).times do |i|
+        travel_to (i + 1).minutes.from_now do
+          described_class.log!(user: user, query: "q#{i}")
+        end
+      end
+
+      results = described_class.recent_for(user).pluck(:query)
+      expect(results.size).to eq(described_class::RECENT_LIMIT)
+      expect(results.first).to eq("q#{described_class::RECENT_LIMIT + 4}")
+    end
+
+    it "scopes by user" do
+      other_user = create(:coplan_user)
+      described_class.log!(user: user, query: "mine")
+      described_class.log!(user: other_user, query: "theirs")
+
+      expect(described_class.recent_for(user).pluck(:query)).to eq(["mine"])
+    end
+  end
+end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -39,13 +39,15 @@ RSpec.describe "Search (COPLAN-21)", type: :request do
         get search_path, params: { q: "roadmap" }
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Quarterly Sitewide Roadmap")
-        expect(response.body).to include("<turbo-frame id=\"search-results\">")
+        # Full-page route uses its own frame id to avoid colliding with the
+        # layout-rendered modal frame.
+        expect(response.body).to match(/<turbo-frame id="search-page-results"/)
       end
 
       it "returns only the results partial when frame=results" do
         get search_path, params: { q: "roadmap", frame: "results" }
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("<turbo-frame id=\"search-results\">")
+        expect(response.body).to match(/<turbo-frame id="search-results"/)
         expect(response.body).not_to include("<html") # layout suppressed
         expect(response.body).to include("Quarterly Sitewide Roadmap")
       end
@@ -74,14 +76,9 @@ RSpec.describe "Search (COPLAN-21)", type: :request do
     end
 
     context "signed-out" do
-      it "allows anonymous access" do
+      it "redirects anonymous visitors to sign-in instead of leaking plan data" do
         get search_path, params: { q: "roadmap" }
-        expect(response).to have_http_status(:ok)
-      end
-
-      it "returns only published plans (brainstorm hidden)" do
-        get search_path, params: { q: "brainstorm" }
-        expect(response.body).not_to include("Personal Brainstorm Memo")
+        expect(response).to redirect_to("/sign_in")
       end
 
       it "does not persist a SearchQuery row" do
@@ -93,14 +90,20 @@ RSpec.describe "Search (COPLAN-21)", type: :request do
   end
 
   describe "header search bar in the layout" do
-    it "is visible to signed-out users" do
+    it "is hidden from signed-out users" do
       get root_path
-      expect(response.body).to include('class="site-nav__search"')
-      expect(response.body).to include('popovertarget="search-modal"')
+      expect(response.body).not_to include('class="site-nav__search"')
+      expect(response.body).not_to include('id="search-modal"')
     end
 
-    it "renders the search modal in the layout once" do
+    it "is visible to signed-in users" do
+      sign_in_as(alice)
+      # `/` redirects signed-in users who already have plans (alice does);
+      # follow through to land on the actual plans index, which uses the
+      # same layout we want to verify.
       get root_path
+      follow_redirect! if response.redirect?
+      expect(response.body).to include('class="site-nav__search"')
       expect(response.body.scan('id="search-modal"').size).to eq(1)
     end
   end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -52,10 +52,20 @@ RSpec.describe "Search (COPLAN-21)", type: :request do
         expect(response.body).to include("Quarterly Sitewide Roadmap")
       end
 
-      it "logs the query to recent searches" do
+      it "logs explicit navigations to recent searches" do
         expect {
           get search_path, params: { q: "roadmap" }
         }.to change { CoPlan::SearchQuery.where(user: alice).count }.by(1)
+      end
+
+      it "does NOT log typeahead requests (frame=results) to recent searches" do
+        # Otherwise typing 'roadmap' would log r, ro, roa, … and evict the
+        # user's real recent searches.
+        expect {
+          get search_path, params: { q: "r",   frame: "results" }
+          get search_path, params: { q: "ro",  frame: "results" }
+          get search_path, params: { q: "roa", frame: "results" }
+        }.not_to change { CoPlan::SearchQuery.where(user: alice).count }
       end
 
       it "includes the signed-in user's own brainstorm plans in results" do

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe "Search (COPLAN-21)", type: :request do
+  # InnoDB FULLTEXT writes are invisible to MATCH … AGAINST inside the same
+  # transaction (the FTS index keeps its own visibility tracking). Run these
+  # request specs without transactional fixtures and TRUNCATE between examples
+  # so the FULLTEXT index actually picks up our seed rows.
+  self.use_transactional_tests = false
+
+  after do
+    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 0")
+    %w[coplan_plan_tags coplan_tags coplan_plan_versions coplan_plans
+       coplan_search_queries coplan_users].each do |t|
+      ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{t}")
+    end
+    ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
+  end
+
+  let!(:alice) { create(:coplan_user, name: "Alice Searcher") }
+  let!(:bob)   { create(:coplan_user, name: "Bob Other") }
+
+  let!(:alice_published) do
+    create(:plan, :considering, created_by_user: alice, title: "Quarterly Sitewide Roadmap")
+  end
+
+  let!(:bob_published) do
+    create(:plan, :considering, created_by_user: bob, title: "Search Infrastructure RFC")
+  end
+
+  let!(:alice_brainstorm) do
+    create(:plan, :brainstorm, created_by_user: alice, title: "Personal Brainstorm Memo")
+  end
+
+  describe "GET /search" do
+    context "signed-in" do
+      before { sign_in_as(alice) }
+
+      it "returns a full-page result list when no frame param is given" do
+        get search_path, params: { q: "roadmap" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Quarterly Sitewide Roadmap")
+        expect(response.body).to include("<turbo-frame id=\"search-results\">")
+      end
+
+      it "returns only the results partial when frame=results" do
+        get search_path, params: { q: "roadmap", frame: "results" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("<turbo-frame id=\"search-results\">")
+        expect(response.body).not_to include("<html") # layout suppressed
+        expect(response.body).to include("Quarterly Sitewide Roadmap")
+      end
+
+      it "logs the query to recent searches" do
+        expect {
+          get search_path, params: { q: "roadmap" }
+        }.to change { CoPlan::SearchQuery.where(user: alice).count }.by(1)
+      end
+
+      it "includes the signed-in user's own brainstorm plans in results" do
+        get search_path, params: { q: "brainstorm" }
+        expect(response.body).to include("Personal Brainstorm Memo")
+      end
+
+      it "renders 'no results' messaging when nothing matches" do
+        get search_path, params: { q: "noplanmatcheszzz" }
+        expect(response.body).to include("No plans match")
+      end
+
+      it "renders 'Type to search' when query is blank" do
+        get search_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Type to search")
+      end
+    end
+
+    context "signed-out" do
+      it "allows anonymous access" do
+        get search_path, params: { q: "roadmap" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns only published plans (brainstorm hidden)" do
+        get search_path, params: { q: "brainstorm" }
+        expect(response.body).not_to include("Personal Brainstorm Memo")
+      end
+
+      it "does not persist a SearchQuery row" do
+        expect {
+          get search_path, params: { q: "roadmap" }
+        }.not_to change { CoPlan::SearchQuery.count }
+      end
+    end
+  end
+
+  describe "header search bar in the layout" do
+    it "is visible to signed-out users" do
+      get root_path
+      expect(response.body).to include('class="site-nav__search"')
+      expect(response.body).to include('popovertarget="search-modal"')
+    end
+
+    it "renders the search modal in the layout once" do
+      get root_path
+      expect(response.body.scan('id="search-modal"').size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Closes [COPLAN-21](https://linear.app/squareup/issue/COPLAN-21).

## What

Fast \`/\`-keyboard-shortcut search across plan title, current content, tag names, and author name, with a header search bar as a visible entry point.

## How it works

- **Storage**: denormalized \`search_text mediumtext\` column on \`coplan_plans\` with a MySQL FULLTEXT index. Maintained by \`Plan#refresh_search_text!\`, fired from after-commit hooks on Plan/PlanTag (PlanVersion changes feed through the Plan via \`current_plan_version_id\` updates).
- **Search**: \`Plan.search(query, user:)\` scope using \`MATCH … AGAINST (… IN BOOLEAN MODE)\` with a trailing \`*\` per token so search-as-you-type matches partial words. User input is sanitized of FULLTEXT operators.
- **Visibility**: brainstorm plans are visible only to their author; signed-out visitors see only published plans. Same rule as the plans index.
- **Recent searches**: new \`coplan_search_queries\` table, deduped on \`(user, query)\`, capped at 10 per user via \`SearchQuery.prune_for\`.
- **UI**: native HTML Popover API (\`popover=\"auto\"\`) modal rendered once in the layout, opened by the header bar (\`popovertarget=\"search-modal\"\`) or by pressing \`/\` anywhere outside an input. Inside the modal, a Turbo Frame swaps results as the user types (150ms debounce). Arrow keys / Enter / Esc all work.
- **Anonymous access**: \`SearchController\` skips the engine's auth requirement and uses the same optional-user pattern as the welcome page. Recent searches are only logged for signed-in users.

## Constraint adherence

MySQL only (per AGENTS.md). The FULLTEXT index is the only explicit MySQL-ism — wrapped in an adapter check in the migration so the schema would still load on a non-MySQL adapter (the FULLTEXT lines would just be skipped).

## Test plan

- 901 specs pass (\`bundle exec rspec\`).
- New specs cover: \`search_text\` denormalization on title/tag/version change, \`Plan.search\` visibility and prefix matching, \`SearchQuery\` dedup + pruning + signed-out skipping, request flow for both signed-in and anonymous, header bar visible to everyone.
- FULLTEXT visibility specs opt out of transactional fixtures (InnoDB FTS index doesn't see same-transaction writes and `TRUNCATE` for cleanup.

## Out of scope

- AI-summarized snippets / highlight matching (just shows status + author + tags meta).
- Per-field weighted ranking (using FULLTEXT relevance only).
- Background reindexing job — synchronous in-callback is fine at hundreds-of-plans scale.
EOF
)