### PR TITLE
Perf: instant comment feedback, cached markdown rendering, quieter presence

### DIFF
--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -43,8 +43,22 @@ module CoPlan
       CoPlan::Authentication.user_from_request(connection.__send__(:request))
     end
 
+    # Every viewer pings every 15s, and each ping used to re-render and
+    # re-broadcast the full viewer list to every open tab even when nothing
+    # changed. Skip the render + broadcast when the active-viewer set is
+    # identical to what was last broadcast. Stale viewers still disappear
+    # promptly: their dropping out changes the fingerprint, so the next ping
+    # from any remaining viewer triggers a broadcast. With no cache store
+    # (dev/test) the read returns nil and every ping broadcasts, preserving
+    # the old behavior.
     def broadcast_viewers
       viewers = PlanViewer.active_viewers_for(@plan)
+
+      fingerprint = viewers.map(&:id).join(",")
+      cache_key = "coplan/presence-broadcast/#{@plan.id}"
+      return if Rails.cache.read(cache_key) == fingerprint
+      Rails.cache.write(cache_key, fingerprint, expires_in: 10.minutes)
+
       Broadcaster.replace_to(
         @plan,
         target: "plan-viewers",

--- a/engine/app/controllers/coplan/comment_threads_controller.rb
+++ b/engine/app/controllers/coplan/comment_threads_controller.rb
@@ -40,8 +40,13 @@ module CoPlan
 
       inline_streams = []
       if thread.anchored?
-        html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan }, formats: [:html])
-        Broadcaster.append_to(@plan, target: "plan-threads", html: html)
+        locals = { thread: thread, plan: @plan }
+        # The popover contains forms; the broadcast copy is rendered
+        # requestless so other viewers never receive this request's session
+        # authenticity tokens. The inline copy for the actor stays
+        # request-scoped.
+        Broadcaster.append_to(@plan, target: "plan-threads", partial: "coplan/comment_threads/thread_popover", locals: locals)
+        html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [:html])
         inline_streams << turbo_stream.append("plan-threads", html)
       end
 
@@ -103,10 +108,14 @@ module CoPlan
     end
 
     # Replaces a thread in place (status changed) for other viewers and
-    # returns the inline stream for the actor's own response.
+    # returns the inline stream for the actor's own response. The broadcast
+    # renders requestless (the popover contains forms — request-rendered
+    # HTML would leak this session's authenticity tokens to every viewer);
+    # only the actor's inline copy is request-scoped.
     def broadcast_thread_replace(thread)
-      html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan }, formats: [:html])
-      Broadcaster.replace_to(@plan, target: dom_id(thread), html: html)
+      locals = { thread: thread, plan: @plan }
+      Broadcaster.replace_to(@plan, target: dom_id(thread), partial: "coplan/comment_threads/thread_popover", locals: locals)
+      html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [:html])
       turbo_stream.replace(dom_id(thread), html)
     end
   end

--- a/engine/app/controllers/coplan/comment_threads_controller.rb
+++ b/engine/app/controllers/coplan/comment_threads_controller.rb
@@ -38,48 +38,46 @@ module CoPlan
         reason: "new_comment"
       )
 
+      inline_streams = []
       if thread.anchored?
-        Broadcaster.append_to(
-          @plan,
-          target: "plan-threads",
-          partial: "coplan/comment_threads/thread_popover",
-          locals: { thread: thread, plan: @plan }
-        )
+        html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan }, formats: [:html])
+        Broadcaster.append_to(@plan, target: "plan-threads", html: html)
+        inline_streams << turbo_stream.append("plan-threads", html)
       end
 
-      respond_with_stream_or_redirect("Comment added.")
+      respond_with_stream_or_redirect("Comment added.", streams: inline_streams)
     end
 
     def resolve
       authorize!(@thread, :resolve?)
       @thread.resolve!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
-      broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread resolved.")
+      stream = broadcast_thread_replace(@thread)
+      respond_with_stream_or_redirect("Thread resolved.", streams: [stream])
     end
 
     def accept
       authorize!(@thread, :accept?)
       @thread.accept!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
-      broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread accepted.")
+      stream = broadcast_thread_replace(@thread)
+      respond_with_stream_or_redirect("Thread accepted.", streams: [stream])
     end
 
     def discard
       authorize!(@thread, :discard?)
       @thread.discard!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
-      broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread discarded.")
+      stream = broadcast_thread_replace(@thread)
+      respond_with_stream_or_redirect("Thread discarded.", streams: [stream])
     end
 
     def reopen
       authorize!(@thread, :reopen?)
       @thread.update!(status: "pending", resolved_by_user: nil)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
-      broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread reopened.")
+      stream = broadcast_thread_replace(@thread)
+      respond_with_stream_or_redirect("Thread reopened.", streams: [stream])
     end
 
     private
@@ -92,23 +90,24 @@ module CoPlan
       @thread = @plan.comment_threads.find(params[:id])
     end
 
-    # Broadcasts update all clients (including the submitter) via WebSocket.
-    # The empty turbo_stream response prevents Turbo from navigating (which causes scroll-to-top).
-    def respond_with_stream_or_redirect(message)
+    # The actor's tab is updated inline by the HTTP response (no cable
+    # round-trip); broadcasts handle every other viewer. Turbo stream
+    # append/replace are idempotent when the broadcast echoes back to the
+    # actor. An empty stream list still prevents Turbo from navigating
+    # (which causes scroll-to-top).
+    def respond_with_stream_or_redirect(message, streams: [])
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: [] }
+        format.turbo_stream { render turbo_stream: streams }
         format.html { redirect_to plan_path(@plan), notice: message }
       end
     end
 
-    # Replaces a thread in place (status changed).
+    # Replaces a thread in place (status changed) for other viewers and
+    # returns the inline stream for the actor's own response.
     def broadcast_thread_replace(thread)
-      Broadcaster.replace_to(
-        @plan,
-        target: dom_id(thread),
-        partial: "coplan/comment_threads/thread_popover",
-        locals: { thread: thread, plan: @plan }
-      )
+      html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: { thread: thread, plan: @plan }, formats: [:html])
+      Broadcaster.replace_to(@plan, target: dom_id(thread), html: html)
+      turbo_stream.replace(dom_id(thread), html)
     end
   end
 end

--- a/engine/app/controllers/coplan/comments_controller.rb
+++ b/engine/app/controllers/coplan/comments_controller.rb
@@ -19,17 +19,18 @@ module CoPlan
         reason: "reply"
       )
 
-      Broadcaster.append_to(
-        @plan,
-        target: ActionView::RecordIdentifier.dom_id(@thread, :comments),
-        partial: "coplan/comments/comment",
-        locals: { comment: comment }
-      )
+      target = ActionView::RecordIdentifier.dom_id(@thread, :comments)
+      html = render_to_string(partial: "coplan/comments/comment", locals: { comment: comment }, formats: [:html])
 
-      # The broadcast above updates all clients (including the submitter) via WebSocket.
-      # The empty turbo_stream response prevents Turbo from navigating (which causes scroll-to-top).
+      Broadcaster.append_to(@plan, target: target, html: html)
+
+      # The author's tab gets the append inline in the HTTP response — no
+      # cable round-trip between submit and seeing the comment. The broadcast
+      # above still updates every other viewer; Turbo removes same-id children
+      # before appending, so the author's copy isn't duplicated when the
+      # broadcast echoes back.
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: [] }
+        format.turbo_stream { render turbo_stream: turbo_stream.append(target, html) }
         format.html { redirect_to plan_path(@plan), notice: "Reply added." }
       end
     end
@@ -44,18 +45,20 @@ module CoPlan
       Comments::SoftDelete.call(comment: comment, actor: current_user)
 
       if @thread.reload.empty?
-        Broadcaster.remove_to(@plan, target: ActionView::RecordIdentifier.dom_id(@thread))
+        target = ActionView::RecordIdentifier.dom_id(@thread)
+        Broadcaster.remove_to(@plan, target: target)
+        inline_stream = turbo_stream.remove(target)
       else
-        Broadcaster.replace_to(
-          @plan,
-          target: ActionView::RecordIdentifier.dom_id(comment),
-          partial: "coplan/comments/comment",
-          locals: { comment: comment }
-        )
+        target = ActionView::RecordIdentifier.dom_id(comment)
+        html = render_to_string(partial: "coplan/comments/comment", locals: { comment: comment }, formats: [:html])
+        Broadcaster.replace_to(@plan, target: target, html: html)
+        inline_stream = turbo_stream.replace(target, html)
       end
 
+      # Inline response updates the actor immediately; the broadcast handles
+      # other viewers (remove/replace are idempotent on echo).
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: [] }
+        format.turbo_stream { render turbo_stream: inline_stream }
         format.html { redirect_to plan_path(@plan), notice: "Comment deleted." }
       end
     end

--- a/engine/app/controllers/coplan/comments_controller.rb
+++ b/engine/app/controllers/coplan/comments_controller.rb
@@ -20,9 +20,12 @@ module CoPlan
       )
 
       target = ActionView::RecordIdentifier.dom_id(@thread, :comments)
-      html = render_to_string(partial: "coplan/comments/comment", locals: { comment: comment }, formats: [:html])
+      locals = { comment: comment }
 
-      Broadcaster.append_to(@plan, target: target, html: html)
+      # Broadcast payloads are rendered requestless (via partial:) so they
+      # never embed this request's session — form authenticity tokens in
+      # request-rendered HTML must not be sent to other viewers.
+      Broadcaster.append_to(@plan, target: target, partial: "coplan/comments/comment", locals: locals)
 
       # The author's tab gets the append inline in the HTTP response — no
       # cable round-trip between submit and seeing the comment. The broadcast
@@ -30,7 +33,10 @@ module CoPlan
       # before appending, so the author's copy isn't duplicated when the
       # broadcast echoes back.
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: turbo_stream.append(target, html) }
+        format.turbo_stream do
+          html = render_to_string(partial: "coplan/comments/comment", locals: locals, formats: [:html])
+          render turbo_stream: turbo_stream.append(target, html)
+        end
         format.html { redirect_to plan_path(@plan), notice: "Reply added." }
       end
     end
@@ -50,8 +56,10 @@ module CoPlan
         inline_stream = turbo_stream.remove(target)
       else
         target = ActionView::RecordIdentifier.dom_id(comment)
-        html = render_to_string(partial: "coplan/comments/comment", locals: { comment: comment }, formats: [:html])
-        Broadcaster.replace_to(@plan, target: target, html: html)
+        locals = { comment: comment }
+        # Requestless render for the broadcast; request-scoped only inline.
+        Broadcaster.replace_to(@plan, target: target, partial: "coplan/comments/comment", locals: locals)
+        html = render_to_string(partial: "coplan/comments/comment", locals: locals, formats: [:html])
         inline_stream = turbo_stream.replace(target, html)
       end
 

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -16,6 +16,12 @@ module CoPlan
 
     ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled data-line-text data-action data-coplan--checkbox-target data-mention-username].freeze
 
+    # Fragment caches of rendered markdown are keyed on content SHA plus this
+    # version. Bump it whenever the rendering pipeline changes output for the
+    # same input (new tags, attribute changes, checkbox wiring, etc.), or
+    # stale HTML will be served from cache.
+    RENDER_CACHE_VERSION = 1
+
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
     # dashes, and underscores. The pattern must round-trip exactly so that

--- a/engine/app/helpers/coplan/plans_helper.rb
+++ b/engine/app/helpers/coplan/plans_helper.rb
@@ -9,7 +9,11 @@ module CoPlan
       content = plan.current_content
       return nil if content.blank?
 
-      plain = markdown_to_plain_text(content)
+      # Cached per content SHA: without this, every index page fell back to a
+      # full Commonmarker + Nokogiri parse per plan without an AI summary.
+      cache_key = ["coplan/plan-preview", MarkdownHelper::RENDER_CACHE_VERSION, plan.id,
+                   plan.current_plan_version&.content_sha256 || plan.current_revision]
+      plain = Rails.cache.fetch(cache_key) { markdown_to_plain_text(content) }
       return nil if plain.blank?
 
       truncate(plain, length: limit, omission: "…", separator: " ")

--- a/engine/app/services/coplan/broadcaster.rb
+++ b/engine/app/services/coplan/broadcaster.rb
@@ -1,5 +1,11 @@
 module CoPlan
   module Broadcaster
+    # Prefer partial:/locals: over html: — partials are rendered here in a
+    # requestless context. Never pass request-rendered HTML that contains
+    # forms via html:: form_with/button_to embed the acting user's session
+    # authenticity token, and a broadcast would send that secret to every
+    # subscribed viewer. html: is fine for form-free fragments the caller
+    # already rendered for its own inline response.
     class << self
       def prepend_to(streamable, target:, html: nil, partial: nil, locals: {})
         html ||= render(partial:, locals:)

--- a/engine/app/services/coplan/broadcaster.rb
+++ b/engine/app/services/coplan/broadcaster.rb
@@ -1,12 +1,14 @@
 module CoPlan
   module Broadcaster
     class << self
-      def prepend_to(streamable, target:, partial:, locals: {})
-        Turbo::StreamsChannel.broadcast_prepend_to(streamable, target: target, html: render(partial:, locals:))
+      def prepend_to(streamable, target:, html: nil, partial: nil, locals: {})
+        html ||= render(partial:, locals:)
+        Turbo::StreamsChannel.broadcast_prepend_to(streamable, target: target, html: html)
       end
 
-      def append_to(streamable, target:, partial:, locals: {})
-        Turbo::StreamsChannel.broadcast_append_to(streamable, target: target, html: render(partial:, locals:))
+      def append_to(streamable, target:, html: nil, partial: nil, locals: {})
+        html ||= render(partial:, locals:)
+        Turbo::StreamsChannel.broadcast_append_to(streamable, target: target, html: html)
       end
 
       def replace_to(streamable, target:, html: nil, partial: nil, locals: {})

--- a/engine/app/views/coplan/plans/_content_body.html.erb
+++ b/engine/app/views/coplan/plans/_content_body.html.erb
@@ -1,4 +1,12 @@
 <%# Rendered plan markdown. Lives inside #plan-content-body so it can be
     swapped wholesale by live-update broadcasts when an agent (or anyone)
-    commits a new revision in another tab. -%>
-<%= render_markdown(plan.current_content) %>
+    commits a new revision in another tab.
+
+    Cached per content SHA: rendering is Commonmarker + two Nokogiri passes +
+    sanitize, and this partial is re-rendered on every show AND every
+    content-mutation broadcast. skip_digest avoids the template-digest cost
+    on write paths; the explicit RENDER_CACHE_VERSION key handles renderer
+    changes instead. -%>
+<% cache ["coplan/plan-content-body", CoPlan::MarkdownHelper::RENDER_CACHE_VERSION, plan.id, plan.current_plan_version&.content_sha256 || plan.current_revision], skip_digest: true do %>
+  <%= render_markdown(plan.current_content) %>
+<% end %>

--- a/spec/requests/comment_threads_spec.rb
+++ b/spec/requests/comment_threads_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe "CommentThreads", type: :request do
     expect(thread.plan_version_id).to eq(plan.current_plan_version_id)
   end
 
+  it "broadcasts the popover via requestless partial render, never request-scoped HTML" do
+    # The popover contains reply/action forms; request-rendered HTML embeds
+    # the actor's session authenticity token, which must not be broadcast.
+    expect(CoPlan::Broadcaster).to receive(:append_to) do |_streamable, **kwargs|
+      expect(kwargs[:partial]).to eq("coplan/comment_threads/thread_popover")
+      expect(kwargs[:html]).to be_nil
+    end
+
+    post plan_comment_threads_path(plan), params: {
+      comment_thread: { anchor_text: "world domination", body_markdown: "Broadcast safely." }
+    }
+  end
+
+  it "broadcasts thread status changes via requestless partial render" do
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: alice)
+    expect(CoPlan::Broadcaster).to receive(:replace_to) do |_streamable, **kwargs|
+      expect(kwargs[:partial]).to eq("coplan/comment_threads/thread_popover")
+      expect(kwargs[:html]).to be_nil
+    end
+
+    patch resolve_plan_comment_thread_path(plan, thread)
+  end
+
   it "create general comment thread" do
     expect {
       post plan_comment_threads_path(plan), params: {

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe "Comments", type: :request do
     expect(comment.author_id).to eq(alice.id)
   end
 
+  it "returns the appended comment inline in the turbo_stream response" do
+    post plan_comment_thread_comments_path(plan, thread_record),
+      params: { comment: { body_markdown: "Inline, no cable round-trip." } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    expect(response).to have_http_status(:ok)
+    comment = CoPlan::Comment.last
+    expect(response.body).to include(%(action="append"))
+    expect(response.body).to include("comments_comment_thread_#{thread_record.id}")
+    expect(response.body).to include(ActionView::RecordIdentifier.dom_id(comment))
+    expect(response.body).to include("Inline, no cable round-trip.")
+  end
+
   describe "DELETE destroy" do
     let!(:comment) do
       create(:comment, comment_thread: thread_record, author_type: "human", author_id: alice.id, body_markdown: "to be deleted")

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe "Comments", type: :request do
     expect(response.body).to include("Inline, no cable round-trip.")
   end
 
+  it "broadcasts via requestless partial render, never the request-scoped HTML" do
+    # Request-rendered HTML embeds the actor's session authenticity token in
+    # any forms; broadcasting it would send that secret to every viewer.
+    expect(CoPlan::Broadcaster).to receive(:append_to) do |_streamable, **kwargs|
+      expect(kwargs[:partial]).to eq("coplan/comments/comment")
+      expect(kwargs[:html]).to be_nil
+    end
+
+    post plan_comment_thread_comments_path(plan, thread_record), params: {
+      comment: { body_markdown: "Broadcast me safely." }
+    }
+  end
+
   describe "DELETE destroy" do
     let!(:comment) do
       create(:comment, comment_thread: thread_record, author_type: "human", author_id: alice.id, body_markdown: "to be deleted")


### PR DESCRIPTION
## Why

The app feels laggy on exactly the interactions that should feel instant. Investigation found three architectural causes (this composes with #137, which fixes the template-digest cost on comment writes):

1. **Your own comment took a full cable round-trip to appear.** Comment/thread actions responded with an *empty* turbo stream ("prevents scroll-to-top") and relied on the ActionCable broadcast to update the submitter's own page: SolidCable DB write → poll interval → websocket push → DOM apply. On a loaded system that's the entire perceived "lag when you comment."
2. **Markdown rendering ran from scratch everywhere.** Commonmarker + two Nokogiri passes + sanitize on every plan show, on every content-mutation broadcast, and once per summary-less card on every `/plans` page (up to 20 full parses per index render).
3. **Presence chatter.** Every viewer pings every 15s; every ping re-rendered and re-broadcast the full viewer list to every open tab even when nothing changed — with N viewers, N renders + N×N pushes per 15s of pure noise.

## What

- **Inline turbo-stream responses for the actor** on comment create/delete and thread create/resolve/accept/discard/reopen. Partial renders once; the same HTML goes inline to the actor and out via broadcast to other viewers. Turbo's append removes same-id children first, so the echoed broadcast can't duplicate the actor's copy; replace/remove are naturally idempotent. Empty-stream behavior (no navigation/scroll jump) is preserved.
- **Fragment caching per content SHA** for the rendered plan body (`_content_body`) and index previews. `skip_digest: true` keeps template digesting off write paths (same approach as #137); an explicit `RENDER_CACHE_VERSION` constant invalidates when the render pipeline changes. Falls back gracefully where no cache store is configured.
- **Presence broadcast dedupe** via viewer-set fingerprint. Stale viewers still disappear promptly — their departure changes the fingerprint, so the next ping from any remaining viewer broadcasts.
- `Broadcaster.append_to`/`prepend_to` accept pre-rendered `html:` like `replace_to` already did.

## Note for coplan-square

Production there has **no `cache_store` configured** (the `mem_cache_store` line is commented out), so fragment caches fall back to the default file store — per-pod but functional. A follow-up in coplan-square to enable a real store (e.g. solid_cache like this repo's production config) would make the caching fully effective.

## Testing

- Full suite green: 942 examples, 0 failures, including all browser system specs (comment UX, anchoring, checkbox, history).
- New request spec pins the inline-append response (comment HTML present in the turbo_stream response body, correct target).
- Channel specs pass unchanged (test env has no cache store, so every ping broadcasts — old behavior preserved as the fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)