### PR TITLE
COPLAN-35: Keep Mermaid comments clickable

### DIFF
--- a/engine/app/javascript/controllers/coplan/comment_nav_controller.js
+++ b/engine/app/javascript/controllers/coplan/comment_nav_controller.js
@@ -128,6 +128,24 @@ export default class extends Controller {
     this.updatePosition()
   }
 
+  handleAnchorsUpdated() {
+    this.updatePosition()
+    if (!this.activeMark || !this.activePopover) return
+
+    const threadId = this.activeMark.dataset.threadId
+    const replacementMark = this.allHighlights.find(mark => mark.dataset.threadId === threadId)
+    if (replacementMark && this.findOpenPopover() === this.activePopover) {
+      replacementMark.classList.add("anchor-highlight--active")
+      this.activeMark = replacementMark
+      this.positionPopoverAtMark(this.activePopover, replacementMark)
+      return
+    }
+
+    try { this.activePopover.hidePopover() } catch {}
+    this.activeMark = null
+    this.activePopover = null
+  }
+
   handleScroll() {
     if (!this.activeMark || !this.activePopover) return
     try {

--- a/engine/app/javascript/controllers/coplan/mermaid_controller.js
+++ b/engine/app/javascript/controllers/coplan/mermaid_controller.js
@@ -43,9 +43,14 @@ export default class extends Controller {
 
     const theme = configureMermaid(mermaid)
     const generation = ++this.renderGeneration
+    let rendered = false
 
     for (const { container, source } of sources) {
-      await this.renderDiagram(mermaid, container, source, theme, generation)
+      rendered = await this.renderDiagram(mermaid, container, source, theme, generation) || rendered
+    }
+
+    if (rendered && this.element.isConnected && generation === this.renderGeneration) {
+      this.element.dispatchEvent(new CustomEvent("coplan:mermaid-rendered", { bubbles: true }))
     }
   }
 
@@ -54,7 +59,7 @@ export default class extends Controller {
 
     try {
       const { svg, bindFunctions } = await mermaid.render(id, source)
-      if (!this.element.isConnected || generation !== this.renderGeneration) return
+      if (!this.element.isConnected || generation !== this.renderGeneration) return false
 
       const diagram = document.createElement("div")
       diagram.className = "mermaid-diagram"
@@ -65,10 +70,12 @@ export default class extends Controller {
       diagram.innerHTML = svg
       sourceContainer.replaceWith(diagram)
       bindFunctions?.(diagram)
+      return true
     } catch {
       document.getElementById(id)?.remove()
       document.getElementById(`d${id}`)?.remove()
       this.showError(sourceContainer)
+      return false
     }
   }
 

--- a/engine/app/javascript/controllers/coplan/mermaid_controller.js
+++ b/engine/app/javascript/controllers/coplan/mermaid_controller.js
@@ -33,24 +33,24 @@ export default class extends Controller {
     ]
     if (sources.length === 0) return
 
-    let mermaid
-    try {
-      mermaid = await loadMermaid()
-    } catch {
-      sources.forEach(({ container }) => this.showError(container))
-      return
-    }
-
-    const theme = configureMermaid(mermaid)
     const generation = ++this.renderGeneration
-    let rendered = false
 
-    for (const { container, source } of sources) {
-      rendered = await this.renderDiagram(mermaid, container, source, theme, generation) || rendered
-    }
+    try {
+      const mermaid = await loadMermaid()
+      if (!this.element.isConnected || generation !== this.renderGeneration) return
 
-    if (rendered && this.element.isConnected && generation === this.renderGeneration) {
-      this.element.dispatchEvent(new CustomEvent("coplan:mermaid-rendered", { bubbles: true }))
+      const theme = configureMermaid(mermaid)
+      for (const { container, source } of sources) {
+        await this.renderDiagram(mermaid, container, source, theme, generation)
+      }
+    } catch {
+      if (this.element.isConnected && generation === this.renderGeneration) {
+        sources.forEach(({ container }) => this.showError(container))
+      }
+    } finally {
+      if (this.element.isConnected && generation === this.renderGeneration) {
+        this.element.dispatchEvent(new CustomEvent("coplan:mermaid-settled", { bubbles: true }))
+      }
     }
   }
 
@@ -59,7 +59,7 @@ export default class extends Controller {
 
     try {
       const { svg, bindFunctions } = await mermaid.render(id, source)
-      if (!this.element.isConnected || generation !== this.renderGeneration) return false
+      if (!this.element.isConnected || generation !== this.renderGeneration) return
 
       const diagram = document.createElement("div")
       diagram.className = "mermaid-diagram"
@@ -70,12 +70,12 @@ export default class extends Controller {
       diagram.innerHTML = svg
       sourceContainer.replaceWith(diagram)
       bindFunctions?.(diagram)
-      return true
     } catch {
       document.getElementById(id)?.remove()
       document.getElementById(`d${id}`)?.remove()
-      this.showError(sourceContainer)
-      return false
+      if (this.element.isConnected && generation === this.renderGeneration) {
+        this.showError(sourceContainer)
+      }
     }
   }
 

--- a/engine/app/javascript/controllers/coplan/text_selection_controller.js
+++ b/engine/app/javascript/controllers/coplan/text_selection_controller.js
@@ -215,6 +215,11 @@ export default class extends Controller {
     this._showThreadPopoverFor(event.currentTarget, "pinned")
   }
 
+  handleMermaidRendered() {
+    this.highlightAnchors()
+    if (this._pendingThreadId) this._openLinkedThread()
+  }
+
   async copyThreadLink(event) {
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
 
@@ -657,11 +662,31 @@ export default class extends Controller {
 
     const domId = `comment_thread_${threadId}`
     const mark = this.contentTarget.querySelector(`mark[data-thread-id="${domId}"]`)
+    // Mermaid replaces its source block asynchronously. Wait for the rendered
+    // label instead of opening a popover against a source mark that will detach.
+    if (mark?.closest('pre[lang="mermaid"]')) {
+      if (attempt < 10) {
+        setTimeout(() => this._openLinkedThread(attempt + 1), 100)
+      }
+      return
+    }
+
     if (mark) {
-      this._pendingThreadId = null
       requestAnimationFrame(() => {
-        mark.scrollIntoView({ behavior: "instant", block: "center" })
-        this.openThreadPopover({ currentTarget: mark })
+        if (this._pendingThreadId !== threadId) return
+
+        const currentMark = this.contentTarget.querySelector(`mark[data-thread-id="${domId}"]`)
+        if (currentMark?.isConnected) {
+          currentMark.scrollIntoView({ behavior: "instant", block: "center" })
+          if (this._showThreadPopoverFor(currentMark, "pinned")) {
+            this._pendingThreadId = null
+            return
+          }
+        }
+
+        if (attempt < 10) {
+          setTimeout(() => this._openLinkedThread(attempt + 1), 100)
+        }
       })
       return
     }

--- a/engine/app/javascript/controllers/coplan/text_selection_controller.js
+++ b/engine/app/javascript/controllers/coplan/text_selection_controller.js
@@ -215,7 +215,7 @@ export default class extends Controller {
     this._showThreadPopoverFor(event.currentTarget, "pinned")
   }
 
-  handleMermaidRendered() {
+  handleMermaidSettled() {
     this.highlightAnchors()
     if (this._pendingThreadId) this._openLinkedThread()
   }
@@ -277,6 +277,22 @@ export default class extends Controller {
     this._attachPopoverHoverListeners(popover)
     this._attachPopoverToggleListener(popover)
     return true
+  }
+
+  _restoreActiveThreadPopover(threadId, mode) {
+    if (!threadId || !this._activePopover) return
+
+    const replacementMark = this.contentTarget.querySelector(`mark[data-thread-id="${threadId}"]`)
+    if (replacementMark && this._findOpenPopover() === this._activePopover) {
+      this._showThreadPopoverFor(replacementMark, mode || "pinned")
+      return
+    }
+
+    this._detachPopoverHoverListeners(this._activePopover)
+    try { this._activePopover.hidePopover() } catch {}
+    this._activeMark = null
+    this._activePopover = null
+    this._openMode = null
   }
 
   handleMarkHoverEnter(mark) {
@@ -516,6 +532,9 @@ export default class extends Controller {
   }
 
   highlightAnchors() {
+    const activeThreadId = this._activeMark?.dataset.threadId
+    const activeMode = this._openMode
+
     // Remove existing anchor highlights before re-highlighting
     this.contentTarget.querySelectorAll("mark.anchor-highlight").forEach(mark => {
       const parent = mark.parentNode
@@ -555,6 +574,7 @@ export default class extends Controller {
       }
     })
 
+    this._restoreActiveThreadPopover(activeThreadId, activeMode)
     this.element.dispatchEvent(new CustomEvent("coplan:anchors-updated", { bubbles: true }))
   }
 

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -67,7 +67,7 @@
         </nav>
         <button type="button" class="content-nav-show-btn" data-action="coplan--content-nav#toggle" data-coplan--content-nav-target="showBtn" title="Show table of contents (])">☰ <kbd>]</kbd></button>
 
-        <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content">
+        <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content" data-action="coplan:mermaid-rendered->coplan--text-selection#handleMermaidRendered">
           <div id="plan-content-body"
                data-controller="coplan--live-update"
                data-coplan--live-update-revision-value="<%= @plan.current_revision %>">

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -67,7 +67,7 @@
         </nav>
         <button type="button" class="content-nav-show-btn" data-action="coplan--content-nav#toggle" data-coplan--content-nav-target="showBtn" title="Show table of contents (])">☰ <kbd>]</kbd></button>
 
-        <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content" data-action="coplan:mermaid-rendered->coplan--text-selection#handleMermaidRendered">
+        <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content" data-action="coplan:mermaid-settled->coplan--text-selection#handleMermaidSettled">
           <div id="plan-content-body"
                data-controller="coplan--live-update"
                data-coplan--live-update-revision-value="<%= @plan.current_revision %>">
@@ -117,7 +117,7 @@
 
 <% open_count = @threads.count(&:open?) %>
 <% if @threads.any? %>
-  <div class="comment-toolbar" data-controller="coplan--comment-nav" data-coplan--comment-nav-plan-id-value="<%= @plan.id %>">
+  <div class="comment-toolbar" data-controller="coplan--comment-nav" data-coplan--comment-nav-plan-id-value="<%= @plan.id %>" data-action="coplan:anchors-updated@document->coplan--comment-nav#handleAnchorsUpdated">
     <span class="comment-toolbar__count">💬 <%= open_count %> open</span>
     <div class="comment-toolbar__nav">
       <button class="btn btn--secondary btn--sm" data-action="coplan--comment-nav#prev" title="Previous comment">↑</button>

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -200,8 +200,52 @@ RSpec.describe "Comment UX", type: :system do
       find(mark_selector, match: :first, wait: 10).click
       expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
 
-      page.execute_script("document.getElementById('comment_thread_#{thread.id}_popover').hidePopover()")
-      expect(page).not_to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+      initial_theme = find(".mermaid-diagram")["data-mermaid-theme"]
+      replacement_theme = initial_theme == "dark" ? "light" : "dark"
+      page.execute_script(<<~JS)
+        document.documentElement.dataset.theme = "#{replacement_theme}"
+        window.dispatchEvent(new CustomEvent("coplan:theme-changed"))
+      JS
+      expect(page).to have_css(
+        ".mermaid-diagram[data-mermaid-theme='#{replacement_theme}']",
+        wait: 10
+      )
+
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+      expect(page).to have_content("Does this claim time out?")
+      active_mark_is_rendered = page.evaluate_script(<<~JS)
+        (() => {
+          const layout = document.querySelector('[data-controller~="coplan--text-selection"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(
+            layout,
+            "coplan--text-selection"
+          )
+          return controller._activeMark?.isConnected &&
+            controller._activeMark.closest(".mermaid-diagram") !== null
+        })()
+      JS
+      expect(active_mark_is_rendered).to be(true)
+    end
+
+    it "keeps a keyboard-opened Mermaid popover attached across re-renders" do
+      plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
+        ```mermaid
+        flowchart LR
+          Queue["assignment"] --> Printer
+        ```
+      MARKDOWN
+      thread = create_anchored_thread(
+        plan: plan,
+        anchor_text: "assignment",
+        body: "Does this need a lease?",
+        user: reviewer
+      )
+
+      visit plan_path(plan)
+
+      expect(page).to have_css(".mermaid-diagram svg", wait: 10)
+      find("body").send_keys("j")
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
 
       initial_theme = find(".mermaid-diagram")["data-mermaid-theme"]
       replacement_theme = initial_theme == "dark" ? "light" : "dark"
@@ -213,10 +257,21 @@ RSpec.describe "Comment UX", type: :system do
         ".mermaid-diagram[data-mermaid-theme='#{replacement_theme}']",
         wait: 10
       )
-      find(mark_selector, match: :first, wait: 10).click
 
       expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
-      expect(page).to have_content("Does this claim time out?")
+      active_mark_is_rendered = page.evaluate_script(<<~JS)
+        (() => {
+          const toolbar = document.querySelector('[data-controller~="coplan--comment-nav"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(
+            toolbar,
+            "coplan--comment-nav"
+          )
+          return controller.activeMark?.isConnected &&
+            controller.activeMark.dataset.threadId === "comment_thread_#{thread.id}" &&
+            controller.activeMark.closest(".mermaid-diagram") !== null
+        })()
+      JS
+      expect(active_mark_is_rendered).to be(true)
     end
 
     it "opens a linked comment and exposes its permalink" do
@@ -264,6 +319,62 @@ RSpec.describe "Comment UX", type: :system do
         })()
       JS
       expect(active_mark_is_rendered).to be(true)
+    end
+
+    it "opens a pending linked comment after Mermaid rendering fails" do
+      plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
+        ```mermaid
+        not a valid diagram
+        ```
+      MARKDOWN
+      thread = create_anchored_thread(
+        plan: plan,
+        anchor_text: "not a valid diagram",
+        body: "The source still needs feedback.",
+        user: reviewer
+      )
+
+      visit plan_path(plan)
+
+      expect(page).to have_css(".mermaid-diagram--error", wait: 10)
+      page.execute_script(<<~JS)
+        const source = document.querySelector(".mermaid-diagram--error")
+        source.querySelector(".mermaid-diagram__error-message")?.remove()
+        source.classList.remove("mermaid-diagram--error")
+        source.setAttribute("lang", "mermaid")
+
+        const layout = document.querySelector('[data-controller~="coplan--text-selection"]')
+        const textSelection = window.Stimulus.getControllerForElementAndIdentifier(
+          layout,
+          "coplan--text-selection"
+        )
+        textSelection._pendingThreadId = "#{thread.id}"
+        textSelection._openLinkedThread(10)
+
+        const markdown = document.querySelector('[data-controller~="coplan--mermaid"]')
+        const mermaid = window.Stimulus.getControllerForElementAndIdentifier(
+          markdown,
+          "coplan--mermaid"
+        )
+        mermaid.renderDiagrams()
+      JS
+
+      expect(page).to have_css(".mermaid-diagram--error", wait: 10)
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+      expect(page).to have_content("The source still needs feedback.")
+      linked_source_is_stable = page.evaluate_script(<<~JS)
+        (() => {
+          const layout = document.querySelector('[data-controller~="coplan--text-selection"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(
+            layout,
+            "coplan--text-selection"
+          )
+          return controller._pendingThreadId === null &&
+            controller._activeMark?.isConnected &&
+            controller._activeMark.closest(".mermaid-diagram--error") !== null
+        })()
+      JS
+      expect(linked_source_is_stable).to be(true)
     end
 
     it "shows reply form for open threads" do

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -177,6 +177,48 @@ RSpec.describe "Comment UX", type: :system do
       expect(page).to have_content("Why not monolith?")
     end
 
+    it "opens a popover for a comment anchored to a Mermaid label" do
+      plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
+        # Request flow
+
+        ```mermaid
+        flowchart LR
+          Queue["assignment — first<br/>fetching device wins"] --> Printer
+        ```
+      MARKDOWN
+      thread = create_anchored_thread(
+        plan: plan,
+        anchor_text: "firstfetching device wins",
+        body: "Does this claim time out?",
+        user: reviewer
+      )
+
+      visit plan_path(plan)
+
+      expect(page).to have_css(".mermaid-diagram svg", wait: 10)
+      mark_selector = ".mermaid-diagram mark[data-thread-id='comment_thread_#{thread.id}']"
+      find(mark_selector, match: :first, wait: 10).click
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+
+      page.execute_script("document.getElementById('comment_thread_#{thread.id}_popover').hidePopover()")
+      expect(page).not_to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+
+      initial_theme = find(".mermaid-diagram")["data-mermaid-theme"]
+      replacement_theme = initial_theme == "dark" ? "light" : "dark"
+      page.execute_script(<<~JS)
+        document.documentElement.dataset.theme = "#{replacement_theme}"
+        window.dispatchEvent(new CustomEvent("coplan:theme-changed"))
+      JS
+      expect(page).to have_css(
+        ".mermaid-diagram[data-mermaid-theme='#{replacement_theme}']",
+        wait: 10
+      )
+      find(mark_selector, match: :first, wait: 10).click
+
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+      expect(page).to have_content("Does this claim time out?")
+    end
+
     it "opens a linked comment and exposes its permalink" do
       thread = create_anchored_thread(plan: plan, anchor_text: "microservices architecture", body: "Why not monolith?", user: reviewer)
 
@@ -189,6 +231,39 @@ RSpec.describe "Comment UX", type: :system do
         click_link "Copy link"
         expect(page).to have_link("Copied!")
       end
+    end
+
+    it "opens a linked comment anchored to a Mermaid label" do
+      plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
+        ```mermaid
+        flowchart LR
+          Queue["~3 min retries"] --> Printer
+        ```
+      MARKDOWN
+      thread = create_anchored_thread(
+        plan: plan,
+        anchor_text: "~3 min retries",
+        body: "Is the retry window configurable?",
+        user: reviewer
+      )
+
+      visit plan_path(plan, thread: thread.id)
+
+      expect(page).to have_css(".mermaid-diagram svg", wait: 10)
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true)
+      expect(page).to have_content("Is the retry window configurable?")
+      active_mark_is_rendered = page.evaluate_script(<<~JS)
+        (() => {
+          const layout = document.querySelector('[data-controller~="coplan--text-selection"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(
+            layout,
+            "coplan--text-selection"
+          )
+          return controller._activeMark?.isConnected &&
+            controller._activeMark.closest(".mermaid-diagram") !== null
+        })()
+      JS
+      expect(active_mark_is_rendered).to be(true)
     end
 
     it "shows reply form for open threads" do


### PR DESCRIPTION
## Why

Plan authors and reviewers need to open, reply to, and resolve feedback anchored to architecture diagrams. Asynchronous Mermaid rendering currently removes those anchors after initial page load, leaving visible comment counts with no clickable thread in active reviews.

## What changes

- Re-highlight comment anchors after the current Mermaid render batch completes.
- Keep direct-linked threads pending until a stable rendered Mermaid label exists.
- Cover cold page loads, theme-triggered re-renders, and direct comment links with system tests.

## Why this approach

This reuses the existing anchor matching and popover behavior on Mermaid's rendered HTML labels. A scoped Stimulus event coordinates diagram completion with comment highlighting without introducing a diagram-specific thread model or a second comment UI.

## Risk / rollback

Risk is low and scoped to successfully rendered Mermaid content. Invalid diagrams continue to show their source and existing error state. Reverting this commit restores the previous behavior.

## Test plan

- `rvm use ruby-3.4.7-portable do bundle exec rspec spec/system/comment_ux_spec.rb:180 spec/system/comment_ux_spec.rb:230 spec/system/comment_ux_spec.rb:291 spec/system/comment_ux_spec.rb:324`
- `rvm use ruby-3.4.7-portable do bundle exec rspec spec/system/comment_ux_spec.rb` (46 examples, 0 failures)
- `rvm use ruby-3.4.7-portable do bundle exec rspec` (1,134 examples, 0 failures)
- `node --check engine/app/javascript/controllers/coplan/comment_nav_controller.js`
- `node --check engine/app/javascript/controllers/coplan/mermaid_controller.js`
- `node --check engine/app/javascript/controllers/coplan/text_selection_controller.js`

## References

- [Original Mermaid review warning](https://github.com/block/coplan/pull/136#discussion_r3574108541)

## Linked ticket

- COPLAN-35

---
**Update Jul 17, 15:15 EDT:** Addressed requested changes around active popovers and failure recovery.

- Rebind click- and keyboard-opened popovers to replacement marks after anchor rebuilding.
- Close stale popovers when their replacement anchor no longer exists.
- Emit a settled event for current Mermaid batches on success or failure so exhausted deep links recover.
- Added regressions for open popovers across theme re-renders and invalid Mermaid source.

Generated with Codex
