### PR TITLE
Docs: clarify migrations almost always belong in the engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,14 @@ Most of the application logic lives in the **CoPlan Rails engine** (`engine/`), 
 - **Policies** — authorization policies in `engine/app/policies/coplan/`
 - **Jobs** — background jobs in `engine/app/jobs/coplan/`
 - **Views, helpers, assets, JS** — all Hotwire views and Stimulus controllers
-- **Migrations** — engine-owned tables go in `engine/db/migrate/`
+- **Migrations** — engine-owned tables go in `engine/db/migrate/`. Data/backfill migrations supporting engine behavior also belong here (the gem only packages `engine/`, so host-only migrations don't reach gem consumers); copy them into the host with `bin/rails co_plan:install:migrations`.
 - **Routes** — engine routes in `engine/config/routes.rb`, mounted by the host
 
 ### Host app (top-level) — thin deployment shell
 - **ActiveAdmin** — admin registrations in `app/admin/`
 - **Auth** — `SessionsController`, `User` model (legacy, being migrated to `CoPlan::User`)
 - **App-specific integrations** — `SlackClient`, `SlackNotificationJob`
-- **Migrations** — only for data migrations, FK rewiring, or host-specific tables in `db/migrate/` (the engine owns schema for `coplan_*` tables)
+- **Migrations** — this app is just the example/demo host, so `db/migrate/` mostly holds the `*.co_plan.rb` copies of engine migrations (the engine owns schema for `coplan_*` tables)
 - **Config** — database, deployment, environment, seeds
 
 **When adding new features, put them in the engine** unless they are deployment- or host-specific (admin UI, external integrations, auth).


### PR DESCRIPTION
## Summary

Clarify in `AGENTS.md` that **almost all migrations belong in the engine** (`engine/db/migrate/`), not just schema changes to `coplan_*` tables but also data/backfill migrations that support engine behavior.

## Why

The `coplan` gem only packages files under `engine/`. A migration placed in the host app's `db/migrate/` is never shipped to external gem consumers, so they receive an engine code change **without** the migration it depends on. This bit us in #128: a backfill supporting an engine `Comment#author` change was initially placed in the host app, which would have left external consumers' data unmigrated.

## Change

- Engine section: migrations (schema **and** data/backfill that support engine behavior) go in `engine/db/migrate/`, then are copied into the host via `bin/rails co_plan:install:migrations`.
- Host section: `db/migrate/` holds the generated `*.co_plan.rb` copies plus the rare genuinely host-only table.

Docs-only change. Relates to COPLAN-33.
