### PR TITLE
Add comment permalinks

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1709,6 +1709,10 @@ img.avatar {
   margin-bottom: var(--space-sm);
 }
 
+.thread-popover__permalink {
+  margin-left: auto;
+}
+
 .thread-popover__quote {
   border-left: 3px solid var(--color-quote-info-border);
   padding: var(--space-xs) var(--space-sm);

--- a/engine/app/javascript/controllers/coplan/text_selection_controller.js
+++ b/engine/app/javascript/controllers/coplan/text_selection_controller.js
@@ -215,6 +215,23 @@ export default class extends Controller {
     this._showThreadPopoverFor(event.currentTarget, "pinned")
   }
 
+  async copyThreadLink(event) {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+
+    event.preventDefault()
+    const link = event.currentTarget
+    const label = link.querySelector("[data-copy-label]")
+
+    try {
+      await navigator.clipboard.writeText(link.href)
+      label.textContent = "Copied!"
+      setTimeout(() => { label.textContent = "Copy link" }, 2000)
+    } catch {
+      label.textContent = "Copy failed"
+      setTimeout(() => { label.textContent = "Copy link" }, 2000)
+    }
+  }
+
   // Internal: open the popover for a given mark in either "hover" or "pinned" mode.
   // Returns true if the popover was shown, false otherwise.
   _showThreadPopoverFor(trigger, mode) {

--- a/engine/app/views/coplan/comment_threads/_thread_popover.html.erb
+++ b/engine/app/views/coplan/comment_threads/_thread_popover.html.erb
@@ -13,6 +13,13 @@
       <% if thread.out_of_date? %>
         <span class="badge badge--abandoned">out of date</span>
       <% end %>
+      <%= link_to plan_path(plan, thread: thread.id),
+                  class: "thread-popover__permalink btn btn--secondary btn--sm",
+                  title: "Copy link to this comment",
+                  data: { action: "coplan--text-selection#copyThreadLink" } do %>
+        <span aria-hidden="true">🔗</span>
+        <span data-copy-label>Copy link</span>
+      <% end %>
     </div>
 
     <% if thread.anchored? %>

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe "Comment UX", type: :system do
       expect(page).to have_content("Why not monolith?")
     end
 
+    it "opens a linked comment and exposes its permalink" do
+      thread = create_anchored_thread(plan: plan, anchor_text: "microservices architecture", body: "Why not monolith?", user: reviewer)
+
+      visit plan_path(plan, thread: thread.id)
+
+      expect(page).to have_css(".thread-popover", visible: true)
+      within(".thread-popover") do
+        expect(page).to have_link("Copy link", href: plan_path(plan, thread: thread.id))
+        expect(page).to have_content("Why not monolith?")
+        click_link "Copy link"
+        expect(page).to have_link("Copied!")
+      end
+    end
+
     it "shows reply form for open threads" do
       create_anchored_thread(plan: plan, anchor_text: "microservices architecture", body: "Why not monolith?", user: reviewer)
       visit plan_path(plan)


### PR DESCRIPTION
## Why
Inline comments already supported deep links, but the URL was not exposed anywhere in the comment UI for sharing with reviewers.

## What
- Add a Copy link control to anchored comment popovers
- Copy the existing `?thread=<id>` URL with success and failure feedback
- Verify linked comments scroll into view and auto-open

## Risk Assessment
Low — this exposes existing deep-link behavior and adds a client-side clipboard action without changing comment persistence or authorization.

## References
- System and request specs: 33 examples, 0 failures

Generated with Amp