### PR TITLE
Expand Mermaid diagrams into a lightbox on click

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1034,6 +1034,7 @@ img.avatar {
 }
 
 .markdown-rendered .mermaid-diagram {
+  position: relative;
   display: flex;
   justify-content: center;
   overflow-x: auto;
@@ -1042,6 +1043,67 @@ img.avatar {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
+  cursor: zoom-in;
+}
+
+.markdown-rendered .mermaid-diagram__expand {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xs);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  cursor: zoom-in;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.markdown-rendered .mermaid-diagram:hover .mermaid-diagram__expand,
+.markdown-rendered .mermaid-diagram__expand:focus-visible {
+  opacity: 1;
+}
+
+.mermaid-lightbox {
+  width: 94vw;
+  height: 92vh;
+  max-width: 94vw;
+  max-height: 92vh;
+  padding: var(--space-lg);
+  margin: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+  cursor: zoom-out;
+}
+
+.mermaid-lightbox::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.mermaid-lightbox__close {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xs);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.mermaid-lightbox__close:hover {
+  color: var(--color-text);
 }
 
 .markdown-rendered .mermaid-diagram svg {
@@ -1055,7 +1117,10 @@ img.avatar {
    height mermaid laid out for. */
 .markdown-rendered .mermaid-diagram foreignObject div,
 .markdown-rendered .mermaid-diagram foreignObject span,
-.markdown-rendered .mermaid-diagram foreignObject p {
+.markdown-rendered .mermaid-diagram foreignObject p,
+.mermaid-lightbox foreignObject div,
+.mermaid-lightbox foreignObject span,
+.mermaid-lightbox foreignObject p {
   line-height: 1.2;
 }
 

--- a/engine/app/javascript/controllers/coplan/mermaid_controller.js
+++ b/engine/app/javascript/controllers/coplan/mermaid_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
     this.renderGeneration += 1
     window.removeEventListener("coplan:theme-changed", this.boundThemeChange)
     this.colorSchemeQuery.removeEventListener("change", this.boundThemeChange)
+    this.lightbox?.close()
   }
 
   async renderDiagrams() {
@@ -63,6 +64,7 @@ export default class extends Controller {
       diagram.dataset.mermaidSource = source
       diagram.dataset.mermaidTheme = theme
       diagram.innerHTML = svg
+      this.makeExpandable(diagram)
       sourceContainer.replaceWith(diagram)
       bindFunctions?.(diagram)
     } catch {
@@ -70,6 +72,57 @@ export default class extends Controller {
       document.getElementById(`d${id}`)?.remove()
       this.showError(sourceContainer)
     }
+  }
+
+  makeExpandable(diagram) {
+    const expand = document.createElement("button")
+    expand.type = "button"
+    expand.className = "mermaid-diagram__expand"
+    expand.setAttribute("aria-label", "Expand diagram")
+    expand.title = "Expand diagram"
+    expand.innerHTML = EXPAND_ICON
+    diagram.append(expand)
+
+    diagram.addEventListener("click", event => {
+      // Let clicks on interactive nodes inside the diagram behave normally.
+      if (event.target.closest("a")) return
+      this.openLightbox(diagram)
+    })
+  }
+
+  openLightbox(diagram) {
+    const svg = diagram.querySelector("svg")
+    if (!svg || this.lightbox) return
+
+    const lightbox = document.createElement("dialog")
+    lightbox.className = "mermaid-lightbox"
+    lightbox.setAttribute("aria-label", "Expanded Mermaid diagram")
+    lightbox.dataset.turboTemporary = ""
+
+    const close = document.createElement("button")
+    close.type = "button"
+    close.className = "mermaid-lightbox__close"
+    close.setAttribute("aria-label", "Close expanded diagram")
+    close.title = "Close"
+    close.innerHTML = CLOSE_ICON
+
+    const content = svg.cloneNode(true)
+    content.removeAttribute("width")
+    content.removeAttribute("height")
+    content.style.maxWidth = "none"
+    content.style.width = "100%"
+    content.style.height = "100%"
+
+    lightbox.append(close, content)
+    lightbox.addEventListener("click", () => lightbox.close())
+    lightbox.addEventListener("close", () => {
+      lightbox.remove()
+      if (this.lightbox === lightbox) this.lightbox = null
+    })
+
+    this.lightbox = lightbox
+    document.body.append(lightbox)
+    lightbox.showModal()
   }
 
   showError(sourceContainer) {
@@ -84,6 +137,18 @@ export default class extends Controller {
     sourceContainer.prepend(message)
   }
 }
+
+const EXPAND_ICON = `
+  <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M9.5 2.5h4v4M13.5 2.5 9 7M6.5 13.5h-4v-4M2.5 13.5 7 9"/>
+  </svg>
+`
+
+const CLOSE_ICON = `
+  <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
+    <path d="M3.5 3.5l9 9M12.5 3.5l-9 9"/>
+  </svg>
+`
 
 function loadMermaid() {
   if (mermaidPromise) return mermaidPromise

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe "Comment UX", type: :system do
       expect(page).to have_css('.mermaid-diagram[data-mermaid-theme="dark"]', wait: 10)
     end
 
+    it "expands a Mermaid diagram into a lightbox on click" do
+      plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
+        ```mermaid
+        flowchart LR
+          Client --> API
+        ```
+      MARKDOWN
+
+      visit plan_path(plan)
+
+      expect(page).to have_css(".mermaid-diagram svg", wait: 10)
+      find(".mermaid-diagram").click
+      expect(page).to have_css(".mermaid-lightbox svg")
+
+      find(".mermaid-lightbox").click
+      expect(page).not_to have_css(".mermaid-lightbox")
+    end
+
     it "keeps invalid Mermaid source readable" do
       plan.current_plan_version.update!(content_markdown: <<~MARKDOWN)
         ```mermaid


### PR DESCRIPTION
## Why
Mermaid diagrams render constrained to the content column, so anything beyond a trivial flowchart is too small to read.

## What
- Clicking a rendered diagram (or the expand button that appears on hover) opens it in a native `<dialog>` sized to the viewport, with the SVG scaled to fit
- Click anywhere or press Escape to close; the dialog is removed on close and tagged `data-turbo-temporary` so Turbo never caches it
- Extend the foreignObject line-height fix (#149) to the lightbox, which lives outside `.markdown-rendered`
- System spec covering expand and click-to-close

## Risk Assessment
Low — additive UI behavior scoped to rendered Mermaid diagrams; no server-side changes.

## Screenshots

Inline diagram with the expand affordance on hover:

![Hover expand button](https://d24qwcpro867f5.cloudfront.net/repos/coplan/prs/151/hover.png)

Clicking opens the lightbox, scaled to the viewport:

![Expanded lightbox](https://d24qwcpro867f5.cloudfront.net/repos/coplan/prs/151/lightbox.png)

For comparison, the same diagram inline before expanding:

![Inline diagram](https://d24qwcpro867f5.cloudfront.net/repos/coplan/prs/151/diagram-collapsed.png)