### PR TITLE
Fix checkbox toggle targeting: sourcepos renderer + line-verified toggles (supersedes #133/#134 approach)

### DIFF
--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -132,10 +132,23 @@ module CoPlan
         return
       end
 
-      checkbox_pattern = /\A\s*[*+-]\s+\[[ xX]\]\s/
+      checkbox_pattern = MarkdownHelper::TASK_LINE_PATTERN
       unless old_text.match?(checkbox_pattern) && new_text.match?(checkbox_pattern)
         render json: { error: "old_text and new_text must be task list items" }, status: :unprocessable_content
         return
+      end
+
+      # Optional 1-based source line carried by the rendered checkbox
+      # (data-line). The line's text must equal old_text, so duplicate task
+      # lines elsewhere can't collide and a stale client fails loudly
+      # instead of toggling a lookalike.
+      line = nil
+      if params[:line].present?
+        line = Integer(params[:line], exception: false)
+        if line.nil? || line < 1
+          render json: { error: "line must be a positive integer" }, status: :unprocessable_content
+          return
+        end
       end
 
       ActiveRecord::Base.transaction do
@@ -148,9 +161,18 @@ module CoPlan
         end
 
         current_content = @plan.current_content || ""
+        operation = { "op" => "replace_exact", "old_text" => old_text, "new_text" => new_text }
+        if line
+          occurrence = occurrence_at_line(current_content, old_text, line)
+          if occurrence.nil?
+            render json: { error: "old_text does not match line #{line}", current_revision: @plan.current_revision }, status: :unprocessable_content
+            return
+          end
+          operation["occurrence"] = occurrence
+        end
         result = Plans::ApplyOperations.call(
           content: current_content,
-          operations: [{ "op" => "replace_exact", "old_text" => old_text, "new_text" => new_text }]
+          operations: [operation]
         )
 
         new_revision = @plan.current_revision + 1
@@ -180,6 +202,25 @@ module CoPlan
     end
 
     private
+
+    # Maps a verified (line, old_text) pair to the occurrence ordinal the
+    # position resolver will select, keeping the toggle a plain
+    # replace_exact. Returns nil unless the line's rstripped text is exactly
+    # old_text — line and text must both agree for the edit to land.
+    def occurrence_at_line(content, old_text, line)
+      lines = content.each_line.to_a
+      return nil if line > lines.length
+      return nil unless lines[line - 1].rstrip == old_text
+
+      line_start = lines.first(line - 1).sum(&:length)
+      occurrence = 1
+      pos = 0
+      while (idx = content.index(old_text, pos)) && idx < line_start
+        occurrence += 1
+        pos = idx + old_text.length
+      end
+      occurrence
+    end
 
     def set_plan
       @plan = Plan.find(params[:id])

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -14,7 +14,14 @@ module CoPlan
       details summary
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled data-line-text data-action data-coplan--checkbox-target data-mention-username].freeze
+    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled data-line data-line-text data-action data-coplan--checkbox-target data-mention-username data-sourcepos].freeze
+
+    # A source line the toggle endpoint will accept as a task item. Shared
+    # between the renderer and PlansController#toggle_checkbox so a checkbox
+    # is only wired up when the server would accept toggling its line —
+    # constructs Commonmarker renders as checkboxes but the endpoint rejects
+    # (ordered-list or blockquoted tasks) stay disabled.
+    TASK_LINE_PATTERN = /\A\s*[*+-]\s+\[[ xX]\]\s/
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -23,7 +30,11 @@ module CoPlan
     MENTION_PATTERN = /\[@([\w.-]+)\]\(mention:\1\)/
 
     def render_markdown(content, interactive: true)
-      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { render: { unsafe: true } }, plugins: { syntax_highlighter: nil })
+      render_options = { unsafe: true }
+      # Sourcepos is only needed to wire checkboxes to their source lines;
+      # make_checkboxes_interactive strips it from the final output.
+      render_options[:sourcepos] = true if interactive
+      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { render: render_options }, plugins: { syntax_highlighter: nil })
       with_chips = transform_mention_anchors(html)
       sanitized = sanitize(with_chips, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
@@ -70,24 +81,29 @@ module CoPlan
 
     private
 
+    # Wires rendered task checkboxes to their source lines via Commonmarker's
+    # sourcepos metadata, so the parser that decides what renders as a
+    # checkbox is also the authority on which line it came from. A checkbox
+    # only becomes interactive when its own source line matches
+    # TASK_LINE_PATTERN.
     def make_checkboxes_interactive(html, content)
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
-      checkboxes = doc.css('input[type="checkbox"]')
-      return html if checkboxes.empty?
+      source_lines = content.to_s.each_line.map(&:rstrip)
 
-      task_lines = extract_task_lines(content)
+      doc.css('input[type="checkbox"]').each do |cb|
+        li = cb.ancestors("li").first
+        line_number = sourcepos_start_line(li)
+        next unless line_number
 
-      checkboxes.each_with_index do |cb, i|
-        line_text = task_lines[i]
-        next unless line_text
+        line_text = source_lines[line_number - 1]
+        next unless line_text&.match?(TASK_LINE_PATTERN)
 
         cb.remove_attribute("disabled")
         cb["data-action"] = "coplan--checkbox#toggle"
         cb["data-coplan--checkbox-target"] = "checkbox"
         cb["data-line-text"] = line_text
+        cb["data-line"] = line_number.to_s
 
-        li = cb.parent
-        next unless li&.name == "li"
         li.add_class("task-list-item")
 
         # Wrap li contents in a <label> so the whole text is clickable
@@ -99,22 +115,18 @@ module CoPlan
         ul.add_class("task-list") if ul&.name == "ul"
       end
 
+      doc.css("[data-sourcepos]").each { |el| el.remove_attribute("data-sourcepos") }
       doc.to_html
     end
 
-    def extract_task_lines(content)
-      lines = []
-      in_fence = false
-      content.to_s.each_line do |line|
-        stripped = line.rstrip
-        if stripped.match?(/\A(`{3,}|~{3,})/)
-          in_fence = !in_fence
-          next
-        end
-        next if in_fence
-        lines << stripped if stripped.match?(/^\s*[*+-]\s+\[[ xX]\]\s/)
-      end
-      lines
+    # Extracts the 1-based start line from an li's data-sourcepos
+    # ("3:1-4:0" -> 3).
+    def sourcepos_start_line(li)
+      raw = li&.[]("data-sourcepos")
+      return nil if raw.nil?
+
+      line = raw.split(":").first.to_i
+      line >= 1 ? line : nil
     end
   end
 end

--- a/engine/app/javascript/controllers/coplan/checkbox_controller.js
+++ b/engine/app/javascript/controllers/coplan/checkbox_controller.js
@@ -16,14 +16,17 @@ export default class extends Controller {
       ? lineText.replace(/([*+-]\s+)\[[ ]\]/, "$1[x]")
       : lineText.replace(/([*+-]\s+)\[[xX]\]/, "$1[ ]")
 
+    // Source line number disambiguates duplicate task-line text server-side.
+    const line = parseInt(checkbox.dataset.line, 10)
+
     // Optimistic UI: update immediately
     checkbox.dataset.lineText = newText
 
     this.inflight = true
-    this.#sendToggle({ checkbox, oldText, newText, nowChecked, retried: false })
+    this.#sendToggle({ checkbox, oldText, newText, line, nowChecked, retried: false })
   }
 
-  #sendToggle({ checkbox, oldText, newText, nowChecked, retried }) {
+  #sendToggle({ checkbox, oldText, newText, line, nowChecked, retried }) {
     const token = document.querySelector('meta[name="csrf-token"]')?.content
 
     fetch(this.toggleUrlValue, {
@@ -36,7 +39,8 @@ export default class extends Controller {
       body: JSON.stringify({
         old_text: oldText,
         new_text: newText,
-        base_revision: this.revisionValue
+        base_revision: this.revisionValue,
+        ...(Number.isInteger(line) && line >= 1 ? { line } : {})
       })
     }).then(response => {
       if (response.ok) {
@@ -50,7 +54,7 @@ export default class extends Controller {
           if (data.current_revision) {
             this.revisionValue = data.current_revision
           }
-          this.#sendToggle({ checkbox, oldText, newText, nowChecked, retried: true })
+          this.#sendToggle({ checkbox, oldText, newText, line, nowChecked, retried: true })
         })
       } else {
         this.#revert(checkbox, oldText, nowChecked)

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -327,6 +327,25 @@ Delete the paragraph containing a needle string. Fails if 0 or >1 paragraphs mat
 }
 ```
 
+### replace_section
+
+Replace an entire section — a heading plus everything under it, up to the next
+heading of equal or higher level. Use this to scope a rewrite to one part of the
+document when the same text appears elsewhere. Fails if the heading is not found
+or matches more than one heading.
+
+```json
+{
+  "op": "replace_section",
+  "heading": "## Testing Strategy",
+  "new_content": "## Testing Strategy\n\nUnit tests only for v1."
+}
+```
+
+- `heading`: the full heading line, including the `#` markers.
+- `new_content`: replaces the whole section. With `"include_heading": false`,
+  only the section body is replaced and the heading line is kept.
+
 ## Commenting
 
 ### Create Comment Thread

--- a/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
+++ b/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
@@ -96,4 +96,93 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(nested["data-line-text"]).to eq("  - [ ] Nested child")
     end
   end
+
+  describe "#render_markdown data-line attribute" do
+    def checkboxes_for(md)
+      html = helper.render_markdown(md)
+      Nokogiri::HTML::DocumentFragment.parse(html).css('input[type="checkbox"]')
+    end
+
+    it "sets data-line to the 1-based source line number" do
+      checkboxes = checkboxes_for("# Heading\n\n- [ ] First\n- [x] Second")
+      expect(checkboxes.map { |cb| cb["data-line"] }).to eq(%w[3 4])
+    end
+
+    it "keeps line numbers accurate across fenced code blocks" do
+      checkboxes = checkboxes_for("```\n- [ ] Fake checkbox\n```\n- [ ] Real checkbox")
+      interactive = checkboxes.reject { |cb| cb["disabled"] }
+      expect(interactive.length).to eq(1)
+      expect(interactive[0]["data-line"]).to eq("4")
+    end
+
+    it "keeps line numbers accurate for duplicate task lines" do
+      checkboxes = checkboxes_for("- [ ] TODO\n\nSome text\n\n- [ ] TODO\n- [ ] Other")
+      expect(checkboxes.map { |cb| cb["data-line"] }).to eq(%w[1 5 6])
+      expect(checkboxes[0]["data-line-text"]).to eq(checkboxes[1]["data-line-text"])
+    end
+
+    it "numbers nested tasks by their own source lines" do
+      checkboxes = checkboxes_for("- [ ] Parent\n  - [ ] Nested child")
+      nested = checkboxes.find { |cb| cb["data-line-text"]&.include?("Nested") }
+      expect(nested["data-line"]).to eq("2")
+    end
+
+    it "handles indented code blocks that contain task-shaped lines" do
+      md = "Intro:\n\n    - [ ] not a task\n\n- [ ] Real task"
+      checkboxes = checkboxes_for(md)
+      interactive = checkboxes.reject { |cb| cb["disabled"] }
+      expect(interactive.map { |cb| cb["data-line"] }).to eq(%w[5])
+    end
+
+    it "leaves ordered-list tasks non-interactive (toggle endpoint rejects them)" do
+      checkboxes = checkboxes_for("1. [ ] Ordered task\n\n- [ ] Bullet task")
+      interactive = checkboxes.reject { |cb| cb["disabled"] }
+      expect(interactive.map { |cb| cb["data-line-text"] }).to eq(["- [ ] Bullet task"])
+    end
+
+    it "strips data-sourcepos from the rendered output" do
+      html = helper.render_markdown("# Heading\n\n- [ ] Task\n\nParagraph.")
+      expect(html).not_to include("data-sourcepos")
+    end
+
+    it "does not emit data-sourcepos in non-interactive renders" do
+      html = helper.render_markdown("- [ ] Task", interactive: false)
+      expect(html).not_to include("data-sourcepos")
+      expect(html).not_to include("data-line")
+    end
+
+    it "keeps every interactive checkbox's line and text in agreement (gauntlet)" do
+      md = <<~MD
+        # Plan
+
+        - [ ] TODO
+        - [ ] TODO
+        - [ ] Deploy
+        - [ ] Deploy to staging
+
+        ```
+        - [ ] fenced fake
+        ~~~
+        - [ ] nested fence fake
+        ```
+
+        1. [ ] ordered task
+
+        > - [ ] quoted task
+
+        - [x] Final real task
+      MD
+
+      source_lines = md.each_line.map(&:rstrip)
+      checkboxes = checkboxes_for(md)
+      interactive = checkboxes.reject { |cb| cb["disabled"] }
+      expect(interactive).not_to be_empty
+
+      interactive.each do |cb|
+        line = Integer(cb["data-line"])
+        expect(source_lines[line - 1]).to eq(cb["data-line-text"])
+        expect(cb["data-line-text"]).to match(CoPlan::MarkdownHelper::TASK_LINE_PATTERN)
+      end
+    end
+  end
 end

--- a/spec/requests/toggle_checkbox_spec.rb
+++ b/spec/requests/toggle_checkbox_spec.rb
@@ -111,4 +111,114 @@ RSpec.describe "Toggle Checkbox", type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "PATCH toggle_checkbox with duplicate task lines" do
+    before do
+      plan.current_plan_version.update!(
+        content_markdown: "# Tasks\n\n- [ ] TODO\n- [ ] TODO\n- [ ] Deploy to staging\n- [ ] Deploy"
+      )
+    end
+
+    it "toggles the checkbox on the given line, leaving its duplicate untouched" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 4
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      plan.reload
+      expect(plan.current_content).to eq("# Tasks\n\n- [ ] TODO\n- [x] TODO\n- [ ] Deploy to staging\n- [ ] Deploy")
+    end
+
+    it "toggles a line whose text is a prefix of another task line" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] Deploy",
+        new_text: "- [x] Deploy",
+        base_revision: plan.current_revision,
+        line: 6
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      plan.reload
+      expect(plan.current_content).to eq("# Tasks\n\n- [ ] TODO\n- [ ] TODO\n- [ ] Deploy to staging\n- [x] Deploy")
+    end
+
+    it "returns 422 when the text is not on the given line" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 5
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body["error"]).to include("does not match line 5")
+      plan.reload
+      expect(plan.current_content).not_to include("- [x] TODO")
+    end
+
+    it "returns 422 when the line is past the end of the document" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 99
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns 422 without a line param when duplicates exist (ambiguity preserved)" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "returns 422 for a non-integer line param" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: "abc"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body["error"]).to include("line must be a positive integer")
+    end
+
+    it "records a plain replace_exact with an occurrence ordinal in operations_json" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] TODO",
+        new_text: "- [x] TODO",
+        base_revision: plan.current_revision,
+        line: 4
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      op = plan.reload.current_plan_version.operations_json.first
+      expect(op["op"]).to eq("replace_exact")
+      expect(op["occurrence"]).to eq(2)
+      expect(op).not_to have_key("lines")
+      expect(op["resolved_range"]).to be_present
+    end
+
+    it "still toggles a unique line when line is provided" do
+      patch toggle_checkbox_plan_path(plan), params: {
+        old_text: "- [ ] Deploy to staging",
+        new_text: "- [x] Deploy to staging",
+        base_revision: plan.current_revision,
+        line: 5
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      plan.reload
+      expect(plan.current_content).to include("- [x] Deploy to staging")
+    end
+  end
 end

--- a/spec/system/checkbox_spec.rb
+++ b/spec/system/checkbox_spec.rb
@@ -153,6 +153,38 @@ RSpec.describe "Interactive checkboxes", type: :system do
     expect(plan.current_content).to include("- [x] Write documentation")
   end
 
+  it "toggles the correct checkbox when task lines are duplicated" do
+    plan.current_plan_version.update!(
+      content_markdown: "# Tasks\n\n- [ ] TODO\n- [ ] TODO\n- [ ] Deploy\n- [ ] Deploy to staging"
+    )
+
+    visit plan_path(plan)
+
+    checkboxes = all('input[type="checkbox"]')
+    checkboxes[1].click
+
+    wait_for_version(plan, 2)
+
+    plan.reload
+    expect(plan.current_content).to eq("# Tasks\n\n- [ ] TODO\n- [x] TODO\n- [ ] Deploy\n- [ ] Deploy to staging")
+  end
+
+  it "toggles a task whose text is a prefix of another task" do
+    plan.current_plan_version.update!(
+      content_markdown: "# Tasks\n\n- [ ] Deploy to staging\n- [ ] Deploy"
+    )
+
+    visit plan_path(plan)
+
+    checkboxes = all('input[type="checkbox"]')
+    checkboxes[1].click
+
+    wait_for_version(plan, 2)
+
+    plan.reload
+    expect(plan.current_content).to eq("# Tasks\n\n- [ ] Deploy to staging\n- [x] Deploy")
+  end
+
   private
 
   def wait_for_version(plan, expected_revision, timeout: 5)


### PR DESCRIPTION
## Why

Toggling a checkbox whose task-line text is duplicated (two literal `- [ ] TODO` items) or prefixes another task (`- [ ] Deploy` vs `- [ ] Deploy to staging`) failed and visibly reverted — the toggle request carried only the text pair, and text alone is not a unique address. Separately, the renderer paired rendered checkboxes to source lines *by index* using a hand-rolled scanner that disagrees with Commonmarker on real constructs (indented code fences, `~~~` nested in backtick fences, ordered-list and blockquoted tasks); one disagreement shifts every checkbox after it, so a click could silently edit a different line than the one toggled — including lines inside code blocks.

This is the synthesis of the discussion on #133/#134 ([Slack thread](https://sq-block.slack.com/archives/C0AHFE5N8SU/p1783632439712509)): keep Bez's two key insights — the parser as single authority via sourcepos, and self-verifying line+text pairs that fail loudly — while keeping line-based addressing **out of the public operations API**, which stays text-first for AI editors.

## What

- **Renderer** (`MarkdownHelper`): checkboxes get their source line from Commonmarker's `sourcepos` metadata instead of a parallel scanner — the parser that decides "this renders as a checkbox" also supplies "and it came from this line," so index-drift mistargeting is impossible by construction. Constructs the toggle endpoint won't accept (ordered-list/blockquoted tasks) now stay disabled instead of grabbing a neighboring task's line. A shared `TASK_LINE_PATTERN` keeps renderer and endpoint in agreement. `data-sourcepos` is stripped from final output.
- **Toggle endpoint** (`PATCH /plans/:id/toggle_checkbox`): accepts an optional `line` param sent by the checkbox UI. The server verifies the line's text equals `old_text` — any drift is a loud 422, never a misdirected edit — then maps the verified pair to an `occurrence` ordinal and applies a plain `replace_exact`. Zero changes to `PositionResolver`; provenance in `operations_json` stays standard.
- **Agent instructions**: documents the existing (previously undocumented) `replace_section` operation as the semantic way to scope edits to one section — the philosophically-consistent alternative to line ranges for agents.

## What this deliberately does not do

No `lines` qualifier on `replace_exact` in the public API, and no line-based addressing in agent instructions. Agents remain in the textual/semantic addressing model (`occurrence`, `count`, `replace_section`, `insert_under_heading`).

## Testing

- Full suite green: 955 examples, 0 failures (plus new system specs: 11 checkbox browser tests).
- New renderer specs including a gauntlet document (duplicates, prefix tasks, backtick+`~~~` fences, indented code, ordered/blockquoted tasks) pinning the invariant: every interactive checkbox's claimed line text equals the actual source line and matches `TASK_LINE_PATTERN`.
- New request specs: duplicate/prefix toggles land on the right line; wrong line → 422; line past EOF → 422; ambiguous toggle without `line` still 422; `operations_json` records `occurrence`, never `lines`.
- New browser system specs toggling the second of two identical task lines and the prefix case end-to-end.

Credit: the sourcepos technique and loud-failure design are from @bezhermoso's #133/#134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)