### PR TITLE
Require openai in coplan.rb so OpenAI constant is loaded

### DIFF
--- a/engine/lib/coplan.rb
+++ b/engine/lib/coplan.rb
@@ -1,5 +1,6 @@
 require "commonmarker"
 require "diffy"
+require "openai"
 require "coplan/configuration"
 require "coplan/analytics"
 require "coplan/engine"


### PR DESCRIPTION
## Problem

The freshly bumped `coplan-engine` is crashing in coplan-square production with:

```
NameError: uninitialized constant CoPlan::AiProviders::OpenAi::OpenAI
        client = OpenAI::Client.new(access_token: api_key)
```

triggered by `SummarizePlanJob` (the new AI summary feature from #118).

## Root cause

`ruby-openai` is declared as a dependency in [engine/coplan.gemspec](engine/coplan.gemspec) (`spec.add_dependency "ruby-openai"`), which installs the gem but does **not** auto-require it. Host apps using `Bundler.require` only auto-require gems listed directly in their own Gemfile — transitive gemspec deps must be required explicitly by the consuming gem.

In dev, this often works by accident (other code paths or dev gems can pull `openai` in), but in coplan-square production the constant is never loaded, so the first `OpenAI::Client.new` call blows up.

## Fix

Add `require "openai"` to [engine/lib/coplan.rb](engine/lib/coplan.rb) alongside the other top-level requires (`commonmarker`, `diffy`).

## Validation

- `bundle exec rspec spec/services/ai_spec.rb spec/jobs/summarize_plan_job_spec.rb` ✅ (15 examples, 0 failures)

Once this merges I'll re-bump coplan-square to pick it up.