### PR TITLE
fix(checkbox-toggle): Make checkbox line numbers come from the markdown parser

### DIFF
--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -132,7 +132,7 @@ module CoPlan
         return
       end
 
-      checkbox_pattern = /\A\s*[*+-]\s+\[[ xX]\]\s/
+      checkbox_pattern = MarkdownHelper::TASK_LINE_PATTERN
       unless old_text.match?(checkbox_pattern) && new_text.match?(checkbox_pattern)
         render json: { error: "old_text and new_text must be task list items" }, status: :unprocessable_content
         return

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -138,6 +138,17 @@ module CoPlan
         return
       end
 
+      # Optional source line number scoping the replacement to a single-line
+      # box, so identical task lines elsewhere in the document can't collide.
+      line = nil
+      if params[:line].present?
+        line = Integer(params[:line], exception: false)
+        if line.nil? || line < 1
+          render json: { error: "line must be a positive integer" }, status: :unprocessable_content
+          return
+        end
+      end
+
       ActiveRecord::Base.transaction do
         @plan.lock!
         @plan.reload
@@ -148,9 +159,11 @@ module CoPlan
         end
 
         current_content = @plan.current_content || ""
+        operation = { "op" => "replace_exact", "old_text" => old_text, "new_text" => new_text }
+        operation["lines"] = line if line
         result = Plans::ApplyOperations.call(
           content: current_content,
-          operations: [{ "op" => "replace_exact", "old_text" => old_text, "new_text" => new_text }]
+          operations: [operation]
         )
 
         new_revision = @plan.current_revision + 1

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -14,7 +14,13 @@ module CoPlan
       details summary
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class href src alt title type checked disabled data-line data-line-text data-action data-coplan--checkbox-target data-mention-username].freeze
+    ALLOWED_ATTRIBUTES = %w[id class href src alt title type checked disabled data-line data-line-text data-action data-coplan--checkbox-target data-mention-username data-sourcepos].freeze
+
+    # A source line the toggle endpoint will accept as a task item. Must stay
+    # in sync with what Commonmarker's tasklist extension can toggle: a
+    # checkbox is only wired up when its source line matches, so the client
+    # never offers a toggle the server would reject or mis-target.
+    TASK_LINE_PATTERN = /\A\s*[*+-]\s+\[[ xX]\]\s/
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -23,7 +29,11 @@ module CoPlan
     MENTION_PATTERN = /\[@([\w.-]+)\]\(mention:\1\)/
 
     def render_markdown(content, interactive: true)
-      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { render: { unsafe: true } }, plugins: { syntax_highlighter: nil })
+      render_options = { unsafe: true }
+      # Sourcepos is only needed to wire checkboxes to their source lines;
+      # make_checkboxes_interactive strips it from the final output.
+      render_options[:sourcepos] = true if interactive
+      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { render: render_options }, plugins: { syntax_highlighter: nil })
       with_chips = transform_mention_anchors(html)
       sanitized = sanitize(with_chips, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
@@ -70,16 +80,24 @@ module CoPlan
 
     private
 
+    # Wires rendered task checkboxes to their source lines via Commonmarker's
+    # sourcepos metadata, so the parser that decides what renders as a
+    # checkbox is also the authority on which line it came from. A checkbox
+    # only becomes interactive when its own source line matches
+    # TASK_LINE_PATTERN — constructs Commonmarker renders but the toggle
+    # endpoint won't accept (ordered-list or blockquoted tasks) stay disabled
+    # rather than being paired with some other line's text.
     def make_checkboxes_interactive(html, content)
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
-      checkboxes = doc.css('input[type="checkbox"]')
-      return html if checkboxes.empty?
+      source_lines = content.to_s.each_line.map(&:rstrip)
 
-      task_lines = extract_task_lines(content)
+      doc.css('input[type="checkbox"]').each do |cb|
+        li = cb.ancestors("li").first
+        line_number = sourcepos_start_line(li)
+        next unless line_number
 
-      checkboxes.each_with_index do |cb, i|
-        line_number, line_text = task_lines[i]
-        next unless line_text
+        line_text = source_lines[line_number - 1]
+        next unless line_text&.match?(TASK_LINE_PATTERN)
 
         cb.remove_attribute("disabled")
         cb["data-action"] = "coplan--checkbox#toggle"
@@ -87,8 +105,6 @@ module CoPlan
         cb["data-line-text"] = line_text
         cb["data-line"] = line_number.to_s
 
-        li = cb.parent
-        next unless li&.name == "li"
         li.add_class("task-list-item")
 
         # Wrap li contents in a <label> so the whole text is clickable
@@ -100,25 +116,18 @@ module CoPlan
         ul.add_class("task-list") if ul&.name == "ul"
       end
 
+      doc.css("[data-sourcepos]").each { |el| el.remove_attribute("data-sourcepos") }
       doc.to_html
     end
 
-    # Returns [1-based line number, rstripped line text] pairs for each task
-    # line, in document order. Fenced lines are counted (so numbering stays
-    # accurate) but never treated as task lines.
-    def extract_task_lines(content)
-      lines = []
-      in_fence = false
-      content.to_s.each_line.with_index(1) do |line, line_number|
-        stripped = line.rstrip
-        if stripped.match?(/\A(`{3,}|~{3,})/)
-          in_fence = !in_fence
-          next
-        end
-        next if in_fence
-        lines << [line_number, stripped] if stripped.match?(/^\s*[*+-]\s+\[[ xX]\]\s/)
-      end
-      lines
+    # Extracts the 1-based start line from an li's data-sourcepos
+    # ("3:1-4:0" -> 3).
+    def sourcepos_start_line(li)
+      raw = li&.[]("data-sourcepos")
+      return nil if raw.nil?
+
+      line = raw.split(":").first.to_i
+      line >= 1 ? line : nil
     end
   end
 end

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -14,7 +14,7 @@ module CoPlan
       details summary
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class href src alt title type checked disabled data-line-text data-action data-coplan--checkbox-target data-mention-username].freeze
+    ALLOWED_ATTRIBUTES = %w[id class href src alt title type checked disabled data-line data-line-text data-action data-coplan--checkbox-target data-mention-username].freeze
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -78,13 +78,14 @@ module CoPlan
       task_lines = extract_task_lines(content)
 
       checkboxes.each_with_index do |cb, i|
-        line_text = task_lines[i]
+        line_number, line_text = task_lines[i]
         next unless line_text
 
         cb.remove_attribute("disabled")
         cb["data-action"] = "coplan--checkbox#toggle"
         cb["data-coplan--checkbox-target"] = "checkbox"
         cb["data-line-text"] = line_text
+        cb["data-line"] = line_number.to_s
 
         li = cb.parent
         next unless li&.name == "li"
@@ -102,17 +103,20 @@ module CoPlan
       doc.to_html
     end
 
+    # Returns [1-based line number, rstripped line text] pairs for each task
+    # line, in document order. Fenced lines are counted (so numbering stays
+    # accurate) but never treated as task lines.
     def extract_task_lines(content)
       lines = []
       in_fence = false
-      content.to_s.each_line do |line|
+      content.to_s.each_line.with_index(1) do |line, line_number|
         stripped = line.rstrip
         if stripped.match?(/\A(`{3,}|~{3,})/)
           in_fence = !in_fence
           next
         end
         next if in_fence
-        lines << stripped if stripped.match?(/^\s*[*+-]\s+\[[ xX]\]\s/)
+        lines << [line_number, stripped] if stripped.match?(/^\s*[*+-]\s+\[[ xX]\]\s/)
       end
       lines
     end

--- a/engine/app/javascript/controllers/coplan/checkbox_controller.js
+++ b/engine/app/javascript/controllers/coplan/checkbox_controller.js
@@ -16,14 +16,17 @@ export default class extends Controller {
       ? lineText.replace(/([*+-]\s+)\[[ ]\]/, "$1[x]")
       : lineText.replace(/([*+-]\s+)\[[xX]\]/, "$1[ ]")
 
+    // Source line number disambiguates duplicate task-line text server-side.
+    const line = parseInt(checkbox.dataset.line, 10)
+
     // Optimistic UI: update immediately
     checkbox.dataset.lineText = newText
 
     this.inflight = true
-    this.#sendToggle({ checkbox, oldText, newText, nowChecked, retried: false })
+    this.#sendToggle({ checkbox, oldText, newText, line, nowChecked, retried: false })
   }
 
-  #sendToggle({ checkbox, oldText, newText, nowChecked, retried }) {
+  #sendToggle({ checkbox, oldText, newText, line, nowChecked, retried }) {
     const token = document.querySelector('meta[name="csrf-token"]')?.content
 
     fetch(this.toggleUrlValue, {
@@ -36,7 +39,8 @@ export default class extends Controller {
       body: JSON.stringify({
         old_text: oldText,
         new_text: newText,
-        base_revision: this.revisionValue
+        base_revision: this.revisionValue,
+        ...(Number.isInteger(line) && line >= 1 ? { line } : {})
       })
     }).then(response => {
       if (response.ok) {
@@ -50,7 +54,7 @@ export default class extends Controller {
           if (data.current_revision) {
             this.revisionValue = data.current_revision
           }
-          this.#sendToggle({ checkbox, oldText, newText, nowChecked, retried: true })
+          this.#sendToggle({ checkbox, oldText, newText, line, nowChecked, retried: true })
         })
       } else {
         this.#revert(checkbox, oldText, nowChecked)

--- a/engine/app/services/coplan/plans/commit_session.rb
+++ b/engine/app/services/coplan/plans/commit_session.rb
@@ -65,6 +65,8 @@ module CoPlan
             rebased_ops = []
             @session.operations_json.each do |op_data|
               op_data = op_data.transform_keys(&:to_s)
+              # "lines" is intentionally absent: this fallback re-resolves against
+              # *current* content, where a base-revision line box would be wrong.
               semantic_keys = %w[op old_text new_text heading content needle occurrence replace_all count new_content include_heading]
               semantic_op = op_data.slice(*semantic_keys)
 

--- a/engine/app/services/coplan/plans/position_resolver.rb
+++ b/engine/app/services/coplan/plans/position_resolver.rb
@@ -38,10 +38,23 @@ module CoPlan
         occurrence = (@op["occurrence"] || 1).to_i
         raise OperationError, "replace_exact: occurrence must be >= 1, got #{occurrence}" if occurrence < 1
 
+        line_box = parse_line_box
+
         ranges = find_all_occurrences(old_text)
 
         if ranges.empty?
           raise OperationError, "replace_exact found 0 occurrences of the specified text"
+        end
+
+        if line_box
+          box = char_range_for_lines(*line_box)
+          total = ranges.length
+          # Only occurrences fully contained in the box survive; the
+          # occurrence/replace_all/count rules below then index within it.
+          ranges = ranges.select { |s, e| s >= box[0] && e <= box[1] }
+          if ranges.empty?
+            raise OperationError, "replace_exact found #{total} occurrence(s) of the text, but none within lines #{line_box[0]}..#{line_box[1]}"
+          end
         end
 
         if replace_all
@@ -106,6 +119,49 @@ module CoPlan
         ranges = [deletion_range_for(para, paragraphs)]
 
         Resolution.new(op: "delete_paragraph_containing", ranges: ranges)
+      end
+
+      # Optional "lines" qualifier: a 1-based inclusive line range ("boxed
+      # context") that scopes replace_exact matching. Accepts an Integer
+      # (single-line box) or a two-element [start, end] pair. Multi-line
+      # old_text is fine as long as the match fits inside the box.
+      def parse_line_box
+        raw = @op["lines"]
+        return nil if raw.nil?
+
+        bounds = raw.is_a?(Array) ? raw : [raw, raw]
+        unless bounds.length == 2 && bounds.all?(Integer)
+          raise OperationError, "replace_exact: 'lines' must be an integer line number or a [start, end] pair of integers"
+        end
+
+        start_line, end_line = bounds
+        if start_line < 1 || end_line < start_line
+          raise OperationError, "replace_exact: 'lines' must satisfy 1 <= start <= end, got #{start_line}..#{end_line}"
+        end
+
+        [start_line, end_line]
+      end
+
+      # Character range [start, end) covering the given 1-based inclusive
+      # line range, including the end line's terminator so a match may end
+      # at the end of that line.
+      def char_range_for_lines(start_line, end_line)
+        total = 0
+        box_start = nil
+        box_end = nil
+        pos = 0
+        @content.each_line do |line|
+          total += 1
+          box_start = pos if total == start_line
+          pos += line.length
+          box_end = pos if total == end_line
+        end
+
+        if box_start.nil? || box_end.nil?
+          raise OperationError, "replace_exact: lines #{start_line}..#{end_line} out of range (document has #{total} lines)"
+        end
+
+        [box_start, box_end]
       end
 
       def find_all_occurrences(text)

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -290,6 +290,22 @@ Find and replace exact text. Fails if text not found or count exceeded.
 }
 ```
 
+Optional `lines` qualifier: a 1-based inclusive line range scoping the match — an
+integer (single line) or a `[start, end]` pair. Use it to disambiguate text that
+appears more than once (only occurrences fully inside the range are considered;
+`occurrence`/`replace_all`/`count` then apply within it). Multi-line `old_text`
+is allowed as long as the match fits inside the range. Fails if the text isn't
+found within the range.
+
+```json
+{
+  "op": "replace_exact",
+  "old_text": "- [ ] Write tests",
+  "new_text": "- [x] Write tests",
+  "lines": 12
+}
+```
+
 ### insert_under_heading
 
 Insert content after a markdown heading. Fails if heading not found or ambiguous.

--- a/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
+++ b/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
@@ -131,5 +131,115 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       nested = doc.css('input[type="checkbox"]').find { |cb| cb["data-line-text"]&.include?("Nested") }
       expect(nested["data-line"]).to eq("2")
     end
+
+    it "strips sourcepos metadata from the rendered output" do
+      html = helper.render_markdown("# Heading\n\n- [ ] Task")
+      expect(html).not_to include("data-sourcepos")
+    end
+  end
+
+  describe "renderer/resolver agreement" do
+    def interactive_checkboxes(md)
+      doc = Nokogiri::HTML::DocumentFragment.parse(helper.render_markdown(md))
+      doc.css('input[type="checkbox"]').partition { |cb| cb["data-action"].present? }
+    end
+
+    # The invariant the toggle flow rests on: every interactive checkbox's
+    # data-line must point at the source line whose rstripped text equals its
+    # data-line-text, and the resolver must accept that (old_text, lines) pair.
+    def expect_agreement(md)
+      interactive, = interactive_checkboxes(md)
+      source_lines = md.each_line.map(&:rstrip)
+      interactive.each do |cb|
+        line = Integer(cb["data-line"])
+        expect(source_lines[line - 1]).to eq(cb["data-line-text"])
+        resolution = CoPlan::Plans::PositionResolver.call(
+          content: md,
+          operation: { "op" => "replace_exact", "old_text" => cb["data-line-text"],
+                       "new_text" => cb["data-line-text"], "lines" => line }
+        )
+        expect(resolution.ranges.length).to eq(1)
+      end
+      interactive
+    end
+
+    it "does not pair a checkbox with a task-looking line inside an indented fence" do
+      md = " ```\n- [ ] inside indented fence\n ```\n\n- [ ] real task"
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["5"])
+    end
+
+    it "does not treat a ~~~ line inside a backtick fence as a fence boundary" do
+      md = "```\n~~~\n- [ ] inside fence\n```\n\n- [ ] real task"
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["6"])
+    end
+
+    it "does not close a fence with fewer backticks than it was opened with" do
+      md = "````\n```\n- [ ] inside fence\n````\n\n- [ ] real task"
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["6"])
+    end
+
+    it "does not pair a checkbox with a task-looking line in a 4-space indented code block" do
+      md = "Some paragraph\n\n    - [ ] indented code task\n\n- [ ] real task"
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["5"])
+    end
+
+    it "does not pair a checkbox with a task-looking line inside an HTML block" do
+      md = "<div>\n- [ ] inside html block\n</div>\n\n- [ ] real task"
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["5"])
+    end
+
+    it "leaves ordered-list task checkboxes disabled instead of mis-pairing them" do
+      md = "1. [ ] ordered task\n\n- [ ] real task"
+      interactive, disabled = interactive_checkboxes(md)
+      expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["3"])
+      expect(disabled.length).to eq(1)
+      expect(disabled.first.has_attribute?("disabled")).to be(true)
+    end
+
+    it "leaves blockquoted task checkboxes disabled instead of mis-pairing them" do
+      md = "> - [ ] quoted task\n\n- [ ] real task"
+      interactive, disabled = interactive_checkboxes(md)
+      expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["3"])
+      expect(disabled.length).to eq(1)
+    end
+
+    it "leaves empty-text task checkboxes disabled" do
+      md = "- [ ] \n- [ ] real task"
+      interactive, = interactive_checkboxes(md)
+      expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(["2"])
+    end
+
+    it "keeps duplicate task lines correctly paired across a gauntlet of divergent constructs" do
+      md = <<~MD
+        # Tasks
+
+        ```
+        - [ ] TODO
+        ~~~
+        ```
+
+        1. [ ] ordered
+
+        > - [ ] quoted
+
+        - [ ] TODO
+        - [ ] TODO
+
+        <div>
+        - [ ] TODO
+        </div>
+      MD
+      interactive = expect_agreement(md)
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(%w[12 13])
+      expect(interactive.map { |cb| cb["data-line-text"] }.uniq).to eq(["- [ ] TODO"])
+    end
   end
 end

--- a/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
+++ b/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
@@ -96,4 +96,40 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(nested["data-line-text"]).to eq("  - [ ] Nested child")
     end
   end
+
+  describe "#render_markdown data-line attribute" do
+    it "sets data-line to the 1-based source line number" do
+      md = "# Heading\n\n- [ ] First\n- [x] Second"
+      html = helper.render_markdown(md)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      checkboxes = doc.css('input[type="checkbox"]')
+      expect(checkboxes.map { |cb| cb["data-line"] }).to eq(%w[3 4])
+    end
+
+    it "keeps line numbers accurate across fenced code blocks" do
+      md = "```\n- [ ] Fake checkbox\n```\n- [ ] Real checkbox"
+      html = helper.render_markdown(md)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      checkboxes = doc.css('input[type="checkbox"]')
+      expect(checkboxes.length).to eq(1)
+      expect(checkboxes[0]["data-line"]).to eq("4")
+    end
+
+    it "keeps line numbers accurate across multiple lists and duplicates" do
+      md = "- [ ] TODO\n\nSome text\n\n- [ ] TODO\n- [ ] Other"
+      html = helper.render_markdown(md)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      checkboxes = doc.css('input[type="checkbox"]')
+      expect(checkboxes.map { |cb| cb["data-line"] }).to eq(%w[1 5 6])
+      expect(checkboxes[0]["data-line-text"]).to eq(checkboxes[1]["data-line-text"])
+    end
+
+    it "numbers nested tasks by their own source lines" do
+      md = "- [ ] Parent\n  - [ ] Nested child"
+      html = helper.render_markdown(md)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      nested = doc.css('input[type="checkbox"]').find { |cb| cb["data-line-text"]&.include?("Nested") }
+      expect(nested["data-line"]).to eq("2")
+    end
+  end
 end

--- a/spec/requests/toggle_checkbox_spec.rb
+++ b/spec/requests/toggle_checkbox_spec.rb
@@ -111,4 +111,87 @@ RSpec.describe "Toggle Checkbox", type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "PATCH toggle_checkbox with duplicate task lines" do
+    before do
+      plan.current_plan_version.update!(
+        content_markdown: "# Tasks\n\n- [ ] TODO\n- [ ] TODO\n- [ ] Deploy to staging\n- [ ] Deploy"
+      )
+    end
+
+    it "toggles the checkbox on the given line, leaving its duplicate untouched" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 4
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      plan.reload
+      expect(plan.current_content).to eq("# Tasks\n\n- [ ] TODO\n- [x] TODO\n- [ ] Deploy to staging\n- [ ] Deploy")
+    end
+
+    it "toggles a line whose text is a prefix of another task line" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] Deploy",
+        new_text: "- [x] Deploy",
+        base_revision: plan.current_revision,
+        line: 6
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      plan.reload
+      expect(plan.current_content).to eq("# Tasks\n\n- [ ] TODO\n- [ ] TODO\n- [ ] Deploy to staging\n- [x] Deploy")
+    end
+
+    it "returns 422 when the text is not on the given line" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 5
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      plan.reload
+      expect(plan.current_content).not_to include("- [x] TODO")
+    end
+
+    it "returns 422 without a line param when duplicates exist (regression guard)" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns 422 for a non-integer line param" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: "abc"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body["error"]).to include("line must be a positive integer")
+    end
+
+    it "records the lines qualifier in the version's operations_json" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 3
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      op = plan.reload.current_plan_version.operations_json.first
+      expect(op["lines"]).to eq(3)
+      expect(op["resolved_range"]).to be_present
+    end
+  end
 end

--- a/spec/services/plans/apply_operations_spec.rb
+++ b/spec/services/plans/apply_operations_spec.rb
@@ -45,6 +45,30 @@ RSpec.describe CoPlan::Plans::ApplyOperations do
         )
       }.to raise_error(CoPlan::Plans::OperationError, /requires 'old_text'/)
     end
+
+    it "scopes replacement with a lines qualifier and records it in applied data" do
+      content = "- [ ] TODO\n- [ ] TODO\n- [ ] Other"
+      result = CoPlan::Plans::ApplyOperations.call(
+        content: content,
+        operations: [{ "op" => "replace_exact", "old_text" => "- [ ] TODO", "new_text" => "- [x] TODO", "lines" => 2 }]
+      )
+      expect(result[:content]).to eq("- [ ] TODO\n- [x] TODO\n- [ ] Other")
+
+      applied = result[:applied].first
+      expect(applied["lines"]).to eq(2)
+      expect(applied["resolved_range"]).to eq([11, 21])
+      expect(applied["new_range"]).to eq([11, 21])
+      expect(applied["delta"]).to eq(0)
+    end
+
+    it "replaces multi-line old_text within a [start, end] lines box" do
+      content = "intro\nalpha\nbeta\nalpha\nbeta"
+      result = CoPlan::Plans::ApplyOperations.call(
+        content: content,
+        operations: [{ "op" => "replace_exact", "old_text" => "alpha\nbeta", "new_text" => "gamma", "lines" => [4, 5] }]
+      )
+      expect(result[:content]).to eq("intro\nalpha\nbeta\ngamma")
+    end
   end
 
   describe "insert_under_heading" do

--- a/spec/services/plans/position_resolver_spec.rb
+++ b/spec/services/plans/position_resolver_spec.rb
@@ -209,6 +209,126 @@ RSpec.describe CoPlan::Plans::PositionResolver do
         expect(content[result.ranges.first[0]...result.ranges.first[1]]).to eq("world")
       end
     end
+
+    describe "lines qualifier" do
+      let(:content) { "# Tasks\n- [ ] TODO\nsome text\n- [ ] TODO\n- [ ] Deploy to staging\n- [ ] Deploy" }
+
+      describe "single-line box disambiguates duplicate lines" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: 4 } }
+
+        it "resolves only the occurrence on that line" do
+          result = resolve
+          expect(result.ranges.length).to eq(1)
+          range = result.ranges.first
+          expect(range[0]).to eq(content.index("some text\n- [ ] TODO") + "some text\n".length)
+          expect(content[range[0]...range[1]]).to eq("- [ ] TODO")
+        end
+      end
+
+      describe "prefix collision" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] Deploy", new_text: "- [x] Deploy", lines: 6 } }
+
+        it "resolves the standalone line, not the longer line containing the prefix" do
+          result = resolve
+          expect(result.ranges.length).to eq(1)
+          expect(result.ranges.first[0]).to eq(content.rindex("- [ ] Deploy"))
+        end
+      end
+
+      describe "match on last line without trailing newline" do
+        let(:content) { "- [ ] TODO\n- [ ] TODO" }
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: 2 } }
+
+        it "resolves the last-line occurrence" do
+          result = resolve
+          expect(result.ranges.first).to eq([11, 21])
+        end
+      end
+
+      describe "text exists globally but not within the box" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: 3 } }
+
+        it "raises with the global count and box" do
+          expect { resolve }.to raise_error(CoPlan::Plans::OperationError, /found 2 occurrence\(s\) of the text, but none within lines 3\.\.3/)
+        end
+      end
+
+      describe "multi-line old_text within a multi-line box" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO\nsome text", new_text: "replaced", lines: [2, 3] } }
+
+        it "resolves the multi-line match" do
+          result = resolve
+          range = result.ranges.first
+          expect(content[range[0]...range[1]]).to eq("- [ ] TODO\nsome text")
+        end
+      end
+
+      describe "old_text straddling the box boundary" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO\nsome text", new_text: "replaced", lines: [2, 2] } }
+
+        it "is filtered out and raises" do
+          expect { resolve }.to raise_error(CoPlan::Plans::OperationError, /none within lines 2\.\.2/)
+        end
+      end
+
+      describe "composes with occurrence" do
+        let(:content) { "foo foo\nfoo foo foo\nfoo" }
+        let(:operation) { { op: "replace_exact", old_text: "foo", new_text: "bar", lines: 2, occurrence: 2 } }
+
+        it "indexes occurrences within the box" do
+          result = resolve
+          expect(result.ranges.first).to eq([12, 15])
+        end
+      end
+
+      describe "composes with replace_all" do
+        let(:content) { "foo foo\nfoo foo foo\nfoo" }
+        let(:operation) { { op: "replace_exact", old_text: "foo", new_text: "bar", lines: [2, 2], replace_all: true } }
+
+        it "replaces only in-box occurrences" do
+          result = resolve
+          expect(result.ranges).to eq([[8, 11], [12, 15], [16, 19]])
+        end
+      end
+
+      describe "still ambiguous within the box" do
+        let(:content) { "foo foo\nbar" }
+        let(:operation) { { op: "replace_exact", old_text: "foo", new_text: "baz", lines: 1 } }
+
+        it "raises the existing ambiguity error" do
+          expect { resolve }.to raise_error(CoPlan::Plans::OperationError, /found 2 occurrences, expected at most 1/)
+        end
+      end
+
+      describe "box beyond end of document" do
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: 99 } }
+
+        it "raises out of range" do
+          expect { resolve }.to raise_error(CoPlan::Plans::OperationError, /lines 99\.\.99 out of range \(document has 6 lines\)/)
+        end
+      end
+
+      describe "invalid values" do
+        [0, -1, "3", [2], [2, 3, 4], ["2", "3"], [3, 2], { start: 1 }].each do |invalid|
+          it "rejects #{invalid.inspect}" do
+            operation = { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: invalid }
+            expect {
+              described_class.call(content: content, operation: operation)
+            }.to raise_error(CoPlan::Plans::OperationError, /'lines' must/)
+          end
+        end
+      end
+
+      describe "fenced duplicate vs real task line" do
+        let(:content) { "```\n- [ ] TODO\n```\n- [ ] TODO" }
+        let(:operation) { { op: "replace_exact", old_text: "- [ ] TODO", new_text: "- [x] TODO", lines: 4 } }
+
+        it "targets the real task line outside the fence" do
+          result = resolve
+          expect(result.ranges.first[0]).to eq(content.rindex("- [ ] TODO"))
+        end
+      end
+    end
   end
 
   describe "insert_under_heading" do


### PR DESCRIPTION
> **Stacked on #133** — review only the last two commits (`Derive checkbox line numbers from Commonmarker sourcepos` and the specs commit) until #133 merges, after which this PR will show just its own diff.

## What's new

Checkbox line numbers now come from the markdown parser itself instead of a parallel scanner. Every rendered checkbox is wired to the exact source line the parser says it came from, and a checkbox only becomes interactive when its source line is something the toggle endpoint will actually accept — anything else stays a plain, disabled checkbox.

## Rationale

The plan renderer previously ran two independent interpretations of the same document: the markdown parser decided which list items render as checkboxes, while a separate hand-rolled scanner (a regex with naive code-fence tracking) decided which source lines are task lines. The two lists were then paired up **by position** — third checkbox gets the third scanned line.

Those two interpretations disagree on a surprising number of real-world constructs. The scanner counts task-shaped lines the parser never renders (inside indented code fences, `~~~` markers nested in backtick fences, mismatched fence lengths, 4-space indented code, raw HTML blocks) and misses items the parser does render (ordered-list tasks, blockquoted tasks, empty tasks). One disagreement anywhere shifts the pairing for **every checkbox after it**, so a click could silently edit a different line than the one the user toggled — including lines inside code blocks. And because the wrong line number and the wrong text arrive together as a self-consistent pair, the server-side safety check introduced in #133 validates them against each other and cannot detect the mix-up.

This change removes the second interpretation entirely. The parser now reports the source position of each list item alongside the rendered HTML, so the single authority that decides "this renders as a checkbox" also supplies "and it came from this line." Disagreement is no longer possible by construction. The position metadata is consumed during rendering and stripped from the final output.

Two smaller consequences:

- Constructs the parser renders as checkboxes but the toggle endpoint won't accept (ordered-list tasks, blockquoted tasks) previously grabbed a *neighboring* task's line and text; they now simply stay disabled — client and server agree on what is toggleable because they now share one task-line pattern.
- The renderer and the toggle endpoint previously each had their own copy of that pattern; they now reference a single shared definition, so they can't drift apart.

## Testing

Beyond the existing checkbox specs (which pass unchanged), this adds an agreement suite that pins the invariant the whole toggle flow rests on: for every interactive checkbox, the text at its claimed line number must equal its claimed text, and the position resolver must accept that pair. The suite covers each divergent construct individually plus a gauntlet document combining fences, ordered/blockquoted tasks, HTML blocks, and duplicate task lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
