### PR TITLE
Skip comment template digest on writes

### DIFF
--- a/engine/app/views/coplan/comments/_comment.html.erb
+++ b/engine/app/views/coplan/comments/_comment.html.erb
@@ -1,5 +1,5 @@
 <%# Per-viewer affordances (Delete) are hidden client-side by the
-    comment_actions Stimulus controller — broadcasts render once with no
+    comment_actions Stimulus controller — one broadcast is shared with every
     `current_user`, so we ship the button on every human comment and let
     the browser remove it for non-authors. Server still enforces auth. %>
 <div class="comment <%= 'comment--deleted' if comment.deleted? %>"
@@ -24,7 +24,8 @@
       · <%= time_ago_in_words(comment.created_at) %> ago
     </div>
     <div class="comment__body">
-      <%= cache(comment) do %>
+      <%# The record version invalidates edits; bump this namespace when Markdown rendering changes. %>
+      <%= cache(["comment-body-v1", comment], skip_digest: true) do %>
         <%= render_markdown(comment.body_markdown) %>
       <% end %>
     </div>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe "Comments", type: :request do
     expect(comment.author_id).to eq(alice.id)
   end
 
+  it "does not calculate a template digest while broadcasting a reply" do
+    original_perform_caching = ActionController::Base.perform_caching
+    ActionController::Base.perform_caching = true
+    allow(ActionView::Digestor).to receive(:digest).and_call_original
+    allow(Rails.cache).to receive(:read).and_call_original
+
+    post plan_comment_thread_comments_path(plan, thread_record), params: {
+      comment: { body_markdown: "This should return without digesting the partial." }
+    }
+
+    expect(Rails.cache).to have_received(:read)
+    expect(ActionView::Digestor).not_to have_received(:digest)
+  ensure
+    ActionController::Base.perform_caching = original_perform_caching
+  end
+
   describe "DELETE destroy" do
     let!(:comment) do
       create(:comment, comment_thread: thread_record, author_type: "human", author_id: alice.id, body_markdown: "to be deleted")


### PR DESCRIPTION
## Why
Production comment writes intermittently take 400–900 ms because the synchronous broadcast computes a fragment template digest. Rails also misreads the partial's `render once` prose as a dependency on the nonexistent `onces/once` template.

## What
- Skip the template digest while retaining record-versioned comment body caching
- Add an explicit cache namespace for intentional invalidation when Markdown rendering changes
- Reword the ERB comment so Rails cannot infer a bogus render dependency
- Add request coverage proving caching remains active without invoking the digestor

## Risk Assessment
Low — comment HTML and broadcast behavior are unchanged. Existing cache entries are refreshed under the new namespace, and comment edits continue to invalidate via the record cache key.

## References
- Digest-error requests: median 578 ms; maximum 909 ms
- Requests without the digest error: median 94 ms
- Full suite: 942 examples, 0 failures
- Datadog: https://square.datadoghq.com/logs?from_ts=1784053200000&live=false&query=service%3Acoplan-square+digesting&stream_sort=desc&to_ts=1784053860000

Generated with Amp
