### PR TITLE
Fix Comment#first_comment_in_thread? UUID string comparison (COPLAN-30)

### DIFF
--- a/engine/app/models/coplan/comment.rb
+++ b/engine/app/models/coplan/comment.rb
@@ -34,7 +34,10 @@ module CoPlan
     private
 
     def first_comment_in_thread?
-      !comment_thread.comments.where("id < ?", id).exists?
+      # IDs are random UUIDs, not insertion-ordered, so we can't compare them
+      # with `id < ?`. after_create_commit guarantees the row is persisted, so
+      # a total count of 1 reliably means this comment opened the thread.
+      comment_thread.comments.count == 1
     end
 
     def notify_plan_author
@@ -42,13 +45,6 @@ module CoPlan
     end
 
     def track_comment_created
-      # NOTE: We deliberately don't reuse `first_comment_in_thread?` here —
-      # that helper compares UUIDs with `id < ?`, which is not insertion-
-      # ordered. After-create-commit guarantees the row is persisted, so a
-      # total count of 1 is the reliable signal for "this comment opened
-      # the thread."
-      is_first = comment_thread.comments.count == 1
-
       CoPlan::Analytics.track(
         "comment_created",
         user: author,
@@ -56,7 +52,7 @@ module CoPlan
         comment_thread_id: comment_thread_id,
         comment_id: id,
         author_type: author_type,
-        is_first_in_thread: is_first,
+        is_first_in_thread: first_comment_in_thread?,
         body_length: body_markdown.to_s.length
       )
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -40,5 +40,20 @@ RSpec.describe CoPlan::Comment, type: :model do
         create(:comment, comment_thread: thread_record)
       }.not_to have_enqueued_job(CoPlan::NotificationJob)
     end
+
+    # Regression for COPLAN-30: `first_comment_in_thread?` used to compare
+    # UUIDs with `id < ?`, which is not insertion-ordered. A reply whose UUID
+    # sorts before the opener's was wrongly treated as the thread opener,
+    # firing a duplicate "new comment thread" notification for the plan author.
+    it "does not enqueue NotificationJob for a reply whose UUID sorts before the opener" do
+      high_id = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+      low_id  = "00000000-0000-0000-0000-000000000001"
+
+      create(:comment, comment_thread: thread_record, id: high_id)
+
+      expect {
+        create(:comment, comment_thread: thread_record, id: low_id)
+      }.not_to have_enqueued_job(CoPlan::NotificationJob)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes [COPLAN-30](https://linear.app/squareup/issue/COPLAN-30). `CoPlan::Comment#first_comment_in_thread?` compared random UUIDs with `id < ?`, a string comparison. A reply whose UUID happened to sort below the thread opener's was wrongly treated as the opener, which gated `after_create_commit :notify_plan_author` and sent the plan author a **duplicate "new comment thread" notification** for a reply.

## Fix

Swap the UUID comparison for `comment_thread.comments.count == 1`. `after_create_commit` fires after the row is persisted, so a total count of 1 reliably means this comment opened the thread. This is the same workaround `track_comment_created` already used — that method now reuses the fixed helper instead of duplicating the count logic.

## Testing

- Added a regression spec creating an opener with a high-sorting UUID and a reply with a low-sorting UUID, asserting `NotificationJob` does **not** enqueue for the reply. Verified it fails against the old `id < ?` implementation.
- `bundle exec rspec` — 895 examples, 0 failures.
