### PR TITLE
Markdown extensions: footnotes, hover definitions, collapsible sections

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1200,6 +1200,57 @@ img.avatar {
   border-radius: var(--radius);
 }
 
+.markdown-rendered abbr[title] {
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+  cursor: help;
+}
+
+.markdown-rendered details {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.markdown-rendered details[open] {
+  padding-bottom: var(--space-md);
+}
+
+.markdown-rendered summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin: calc(var(--space-sm) * -1) calc(var(--space-md) * -1);
+  padding: var(--space-sm) var(--space-md);
+}
+
+.markdown-rendered details[open] summary {
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-md);
+}
+
+.markdown-rendered .footnote-ref a,
+.markdown-rendered sup a[data-footnote-ref] {
+  text-decoration: none;
+  padding: 0 2px;
+}
+
+.markdown-rendered section[data-footnotes] {
+  margin-top: var(--space-xl);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-md);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.markdown-rendered section[data-footnotes] p {
+  margin-bottom: var(--space-xs);
+}
+
+.markdown-rendered a[data-footnote-backref] {
+  text-decoration: none;
+}
+
 /* Comment popover (appears on text selection) */
 .comment-popover {
   position: absolute;

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -36,7 +36,11 @@ module CoPlan
     # casual `[foo](mention:bar)` typed by hand doesn't get rendered as a chip.
     MENTION_PATTERN = /\[@([\w.-]+)\]\(mention:\1\)/
 
-    def render_markdown(content, interactive: true)
+    # footnote_prefix: pass a DOM-unique string when a page renders more than
+    # one markdown fragment (e.g. each comment) — commonmarker numbers
+    # footnote ids from #fn-1 per document, so unprefixed fragments collide
+    # and reference/backref links jump to the wrong footnote.
+    def render_markdown(content, interactive: true, footnote_prefix: nil)
       render_options = { unsafe: true }
       # Sourcepos is only needed to wire checkboxes to their source lines;
       # make_checkboxes_interactive strips it from the final output.
@@ -45,6 +49,7 @@ module CoPlan
       with_chips = transform_mention_anchors(html)
       sanitized = sanitize(with_chips, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
+      result = scope_footnote_ids(result, footnote_prefix) if footnote_prefix
       tag.div(result.html_safe, class: "markdown-rendered", data: { controller: "coplan--mermaid" })
     end
 
@@ -123,6 +128,24 @@ module CoPlan
       end
 
       doc.css("[data-sourcepos]").each { |el| el.remove_attribute("data-sourcepos") }
+      doc.to_html
+    end
+
+    # Rewrites commonmarker's per-document footnote ids (#fn-N / #fnref-N)
+    # and the hrefs that point at them so multiple fragments can coexist in
+    # one DOM. Only ids/fragments with the fn-/fnref- shape are touched —
+    # heading anchors and user-supplied ids pass through untouched.
+    FOOTNOTE_ID_PATTERN = /\A(fn|fnref)-/
+
+    def scope_footnote_ids(html, prefix)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      doc.css("[id]").each do |el|
+        el["id"] = "#{prefix}-#{el["id"]}" if el["id"].match?(FOOTNOTE_ID_PATTERN)
+      end
+      doc.css(%(a[href^="#fn"])).each do |a|
+        fragment = a["href"].delete_prefix("#")
+        a["href"] = "##{prefix}-#{fragment}" if fragment.match?(FOOTNOTE_ID_PATTERN)
+      end
       doc.to_html
     end
 

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -12,9 +12,16 @@ module CoPlan
       dd dt dl
       sup sub
       details summary
+      abbr
+      section
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled data-line data-line-text data-action data-coplan--checkbox-target data-mention-username data-sourcepos].freeze
+    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled open aria-label data-line data-line-text data-action data-coplan--checkbox-target data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
+
+    # Commonmarker extensions beyond the gem defaults (tables, tasklist,
+    # strikethrough, autolink stay on). Footnotes: `[^1]` in text plus a
+    # `[^1]: definition` block anywhere in the document.
+    EXTENSION_OPTIONS = { footnotes: true }.freeze
 
     # A source line the toggle endpoint will accept as a task item. Shared
     # between the renderer and PlansController#toggle_checkbox so a checkbox
@@ -34,7 +41,7 @@ module CoPlan
       # Sourcepos is only needed to wire checkboxes to their source lines;
       # make_checkboxes_interactive strips it from the final output.
       render_options[:sourcepos] = true if interactive
-      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { render: render_options }, plugins: { syntax_highlighter: nil })
+      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { extension: EXTENSION_OPTIONS, render: render_options }, plugins: { syntax_highlighter: nil })
       with_chips = transform_mention_anchors(html)
       sanitized = sanitize(with_chips, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
@@ -63,7 +70,7 @@ module CoPlan
     end
 
     def markdown_to_plain_text(content)
-      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), plugins: { syntax_highlighter: nil })
+      html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { extension: EXTENSION_OPTIONS }, plugins: { syntax_highlighter: nil })
       Nokogiri::HTML::DocumentFragment.parse(html).text.squish
     end
 

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -60,6 +60,16 @@ flowchart LR
 
 The web UI renders these blocks as diagrams. Keep the Mermaid source in the plan so humans and agents can review and edit it alongside the surrounding Markdown.
 
+#### Rich formatting
+
+Beyond standard Markdown (tables, task lists, strikethrough), plans support:
+
+- **Footnotes** — `Some claim.[^1]` with `[^1]: Supporting detail or citation.` anywhere in the document. Rendered as numbered superscript links with a footnote section at the bottom. Use these for caveats, citations, and asides that would clutter the main text.
+- **Collapsible sections** — `<details><summary>Title shown when collapsed</summary>` … `</details>`. Use for long appendices, raw logs, or optional deep-dives so the document stays scannable. Add `open` to the `<details>` tag to render expanded by default. Leave a blank line after `<summary>…</summary>` so Markdown inside the section still renders.
+- **Hover definitions** — `<abbr title="Definition shown on hover">TERM</abbr>`. Use for acronyms and project-specific jargon so readers outside the team can follow along.
+
+Other raw HTML is stripped on render (the Markdown source is preserved), so stick to these plus standard Markdown.
+
 ### Update Plan
 
 Update plan metadata (title, status, tags). Only fields included in the request body are changed.

--- a/engine/app/views/coplan/comments/_comment.html.erb
+++ b/engine/app/views/coplan/comments/_comment.html.erb
@@ -25,8 +25,10 @@
     </div>
     <div class="comment__body">
       <%# The record version invalidates edits; bump this namespace when Markdown rendering changes. %>
-      <%= cache(["comment-body-v1", comment], skip_digest: true) do %>
-        <%= render_markdown(comment.body_markdown) %>
+      <%= cache(["comment-body-v2", comment], skip_digest: true) do %>
+        <%# footnote_prefix keeps footnote ids unique per comment — the plan
+            body and every other comment render in the same DOM. %>
+        <%= render_markdown(comment.body_markdown, footnote_prefix: "comment-#{comment.id}") %>
       <% end %>
     </div>
     <% if comment.author_type == "human" %>

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(html).to include("[^brackets]")
       expect(html).not_to include("footnote-ref")
     end
+
+    it "scopes footnote ids and hrefs with footnote_prefix" do
+      html = helper.render_markdown(markdown, footnote_prefix: "comment-abc")
+      expect(html).to include('id="comment-abc-fnref-1"')
+      expect(html).to include('href="#comment-abc-fn-1"')
+      expect(html).to include('id="comment-abc-fn-1"')
+      expect(html).to include('href="#comment-abc-fnref-1"')
+      expect(html).not_to match(/id="fn(ref)?-1"/)
+    end
+
+    it "leaves non-footnote ids and anchors alone when prefixing" do
+      html = helper.render_markdown("# Heading\n\n[jump](#fnord) <span id=\"fnord\">x</span>\n\n" + markdown, footnote_prefix: "p")
+      expect(html).to include('href="#fnord"')
+      expect(html).to include('id="fnord"')
+    end
   end
 
   describe "hover definitions (abbr)" do

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -35,6 +35,69 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
     end
   end
 
+  describe "footnotes" do
+    let(:markdown) { "A bold claim.[^1]\n\n[^1]: The supporting detail." }
+
+    it "renders footnote references as superscript links" do
+      html = helper.render_markdown(markdown)
+      expect(html).to include('<sup class="footnote-ref">')
+      expect(html).to include('href="#fn-1"')
+      expect(html).to include('data-footnote-ref')
+    end
+
+    it "renders the footnote section with a backreference" do
+      html = helper.render_markdown(markdown)
+      expect(html).to match(/<section class="footnotes" data-footnotes(="")?>/)
+      expect(html).to include("The supporting detail.")
+      expect(html).to include('data-footnote-backref')
+      expect(html).to include('href="#fnref-1"')
+    end
+
+    it "works in non-interactive mode" do
+      html = helper.render_markdown(markdown, interactive: false)
+      expect(html).to include('data-footnotes')
+    end
+
+    it "keeps footnote text in plain-text extraction without literal markers" do
+      plain = helper.markdown_to_plain_text(markdown)
+      expect(plain).to include("The supporting detail.")
+      expect(plain).not_to include("[^1]")
+    end
+
+    it "does not treat unreferenced bracket-caret text as a footnote" do
+      html = helper.render_markdown("Just [^brackets] with no definition.")
+      expect(html).to include("[^brackets]")
+      expect(html).not_to include("footnote-ref")
+    end
+  end
+
+  describe "hover definitions (abbr)" do
+    it "preserves abbr elements with their title" do
+      html = helper.render_markdown('The <abbr title="Optimistic Concurrency Control">OCC</abbr> check.')
+      expect(html).to include('<abbr title="Optimistic Concurrency Control">OCC</abbr>')
+    end
+
+    it "strips event-handler attributes from abbr" do
+      html = helper.render_markdown('<abbr title="ok" onmouseover="alert(1)">X</abbr>')
+      expect(html).to include("<abbr")
+      expect(html).not_to include("onmouseover")
+    end
+  end
+
+  describe "collapsible sections" do
+    it "preserves the open attribute on details" do
+      html = helper.render_markdown("<details open><summary>Expanded</summary>\n\nBody text.\n\n</details>")
+      expect(html).to match(/<details open(="")?>/)
+    end
+
+    it "renders markdown inside a details block separated by blank lines" do
+      html = helper.render_markdown("<details>\n<summary>More</summary>\n\n- [ ] Task inside\n\n</details>")
+      expect(html).to include('type="checkbox"')
+      expect(html).to include('data-line-text="- [ ] Task inside"')
+      expect(html).not_to include("disabled")
+    end
+  end
+
   describe "#render_line_view" do
     it "creates numbered divs" do
       html = helper.render_line_view("line one\nline two\nline three")

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe "Plans", type: :request do
     expect(response.body).to include("plan-layout__content")
   end
 
+  it "scopes comment footnote ids so they can't collide with the plan body's" do
+    thread = create(:comment_thread, :with_anchor, plan: plan, plan_version: plan.current_plan_version, created_by_user: alice)
+    comment = create(:comment, comment_thread: thread, author_type: "human", author_id: alice.id,
+                     body_markdown: "Noted.[^1]\n\n[^1]: A comment footnote.")
+
+    get plan_path(plan)
+    expect(response.body).to include(%(id="comment-#{comment.id}-fn-1"))
+    expect(response.body).to include(%(href="#comment-#{comment.id}-fn-1"))
+  end
+
   it "show plan renders content navigation sidebar" do
     get plan_path(plan)
     expect(response).to have_http_status(:success)


### PR DESCRIPTION
Adds the rich-document features from Mark's Slack thread, in the allow-listed-HTML direction we settled on there — no new syntax invented, everything stays reviewable Markdown.

**Stacked on #138** (base branch is `hampton/checkbox-sourcepos-toggle`) because both touch `markdown_helper.rb`. Once #138 merges, I'll retarget this to `main`.

## What plans can now express

- **Footnotes** — `A bold claim.[^1]` + `[^1]: Supporting detail.` anywhere in the doc. Commonmarker's footnotes extension renders numbered superscript links plus a footnotes section at the bottom, with backreference links. Great for citations and caveats that would clutter the main text.
- **Hover definitions** — `<abbr title="Optimistic Concurrency Control">OCC</abbr>` now survives the sanitizer, styled with a dotted underline + help cursor. Covers the glossary/jargon ask without a glossary data model.
- **Collapsible sections** — `<details>/<summary>` were already allowlisted; this adds the `open` attribute (expanded by default) and card styling. Agent docs note the blank-line-after-summary rule so Markdown inside still renders — including interactive task checkboxes (spec'd).

## Implementation notes

- Footnote markup allowlist additions: `section` tag, `data-footnote-*` attrs, `aria-label` (backref accessibility). Verified event handlers still stripped.
- `markdown_to_plain_text` also enables the extension so index-card previews show footnote text instead of literal `[^1]` markers.
- Agent-instructions gains a "Rich formatting" section documenting all three constructs and the fact that other raw HTML is stripped.
- ⚠️ Merge-order note: if #139 (fragment caching) lands first, `RENDER_CACHE_VERSION` should be bumped when this merges, since rendering output changes for the same content. I'll handle it on retarget.

## Tests

Full suite: 969 examples, 0 failures. New specs cover footnote refs/section/backrefs, plain-text extraction, unreferenced `[^text]` staying literal, abbr preservation + XSS stripping, `open` attribute, and checkbox interactivity inside `<details>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)