### PR TITLE
Pin brainstorms first in My Plans ordering (COPLAN-32)

### DIFF
--- a/engine/app/models/coplan/plan.rb
+++ b/engine/app/models/coplan/plan.rb
@@ -2,9 +2,12 @@ module CoPlan
   class Plan < ApplicationRecord
     STATUSES = %w[brainstorm considering developing live abandoned].freeze
 
-    # Order used when grouping "My Plans" on the index: active work first,
-    # brainstorms next, abandoned last.
-    STATUS_PRIORITY = %w[developing live considering brainstorm abandoned].freeze
+    # Order used when grouping "My Plans" on the index: brainstorms first
+    # (private drafts, most relevant to the author), then active work by
+    # maturity, abandoned last. Pinning brainstorm to the top keeps the
+    # author's own brainstorms on page 1 instead of buried past the
+    # PER_PAGE pagination cut (see COPLAN-32).
+    STATUS_PRIORITY = %w[brainstorm considering developing live abandoned].freeze
 
     # Order plans by STATUS_PRIORITY, then most-recently-updated within each group.
     scope :prioritized_by_status, -> {

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -177,9 +177,20 @@ RSpec.describe "Plans", type: :request do
       create(:plan, :brainstorm,  created_by_user: alice, title: "Brainstorm Plan")
       get plans_path
       expect(response.body).to include("plans-list__section")
-      # active work appears before brainstorm
-      expect(response.body.index("Developing Plan")).to be < response.body.index("Brainstorm Plan")
-      expect(response.body.index("Considering Plan")).to be < response.body.index("Brainstorm Plan")
+      # brainstorms are pinned first (COPLAN-32), then active work by maturity
+      expect(response.body.index("Brainstorm Plan")).to be < response.body.index("Considering Plan")
+      expect(response.body.index("Considering Plan")).to be < response.body.index("Developing Plan")
+    end
+
+    # COPLAN-32: with more active plans than fit on the first page, the
+    # author's own brainstorms must still land on page 1 of the default
+    # Mine/Any-status view rather than being buried past the pagination cut.
+    it "surfaces the author's own brainstorms on page 1 despite many active plans" do
+      brainstorm = create(:plan, :brainstorm, created_by_user: alice, title: "Buried Brainstorm")
+      create_list(:plan, CoPlan::PlansController::PER_PAGE + 5, :developing, created_by_user: alice)
+      get plans_path
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(brainstorm.title)
     end
 
     it "does not group when filtered to a single status" do


### PR DESCRIPTION
## Summary

Fixes [COPLAN-32](https://linear.app/squareup/issue/COPLAN-32): an author's own **brainstorm** plans were buried under the default **Mine / Any status** view on the plans index.

This is **not** a visibility/query bug — the query returns the author's brainstorms correctly. It's an ordering + pagination problem:

- `Plan::STATUS_PRIORITY` ranked `brainstorm` **4th** (`developing live considering brainstorm abandoned`).
- The index paginates at `PER_PAGE = 20` (Turbo Frame infinite scroll).

So an author with many active plans saw all `developing`/`live`/`considering` plans first, pushing brainstorms past page 1. Verified against the dev DB for `hampton`: **212 plans, 7 brainstorms — the first brainstorm sat at position 205 (page 11)**. The only way to find them was to explicitly select the Brainstorm status filter.

## Fix

Reorder `STATUS_PRIORITY` to **`brainstorm → considering → developing → live → abandoned`**. Brainstorms are private, author-only drafts (and few in number), so pinning them to the top of the grouped Mine view keeps them on page 1 regardless of how many active plans exist. Confirmed the new order with Hampton.

```diff
-STATUS_PRIORITY = %w[developing live considering brainstorm abandoned].freeze
+STATUS_PRIORITY = %w[brainstorm considering developing live abandoned].freeze
```

Non-authors are unaffected — brainstorms remain filtered out for everyone but the author (existing behavior, unchanged).

## Acceptance

- ✅ Landing on the default Mine / Any status view, an author sees their own brainstorms on page 1 without manually selecting the Brainstorm filter.
- ✅ Brainstorms remain hidden from non-authors.

## Testing

- Updated the "groups My Plans by status" spec for the new ordering.
- Added a spec asserting an author's brainstorm appears on page 1 even with more than `PER_PAGE` active plans.
- `bundle exec rspec` — **894 examples, 0 failures**.
- `code-review` skill — clean (only low-severity "no fix needed" nits).
