### PR TITLE
Fix ActionCable request fallback

### DIFF
--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -40,7 +40,7 @@ module CoPlan
     def resolve_current_user
       return connection.current_user if connection.respond_to?(:current_user) && connection.current_user
 
-      CoPlan::Authentication.user_from_request(connection.request)
+      CoPlan::Authentication.user_from_request(connection.__send__(:request))
     end
 
     def broadcast_viewers

--- a/spec/channels/coplan/plan_presence_channel_spec.rb
+++ b/spec/channels/coplan/plan_presence_channel_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe CoPlan::PlanPresenceChannel, type: :channel do
       expect(CoPlan::PlanViewer.where(plan: plan, user: websocket_user)).to exist
     end
 
+    it "authenticates through the engine callback when ActionCable keeps the request private" do
+      request = ActionDispatch::Request.empty
+      private_request_connection = Class.new do
+        def initialize(request)
+          @request = request
+        end
+
+        private
+
+        attr_reader :request
+      end.new(request)
+      channel = described_class.allocate
+      allow(channel).to receive(:connection).and_return(private_request_connection)
+      allow(CoPlan.configuration).to receive(:authenticate).and_return(
+        ->(received_request) { { external_id: "private-request-user", name: received_request.object_id.to_s } }
+      )
+
+      websocket_user = channel.send(:resolve_current_user)
+
+      expect(websocket_user.external_id).to eq("private-request-user")
+      expect(websocket_user.name).to eq(request.object_id.to_s)
+    end
+
     it "rejects when plan does not exist" do
       subscribe(plan_id: "nonexistent")
       expect(subscription).to be_rejected


### PR DESCRIPTION
## Why
CoPlan production is reporting repeated ActionCable subscription failures from the plan presence channel because Rails exposes the connection request as a private method.

## What
- Use the ActionCable request fallback through `__send__` when no connection `current_user` is available
- Add a channel spec covering connections whose request method is private

## Risk Assessment
Low — scoped to the presence-channel authentication fallback; existing connections with `current_user` are unchanged.

## References
- Slack/Sentry thread: https://sq-block.slack.com/archives/C0AHFE5N8SU/p1781644558959319?thread_ts=1779823325.283449&cid=C0AHFE5N8SU
- Validation: `bundle exec rspec spec/channels/coplan/plan_presence_channel_spec.rb`

Generated with Amp