### PR TITLE
Require ruby-openai in engine entry point (COPLAN-24 hotfix)

### DIFF
--- a/engine/lib/coplan.rb
+++ b/engine/lib/coplan.rb
@@ -1,5 +1,6 @@
 require "commonmarker"
 require "diffy"
+require "openai"
 require "coplan/configuration"
 require "coplan/analytics"
 require "coplan/engine"


### PR DESCRIPTION
Hotfix for COPLAN-24.

## What broke

Downstream hosts that consume `coplan-engine` as a gem (e.g. coplan-square) hit:

```
NameError: uninitialized constant CoPlan::AiProviders::OpenAi::OpenAI
  in app/services/coplan/ai_providers/open_ai.rb:15
     `client = OpenAI::Client.new(...)`
```

The engine's [coplan.gemspec](engine/coplan.gemspec) declares `ruby-openai` as a runtime dep, but [engine/lib/coplan.rb](engine/lib/coplan.rb) never `require`d it. The local test suite passed because the host Gemfile in this repo *also* lists `gem "ruby-openai"`, which masked the missing require.

## Fix

Add `require "openai"` to the engine entry point alongside the existing `require "commonmarker"` and `require "diffy"`, so the engine self-loads its declared dependencies.

## Follow-up

Should add a smoke test that boots the engine in isolation (without the host Gemfile) to catch this class of bug — tracking separately.

🤖 Drafted with [Amp](https://ampcode.com).

Co-authored-by: Amp <amp@ampcode.com>
