### PR TITLE
docs: point agents at /agent-instructions and the skill template in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,22 @@ Agents authenticate with `Authorization: Bearer <token>`. Key endpoints:
 - `POST /api/v1/plans/:id/operations` — apply semantic edits
 - `POST /api/v1/plans/:id/comments` — comment on a plan
 
+Every instance also serves a self-describing reference for agents at
+`GET /agent-instructions` — a Markdown document covering the full set of
+endpoints, the editing lease workflow, commenting, and the review process.
+
 See [docs/PLAN.md](./docs/PLAN.md) for full architecture.
+
+## Using CoPlan from an AI Agent
+
+The recommended way to make an agent CoPlan-aware is a small **skill** that
+points the agent at the `/agent-instructions` endpoint, so the agent discovers
+and follows the API on its own instead of being handed the URL each time.
+[`EXAMPLE_SKILL.md`](./EXAMPLE_SKILL.md) is a ready-to-adapt template — set
+`BASE_URL` to your instance and install it wherever your agent loads skills.
+
+Install the skill once and any future session picks it up automatically
+whenever a task mentions a CoPlan plan or URL.
 
 ## Project Resources
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ and follows the API on its own instead of being handed the URL each time.
 [`EXAMPLE_SKILL.md`](./EXAMPLE_SKILL.md) is a ready-to-adapt template — set
 `BASE_URL` to your instance and install it wherever your agent loads skills.
 
-Install the skill once and any future session picks it up automatically
-whenever a task mentions a CoPlan plan or URL.
-
 ## Project Resources
 
 | Resource | Description |


### PR DESCRIPTION
## What

Adds two things to the README:

1. A note that every instance serves a self-describing agent reference at `GET /agent-instructions` (already a first-class route in the engine and surfaced via the `X-Agent-Instructions` response header, but undocumented in the README).
2. A short **"Using CoPlan from an AI Agent"** section pointing at the existing [`EXAMPLE_SKILL.md`](../blob/main/EXAMPLE_SKILL.md) template as the recommended way to make an agent CoPlan-aware.

## Why

The README documents the raw API endpoints but never mentions how an agent is *meant to discover and consume* them. In practice, an agent that isn't told about CoPlan up front can't find it — so it ends up being handed the `/agent-instructions` URL by hand on every session. The intended fix (a small skill wrapping that endpoint) already exists as `EXAMPLE_SKILL.md`, but nothing in the README points readers to it.

This is a docs-only change — no code, no behavior change. It just closes the discovery gap for anyone integrating an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)