### PR TITLE
Restrict comment thread actions by viewer role

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1762,6 +1762,22 @@ img.avatar {
   border-top: 1px solid var(--color-border);
 }
 
+/* Viewer-specific thread actions.
+   Broadcasts re-render thread partials for every subscriber with no
+   current_user, so these are rendered unconditionally and hidden by default.
+   The coplan--viewer-role controller tags each thread with the viewer's role
+   (.viewer-is-plan-author / .viewer-is-thread-author) to reveal them. */
+.comment-actions--plan-author,
+.comment-actions--owner {
+  display: none;
+}
+
+.viewer-is-plan-author .comment-actions--plan-author,
+.viewer-is-plan-author .comment-actions--owner,
+.viewer-is-thread-author .comment-actions--owner {
+  display: flex;
+}
+
 /* Ensure content doesn't get hidden behind fixed toolbar */
 body:has(.comment-toolbar) .main-content {
   padding-bottom: 3.5rem;

--- a/engine/app/javascript/controllers/coplan/viewer_role_controller.js
+++ b/engine/app/javascript/controllers/coplan/viewer_role_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Gates viewer-specific thread actions (Accept/Discard/Reopen) on the client.
+//
+// Turbo Stream broadcasts re-render thread partials for *every* subscriber with
+// no server-side current_user, so the server can't decide which viewer-specific
+// actions to show. Those actions are therefore rendered unconditionally and
+// hidden by default via CSS; this controller compares the viewer's id (known on
+// the client) against each thread's author / plan-author ids and reveals only
+// the actions the viewer is actually allowed to take.
+export default class extends Controller {
+  static values = { viewerId: String }
+
+  connect() {
+    this.apply()
+    // Reapply when threads are appended or replaced by a broadcast.
+    this._observer = new MutationObserver(() => this.apply())
+    this._observer.observe(this.element, { childList: true })
+  }
+
+  disconnect() {
+    if (this._observer) {
+      this._observer.disconnect()
+      this._observer = null
+    }
+  }
+
+  apply() {
+    const viewerId = this.viewerIdValue
+    this.element.querySelectorAll("[data-plan-author-id]").forEach((thread) => {
+      const isPlanAuthor = viewerId !== "" && thread.dataset.planAuthorId === viewerId
+      const isThreadAuthor = viewerId !== "" && thread.dataset.threadAuthorId === viewerId
+      thread.classList.toggle("viewer-is-plan-author", isPlanAuthor)
+      thread.classList.toggle("viewer-is-thread-author", isThreadAuthor)
+    })
+  }
+}

--- a/engine/app/views/coplan/comment_threads/_thread.html.erb
+++ b/engine/app/views/coplan/comment_threads/_thread.html.erb
@@ -2,7 +2,9 @@
      data-anchor-text="<%= thread.anchor_text %>"
      data-anchor-context="<%= thread.anchor_context %>"
      data-anchor-occurrence="<%= thread.anchor_occurrence_index %>"
-     data-thread-id="<%= thread.id %>">
+     data-thread-id="<%= thread.id %>"
+     data-plan-author-id="<%= plan.created_by_user_id %>"
+     data-thread-author-id="<%= thread.created_by_user_id %>">
   <div class="comment-thread__header">
     <div class="comment-thread__meta">
       <span class="badge badge--<%= thread.open? ? 'live' : 'abandoned' %>"><%= thread.status %></span>
@@ -21,25 +23,20 @@
     <% end %>
   </div>
 
-  <%# current_user may not be available during Turbo Stream broadcasts — show all actions in that case %>
-  <% viewer = local_assigns.fetch(:current_user, nil) %>
-  <% is_plan_author = viewer.nil? || plan.created_by_user_id == viewer.id %>
-  <% is_thread_author = viewer.nil? || thread.created_by_user_id == viewer.id %>
-
+  <%# Action visibility is gated client-side by coplan--viewer-role: broadcasts
+      re-render this partial for every subscriber with no current_user, so the
+      server can't decide who may act. The buttons are always rendered and the
+      viewer's role (plan author / thread author) reveals them via CSS. %>
   <% if thread.open? %>
     <%= render partial: "coplan/comment_threads/reply_form", locals: { thread: thread, plan: plan } %>
 
-    <div class="comment-thread__actions">
-      <% if is_plan_author %>
-        <%= link_to "Accept", accept_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
-        <%= link_to "Discard", discard_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
-      <% end %>
+    <div class="comment-thread__actions comment-actions--plan-author">
+      <%= link_to "Accept", accept_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
+      <%= link_to "Discard", discard_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
     </div>
   <% else %>
-    <% if is_plan_author || is_thread_author %>
-      <div class="comment-thread__actions">
-        <%= link_to "Reopen", reopen_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
-      </div>
-    <% end %>
+    <div class="comment-thread__actions comment-actions--owner">
+      <%= link_to "Reopen", reopen_plan_comment_thread_path(plan, thread), data: { turbo_method: :patch }, class: "btn btn--secondary btn--sm" %>
+    </div>
   <% end %>
 </div>

--- a/engine/app/views/coplan/comment_threads/_thread_popover.html.erb
+++ b/engine/app/views/coplan/comment_threads/_thread_popover.html.erb
@@ -3,7 +3,9 @@
      data-anchor-text="<%= thread.anchor_text %>"
      data-anchor-occurrence="<%= thread.anchor_occurrence_index %>"
      data-thread-id="<%= thread.id %>"
-     data-thread-status="<%= thread.status %>">
+     data-thread-status="<%= thread.status %>"
+     data-plan-author-id="<%= plan.created_by_user_id %>"
+     data-thread-author-id="<%= thread.created_by_user_id %>">
 
   <div popover="auto" id="<%= dom_id(thread) %>_popover" class="thread-popover">
     <div class="thread-popover__header">
@@ -23,11 +25,10 @@
       <% end %>
     </div>
 
-    <%# current_user may not be available during Turbo Stream broadcasts %>
-    <% viewer = local_assigns.fetch(:current_user, nil) %>
-    <% is_plan_author = viewer.nil? || plan.created_by_user_id == viewer&.id %>
-    <% is_thread_author = viewer.nil? || thread.created_by_user_id == viewer&.id %>
-
+    <%# Action visibility is gated client-side by coplan--viewer-role: broadcasts
+        re-render this partial for every subscriber with no current_user, so the
+        server can't decide who may act. The buttons are always rendered and the
+        viewer's role (plan author / thread author) reveals them via CSS. %>
     <% if thread.open? %>
       <div class="thread-popover__reply">
         <%= form_with url: plan_comment_thread_comments_path(plan, thread), method: :post, data: { action: "turbo:submit-end->coplan--text-selection#resetReplyForm" } do |f| %>
@@ -39,20 +40,16 @@
         <% end %>
       </div>
 
-      <div class="thread-popover__actions">
-        <% if is_plan_author %>
-          <% if thread.status == "pending" %>
-            <%= button_to "Accept (a)", accept_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm", form: { "data-action-name": "accept" } %>
-          <% end %>
-          <%= button_to "Discard (d)", discard_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm", form: { "data-action-name": "discard" } %>
+      <div class="thread-popover__actions comment-actions--plan-author">
+        <% if thread.status == "pending" %>
+          <%= button_to "Accept (a)", accept_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm", form: { "data-action-name": "accept" } %>
         <% end %>
+        <%= button_to "Discard (d)", discard_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm", form: { "data-action-name": "discard" } %>
       </div>
     <% else %>
-      <% if is_plan_author || is_thread_author %>
-        <div class="thread-popover__actions">
-          <%= button_to "Reopen", reopen_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm" %>
-        </div>
-      <% end %>
+      <div class="thread-popover__actions comment-actions--owner">
+        <%= button_to "Reopen", reopen_plan_comment_thread_path(plan, thread), method: :patch, class: "btn btn--secondary btn--sm" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -51,9 +51,11 @@
           <%= render partial: "coplan/comment_threads/new_comment_form", locals: { plan: @plan } %>
         </div>
 
-        <div id="plan-threads" data-coplan--text-selection-target="threads">
+        <div id="plan-threads" data-coplan--text-selection-target="threads"
+             data-controller="coplan--viewer-role"
+             data-coplan--viewer-role-viewer-id-value="<%= current_user&.id %>">
           <% @threads.select(&:anchored?).each do |thread| %>
-            <%= render partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan, current_user: current_user } %>
+            <%= render partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan } %>
           <% end %>
         </div>
       </div>

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -171,6 +171,56 @@ RSpec.describe "Comment UX", type: :system do
     end
   end
 
+  describe "thread popovers as a non-author" do
+    before { sign_in(reviewer) }
+
+    it "does not show Accept/Discard to someone who isn't the plan author" do
+      # The reviewer authored this comment but does not own the plan, so they
+      # must not see the author-only triage actions.
+      create_anchored_thread(plan: plan, anchor_text: "microservices architecture", body: "Feedback", user: reviewer)
+      visit plan_path(plan)
+      find("mark.anchor-highlight--open").click
+
+      within(".thread-popover") do
+        expect(page).to have_css("textarea[placeholder='Press r to reply']")
+        expect(page).to have_no_button("Accept (a)")
+        expect(page).to have_no_button("Discard (d)")
+      end
+    end
+
+    it "shows Reopen on a closed thread to the thread author" do
+      # The reviewer authored this thread, so they may reopen it even though
+      # they don't own the plan.
+      thread = create_anchored_thread(plan: plan, anchor_text: "PostgreSQL", body: "Consider MySQL", user: reviewer)
+      thread.discard!(author)
+      visit plan_path(plan)
+      check "Show resolved"
+      find("mark.anchor-highlight--resolved").click
+
+      within(".thread-popover") do
+        expect(page).to have_button("Reopen")
+      end
+    end
+  end
+
+  describe "thread popovers as an uninvolved viewer" do
+    let(:bystander) { create(:coplan_user, email: "bystander@example.com") }
+
+    before { sign_in(bystander) }
+
+    it "does not show Reopen on a closed thread the viewer neither owns nor authored" do
+      thread = create_anchored_thread(plan: plan, anchor_text: "PostgreSQL", body: "Consider MySQL", user: reviewer)
+      thread.discard!(author)
+      visit plan_path(plan)
+      check "Show resolved"
+      find("mark.anchor-highlight--resolved").click
+
+      within(".thread-popover") do
+        expect(page).to have_no_button("Reopen")
+      end
+    end
+  end
+
   describe "comment toolbar" do
     before { sign_in(author) }
 


### PR DESCRIPTION
## Summary

When a user creates a comment they are able to see buttons they shouldn't have access to, this is because turbo stream broadcasts without current_user context. 

Closes [COPLAN-34](https://linear.app/squareup/issue/COPLAN-34/restrict-comment-thread-actions-to-authorized-viewers).

## Decisions

- **Client-side visibility, server-side authorization** — broadcasts cannot safely personalize partials, so controls are hidden by default and revealed by viewer role; controller policies still enforce the real authorization boundary.
- **Plan author owns triage** — only the plan author sees Accept/Discard.
- **Plan author or thread author can reopen** — matches `CommentThreadPolicy#reopen?` and lets reviewers reopen their own closed feedback.
- **No refresh requirement after broadcasts** — role classes are reapplied when thread data is appended or replaced.

## Changes

- Adds `coplan--viewer-role`, a Stimulus controller that tags rendered thread data as plan-author and/or thread-author for the current viewer.
- Adds plan-author and thread-author IDs to thread partial data attributes.
- Hides lifecycle action groups by default and reveals them via viewer role classes.
- Wires `#plan-threads` to the new viewer-role controller with the current viewer ID.
- Adds system specs covering non-author, thread-author, and uninvolved viewer popover behavior.

## Images
### Before
<img width="1680" height="1678" alt="image" src="https://github.com/user-attachments/assets/2f113db6-2d68-47fb-bca1-bdb34f03d9e8" />

### After
<img width="1128" height="795" alt="image" src="https://github.com/user-attachments/assets/9bf41275-7375-4b0a-b6a9-556b81711f11" />


## Testing

- `bundle exec rspec spec/system/comment_ux_spec.rb` — **39 examples, 0 failures**.