### PR TITLE
Folder navigation polish: spring-loaded tunneling, whole-card rows, native-feel fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,31 @@ Most of the application logic lives in the **CoPlan Rails engine** (`engine/`), 
 - No npm packages — everything through importmaps or inline
 - Views use Turbo Frames for partial page updates, Turbo Streams for realtime broadcasts
 - Keep it simple: no React, no Vue, no component libraries
+
+### HARD REQUIREMENT: native feel, secretly HTML
+
+The entire goal of this stack is an app that is plain HTML over the wire but
+**feels indistinguishable from a native app**. Server-rendered HTML is the
+implementation, never the excuse. Concretely, every interaction must meet
+this bar:
+
+- **No layout jiggle between navigations.** Page width and shared chrome must
+  not shift when moving between pages (`scrollbar-gutter: stable` guards the
+  scrollbar case; keep shared containers dimensionally consistent).
+- **No scroll jumps or full-page reloads for in-page actions.** Submitting a
+  form, uploading a file, toggling state — the result appears in place
+  (Turbo Streams / fetch + partial swap), with progress feedback during the
+  wait. `redirect_to` + full reload for something the user did mid-page is a
+  bug, not a fallback.
+- **Immediate feedback for every action** — optimistic UI, busy/progress
+  states, pulses. Nothing may silently wait on a server round-trip.
+- **Instant-feeling navigation.** Real navigations use Turbo Drive with hover
+  prefetch; anything that can be preloaded on intent (hover, spring pulses)
+  should be.
+
+If an interaction scrolls, flashes, reflows, or stalls in a way a native app
+wouldn't, treat it as a bug — regardless of how idiomatic the Rails behind
+it is.
 - **Prefer server-rendered HTML with standard Stimulus bindings** (`data-controller`, `data-action`, `data-*-target`) — direct `addEventListener` is a last resort, only when elements are created dynamically in JS and Stimulus can't bind to them (e.g., inline text highlights wrapping arbitrary DOM ranges). Even these cases should be revisited for server-side alternatives when practical.
 
 ## Testing

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -281,6 +281,11 @@ html {
   color: var(--color-text);
   background-color: var(--color-bg);
   -webkit-font-smoothing: antialiased;
+  /* Native-feel hard requirement: page width must NOT change between
+     navigations. Without a stable gutter, the scrollbar appearing or
+     disappearing between a long page and a short one re-centers the whole
+     layout — a "jiggle" on every workspace → plan hop. */
+  scrollbar-gutter: stable;
 }
 
 body {
@@ -494,6 +499,20 @@ img, svg {
   flex-direction: row-reverse;
 }
 
+/* Each avatar is wrapped in a profile link — the link owns the stacking
+   overlap and the tooltip (::after can't render on an <img>). */
+.plan-viewers__avatar-link {
+  display: flex;
+  margin-left: -0.5rem;
+  border-radius: 50%;
+  position: relative;
+}
+
+.plan-viewers__avatar-link:hover {
+  z-index: 1;
+  transform: translateY(-1px);
+}
+
 .plan-viewers__avatar {
   display: flex;
   align-items: center;
@@ -506,9 +525,6 @@ img, svg {
   font-size: 0.7rem;
   font-weight: 600;
   border: 2px solid var(--color-surface);
-  margin-left: -0.5rem;
-  cursor: default;
-  position: relative;
   object-fit: cover;
 }
 
@@ -516,7 +532,7 @@ img, svg {
   background: var(--color-success);
 }
 
-.plan-viewers__avatar::after {
+.plan-viewers__avatar-link::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 6px);
@@ -535,7 +551,7 @@ img, svg {
   z-index: 10;
 }
 
-.plan-viewers__avatar:hover::after {
+.plan-viewers__avatar-link:hover::after {
   opacity: 1;
 }
 
@@ -2965,7 +2981,26 @@ img.avatar {
 
 .dropzone--busy {
   pointer-events: none;
-  opacity: 0.7;
+  opacity: 0.85;
+}
+
+/* Live upload progress — fills as bytes actually leave the machine. */
+.dropzone__progress {
+  width: min(18rem, 100%);
+  height: 5px;
+  margin-top: var(--space-xs);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+  overflow: hidden;
+}
+
+.dropzone__progress-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: var(--color-primary);
+  transition: width 0.15s ease;
 }
 
 .dropzone__icon {
@@ -4001,36 +4036,39 @@ img.avatar {
   font-size: var(--text-xs);
 }
 
-/* The header bookmark: save/move/remove via the folder navigator. */
-.plan-shelves__bookmark {
+/* The save bookmark sits beside the plan title (mounted into
+   #plan-bookmark-slot by plan_bookmark_controller) — a quiet icon that
+   fills once the plan is on your shelf, like a bookmark star. */
+.plan-bookmark-slot {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: var(--text-xs);
-  font-family: inherit;
-  padding: 3px 8px;
-  border: 1px dashed var(--color-border);
-  border-radius: 9999px;
+}
+
+.plan-bookmark {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  border: none;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: color 0.12s ease, border-color 0.12s ease;
+  transition: color 0.12s ease, background 0.12s ease;
 }
 
-.plan-shelves__bookmark:hover {
+.plan-bookmark:hover {
   color: var(--color-primary);
-  border-color: var(--color-primary);
+  background: var(--color-primary-light);
 }
 
-.plan-shelves__bookmark--saved {
+.plan-bookmark--saved {
   color: var(--color-primary);
-  border-style: solid;
 }
 
 /* Saved = a second click removes; hint at that on hover. */
-.plan-shelves__bookmark--saved:hover {
+.plan-bookmark--saved:hover {
   color: var(--color-danger, #e0637a);
-  border-color: var(--color-danger, #e0637a);
+  background: color-mix(in srgb, var(--color-danger, #e0637a) 10%, transparent);
 }
 
 /* Library browsing page (read-only shelves) */
@@ -4689,6 +4727,8 @@ img.avatar {
   color: var(--color-text);
   text-decoration: none;
   min-width: 0;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 /* Leaf nodes (no <details>) keep the same left padding so labels align. */
@@ -4707,12 +4747,86 @@ img.avatar {
   font-weight: 500;
 }
 
-/* Live drop target under the cursor — folder links and group headings. */
+/* Live drop target under the cursor — folder links and group headings.
+   Loud on purpose: a solid ring, a glow, and primary-tinted contents, so
+   there's no squinting about where the drop will land. */
 .dnd-drop {
-  outline: 2px dashed var(--color-primary);
+  outline: 2px solid var(--color-primary);
   outline-offset: -2px;
   background: var(--color-primary-light);
   border-radius: var(--radius);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 22%, transparent);
+  color: var(--color-primary);
+}
+
+.dnd-drop .folder-row__icon,
+.dnd-drop .folder-row__name,
+.dnd-drop .folder-row__count,
+.dnd-drop .folder-tree__name,
+.dnd-drop .sidebar__count {
+  color: var(--color-primary);
+}
+
+/* Drop accepted, PATCH + refresh in flight — the target pulses until the
+   page re-renders so the move never feels like it silently stalled. */
+.dnd-drop--busy {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  background: var(--color-primary-light);
+  border-radius: var(--radius);
+  animation: dnd-busy-pulse 0.8s ease-in-out infinite;
+}
+
+@keyframes dnd-busy-pulse {
+  50% { opacity: 0.45; }
+}
+
+.workspace--moving,
+.workspace--moving * {
+  cursor: progress;
+}
+
+/* The row that was just dropped stays ghosted (dragend strips the
+   --dragging class before the server round-trip finishes). */
+.dnd-source--moving {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/* Spring-loading, Finder-style: keep the drag hovering on a folder and it
+   pulses twice, then springs open. */
+.dnd-spring {
+  animation: dnd-spring-pulse 0.3s ease-in-out 2;
+}
+
+@keyframes dnd-spring-pulse {
+  50% {
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-primary) 38%, transparent);
+    transform: scale(1.012);
+  }
+}
+
+/* Tunneled pane: springing a main-pane folder swaps the pane to that
+   folder's real level view mid-drag. A quick slide-in sells the "you just
+   went somewhere" feel each level down. */
+.workspace__main--tunneled {
+  animation: dnd-tunnel-in 0.18s ease-out;
+}
+
+@keyframes dnd-tunnel-in {
+  from {
+    opacity: 0.4;
+    transform: translateY(4px);
+  }
+}
+
+/* The pane itself is the fallback drop target ("file into the folder
+   you're looking at"). Ring it quietly and don't tint its text — the loud
+   treatment belongs to specific rows/crumbs. */
+.workspace__main.dnd-drop {
+  color: inherit;
+  box-shadow: none;
+  outline-style: dashed;
 }
 
 .folder-tree__link--dragging {
@@ -4906,6 +5020,8 @@ img.avatar {
   color: var(--color-text);
   text-decoration: none;
   transition: background 0.12s ease, box-shadow 0.12s ease;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .folder-row:hover {
@@ -4946,6 +5062,11 @@ img.avatar {
   border-radius: var(--radius);
   margin-bottom: var(--space-xs);
   transition: background 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+  /* Selectable text hijacks press-and-drag: the browser starts a text
+     selection instead of the row drag, and the mouseup then *navigates*
+     the title link. Rows are chrome, not prose — don't select. */
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 /* The file icon spans both text rows — a Drive/Finder file entry. */
@@ -4963,6 +5084,26 @@ img.avatar {
   background: var(--glass-bg-strong);
   box-shadow: var(--shadow-pop);
   transform: translateY(-1px);
+  cursor: pointer;
+}
+
+/* Whole-card click target: the title link stretches over the card, so
+   clicking (and hover-prefetching) works anywhere on the row. Every other
+   interactive element in the row rises above the stretch. */
+.plan-row {
+  position: relative;
+}
+
+.plan-row__title::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.plan-row a:not(.plan-row__title),
+.plan-row button {
+  position: relative;
+  z-index: 1;
 }
 
 .plan-row--dragging {

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -4870,6 +4870,16 @@ img.avatar {
   outline-offset: -1px;
 }
 
+/* While a drag is live, the pane grows a runway below the level's
+   contents: an empty (or short) folder — especially one just tunneled
+   into — otherwise offers almost nothing to drop on. Padding, not
+   margin: padding is inside the element, so the runway IS the pane's
+   drop target. */
+.workspace--dragging .workspace__main {
+  padding-bottom: 10rem;
+  min-height: 60vh;
+}
+
 /* Needs attention strip */
 .attention {
   margin-bottom: var(--space-lg);

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -4,7 +4,9 @@
   color-scheme: light;
 
   /* Colors */
-  --color-bg: #fafafa;
+  /* Slightly cool and dark for a page background: white cards need
+     something to stand out against, or light mode reads as fog. */
+  --color-bg: #eef0f5;
   --color-bg-muted: #f3f4f6;
   --color-surface: #ffffff;
   --color-surface-muted: #f9fafb;
@@ -108,7 +110,11 @@
   --glass-edge: rgba(255, 255, 255, 0.75);
   --glass-blur: blur(16px) saturate(1.6);
   --shadow-glass: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 1px 2px rgba(15, 23, 42, 0.04), 0 10px 30px rgba(15, 23, 42, 0.08);
-  --surface-translucent: rgba(255, 255, 255, 0.6);
+  --surface-translucent: rgba(255, 255, 255, 0.75);
+  /* Card outline. The white --glass-edge reads as a specular highlight on
+     dark backdrops but disappears white-on-white — cards and rows use this
+     faintly dark line instead so light mode has real definition. */
+  --card-edge: rgba(24, 33, 54, 0.10);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -184,6 +190,7 @@
     --glass-blur: blur(16px) saturate(1.4);
     --shadow-glass: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px rgba(0, 0, 0, 0.4);
     --surface-translucent: rgba(21, 32, 51, 0.55);
+    --card-edge: rgba(148, 163, 184, 0.16);
   }
 }
 
@@ -260,6 +267,7 @@
   --glass-blur: blur(16px) saturate(1.4);
   --shadow-glass: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 1px 2px rgba(0, 0, 0, 0.3), 0 12px 32px rgba(0, 0, 0, 0.4);
   --surface-translucent: rgba(21, 32, 51, 0.55);
+  --card-edge: rgba(148, 163, 184, 0.16);
 }
 
 /* Forced light theme — overrides system dark preference */
@@ -669,7 +677,7 @@ img, svg {
   background: var(--glass-bg-strong);
   -webkit-backdrop-filter: var(--glass-blur);
   backdrop-filter: var(--glass-blur);
-  border: 1px solid var(--glass-edge);
+  border: 1px solid var(--card-edge);
   border-radius: var(--radius-lg);
   padding: var(--space-lg);
   box-shadow: var(--shadow-glass);
@@ -2093,6 +2101,12 @@ img.avatar {
   width: 220px;
   flex-shrink: 0;
   max-height: calc(100vh - var(--nav-height) - var(--space-xl) * 2);
+  /* The nav is the scroll container — a long outline must not push the
+     back-matter links (References/Attachments) below the sticky bound
+     where no amount of page scrolling reaches them. */
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
   transition: width 0.2s ease, opacity 0.2s ease;
   margin-right: var(--space-lg);
 }
@@ -2141,10 +2155,8 @@ img.avatar {
   list-style: none;
   padding: 0;
   margin: 0;
-  overflow-y: auto;
-  max-height: calc(100vh - var(--nav-height) - 8rem);
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-border) transparent;
+  /* No inner scroll region: the whole nav scrolls (see .content-nav), so
+     the outline and the back-matter links share one scroll. */
 }
 
 .content-nav__item {
@@ -2538,27 +2550,26 @@ img.avatar {
 /* Plan document + footnotes: one page, no tabs. The document is the main
    glass card; references and attachments follow like back matter — same
    page, quieter surface. */
+/* Back matter lives inside the content column, closing out the document
+   after a rule — no card-within-card, no space below the sidebar. Empty
+   sections are a single quiet line. */
 .plan-footnotes {
-  margin-top: var(--space-xl);
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
 
 .plan-footnote {
-  /* Set apart from the document proper: flatter, edge-lit, no heavy card. */
-  background: var(--surface-translucent);
-  border: 1px solid var(--glass-edge);
-  border-left: 3px solid var(--color-border);
-  border-radius: var(--radius);
-  scroll-margin-top: var(--space-lg);
+  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
 }
 
 .plan-footnote__header {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  padding: var(--space-md) var(--space-lg) 0;
 }
 
 .plan-footnote__title {
@@ -2737,8 +2748,17 @@ img.avatar {
 }
 
 /* References section */
-.references-section {
-  padding: var(--space-lg);
+/* Section bodies hang under the header, indented past the round "+" so
+   content lines up with the section title. */
+.references-section,
+.attachments-section {
+  padding: 0 0 0 calc(24px + var(--space-sm));
+}
+
+.plan-footnote__empty {
+  margin: var(--space-xs) 0 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
 }
 
 .references-list {
@@ -2942,10 +2962,6 @@ img.avatar {
 }
 
 /* Attachments section */
-.attachments-section {
-  padding: var(--space-lg);
-}
-
 .attachments-section__header {
   margin-bottom: var(--space-md);
 }
@@ -4539,6 +4555,12 @@ img.avatar {
   top: calc(var(--nav-height) + var(--space-md));
   font-size: var(--text-sm);
   min-width: 0;
+  /* A sticky sidebar taller than the viewport pins its overflow below the
+     fold forever — page scroll can't reach it. Scroll the sidebar itself. */
+  max-height: calc(100vh - var(--nav-height) - var(--space-md) * 2);
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
 }
 
 .workspace__sidebar-sections {
@@ -4900,17 +4922,18 @@ img.avatar {
    history, quieter than the warning-toned attention strip. */
 .recent-updates {
   margin-bottom: var(--space-lg);
-  padding: var(--space-sm) var(--space-md);
-  border: 1px solid var(--glass-edge);
+  padding: var(--space-md);
+  border: 1px solid var(--card-edge);
   border-radius: var(--radius);
   background: var(--surface-translucent);
+  box-shadow: var(--shadow);
 }
 
 .recent-updates__heading {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
-  margin: 0 0 var(--space-xs);
+  margin: 0 0 var(--space-sm);
   font-size: 0.8rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -4924,7 +4947,8 @@ img.avatar {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  /* Roomy enough to scan — this read as one bunched block at 2px. */
+  gap: var(--space-sm);
 }
 
 .recent-updates__item {
@@ -5014,9 +5038,10 @@ img.avatar {
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   background: var(--surface-translucent);
-  border: 1px solid var(--glass-edge);
+  border: 1px solid var(--card-edge);
   border-radius: var(--radius);
   margin-bottom: var(--space-xs);
+  box-shadow: var(--shadow);
   color: var(--color-text);
   text-decoration: none;
   transition: background 0.12s ease, box-shadow 0.12s ease;
@@ -5058,9 +5083,10 @@ img.avatar {
   /* Translucent without backdrop blur — rows are numerous and per-row
      blur is a GPU tax; the mesh still glows through faintly. */
   background: var(--surface-translucent);
-  border: 1px solid var(--glass-edge);
+  border: 1px solid var(--card-edge);
   border-radius: var(--radius);
   margin-bottom: var(--space-xs);
+  box-shadow: var(--shadow);
   transition: background 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
   /* Selectable text hijacks press-and-drag: the browser starts a text
      selection instead of the row drag, and the mouseup then *navigates*
@@ -5148,8 +5174,15 @@ img.avatar {
   text-decoration: none;
 }
 
-.plan-row__spacer {
-  flex: 1;
+/* Byline pinned to the card's top-right corner: it must not ride along
+   with wrapping titles or drift to a second line mid-card. */
+.plan-row__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-left: auto;
+  align-self: flex-start;
+  flex-shrink: 0;
 }
 
 .plan-row__time {
@@ -5169,40 +5202,6 @@ img.avatar {
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-/* Row bookmark — the keyboard/no-drag door into the folder navigator. */
-.plan-row__save {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px;
-  background: none;
-  border: none;
-  border-radius: var(--radius);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s ease, color 0.12s ease;
-}
-
-.plan-row:hover .plan-row__save,
-.plan-row__save:focus-visible,
-.plan-row__save--saved {
-  opacity: 1;
-}
-
-.plan-row__save:hover {
-  color: var(--color-primary);
-  background: var(--color-bg-muted);
-}
-
-.plan-row__save--saved {
-  color: var(--color-primary);
-}
-
-/* Saved = a second click removes; hint at that on hover. */
-.plan-row__save--saved:hover {
-  color: var(--color-danger, #e0637a);
 }
 
 /* Toasts (drag & drop feedback) */
@@ -5232,6 +5231,8 @@ img.avatar {
      tap to expand, out of the way otherwise. */
   .workspace__sidebar {
     position: static;
+    max-height: none;
+    overflow: visible;
   }
 
   .workspace__sidebar-toggle {
@@ -5326,10 +5327,13 @@ img.avatar {
     overflow-wrap: anywhere;
   }
 
-  .plan-document,
+  .plan-document {
+    padding: var(--space-md);
+  }
+
   .references-section,
   .attachments-section {
-    padding: var(--space-md);
+    padding-left: 0;
   }
 
   .plan-actions {

--- a/engine/app/controllers/coplan/attachments_controller.rb
+++ b/engine/app/controllers/coplan/attachments_controller.rb
@@ -9,7 +9,10 @@ module CoPlan
 
       files = Array(params[:files]).reject(&:blank?)
       if files.empty?
-        return redirect_to plan_path(@plan, anchor: "footnote-attachments"), alert: "Choose at least one file to upload."
+        return respond_to do |format|
+          format.turbo_stream { render turbo_stream: toast_stream("Choose at least one file to upload.", "alert") }
+          format.html { redirect_to plan_path(@plan, anchor: "footnote-attachments"), alert: "Choose at least one file to upload." }
+        end
       end
 
       errors = []
@@ -19,10 +22,18 @@ module CoPlan
       end
 
       uploaded = files.size - errors.size
-      flash_options = {}
-      flash_options[:notice] = "#{uploaded} #{"file".pluralize(uploaded)} uploaded." if uploaded.positive?
-      flash_options[:alert] = errors.join(" ") if errors.any?
-      redirect_to plan_path(@plan, anchor: "footnote-attachments"), flash_options
+      notice = "#{uploaded} #{"file".pluralize(uploaded)} uploaded." if uploaded.positive?
+      alert = errors.join(" ") if errors.any?
+
+      respond_to do |format|
+        # In-place: swap the attachments section where it stands and toast —
+        # never bounce the reader to the top of the plan they're in.
+        format.turbo_stream { render_attachments_update(notice: notice, alert: alert) }
+        format.html do
+          redirect_to plan_path(@plan, anchor: "footnote-attachments"),
+            { notice: notice, alert: alert }.compact
+        end
+      end
     end
 
     def destroy
@@ -43,13 +54,41 @@ module CoPlan
         metadata: { content_type: content_type }
       )
 
-      redirect_to plan_path(@plan, anchor: "footnote-attachments"), notice: "Attachment removed."
+      respond_to do |format|
+        format.turbo_stream { render_attachments_update(notice: "Attachment removed.") }
+        format.html do
+          redirect_to plan_path(@plan, anchor: "footnote-attachments"), notice: "Attachment removed."
+        end
+      end
     end
 
     private
 
     def set_plan
       @plan = Plan.find(params[:plan_id])
+    end
+
+    # Re-renders #plan-attachments in place plus a bottom-corner toast per
+    # message — the whole point is that the reader's scroll position never
+    # moves.
+    def render_attachments_update(notice: nil, alert: nil)
+      attachments = @plan.attachments_attachments.includes(:blob).order(created_at: :desc)
+      streams = [
+        turbo_stream.replace("plan-attachments",
+          partial: "coplan/plans/attachments",
+          locals: { plan: @plan, attachments: attachments })
+      ]
+      streams << toast_stream(notice, "notice") if notice
+      streams << toast_stream(alert, "alert") if alert
+      render turbo_stream: streams
+    end
+
+    def toast_stream(message, kind)
+      turbo_stream.append("coplan-toasts",
+        helpers.content_tag(:div, message,
+          class: "flash flash--#{kind} toasts__toast",
+          role: "status",
+          data: { controller: "coplan--toast" }))
     end
   end
 end

--- a/engine/app/controllers/coplan/attachments_controller.rb
+++ b/engine/app/controllers/coplan/attachments_controller.rb
@@ -76,11 +76,20 @@ module CoPlan
       streams = [
         turbo_stream.replace("plan-attachments",
           partial: "coplan/plans/attachments",
-          locals: { plan: @plan, attachments: attachments })
+          locals: { plan: @plan, attachments: attachments }),
+        # The count shows in the footnote header AND the document outline —
+        # both were rendered by the redirect this stream response replaced.
+        count_stream("attachments-count", attachments.size),
+        count_stream("nav-attachments-count", attachments.size)
       ]
       streams << toast_stream(notice, "notice") if notice
       streams << toast_stream(alert, "alert") if alert
       render turbo_stream: streams
+    end
+
+    def count_stream(id, count)
+      turbo_stream.replace(id,
+        html: helpers.content_tag(:span, count, class: "section-count", id: id))
     end
 
     def toast_stream(message, kind)

--- a/engine/app/controllers/coplan/references_controller.rb
+++ b/engine/app/controllers/coplan/references_controller.rb
@@ -88,6 +88,12 @@ module CoPlan
         turbo_stream.replace(
           "references-count",
           html: helpers.content_tag(:span, references.size, class: "section-count", id: "references-count")
+        ),
+        # The document outline shows the same count; without this it goes
+        # stale the moment a reference is added or removed.
+        turbo_stream.replace(
+          "nav-references-count",
+          html: helpers.content_tag(:span, references.size, class: "section-count", id: "nav-references-count")
         )
       ]
     end

--- a/engine/app/helpers/coplan/plans_helper.rb
+++ b/engine/app/helpers/coplan/plans_helper.rb
@@ -32,11 +32,11 @@ module CoPlan
       flags << hidden_state_flag("Archived", "Hidden from lists unless filtered for") if plan.archived?
       return "".html_safe if flags.empty?
 
-      safe_join([" ", safe_join(flags, " ")])
+      safe_join([ " ", safe_join(flags, " ") ])
     end
 
     def hidden_state_flag(label, title)
-      content_tag(:span, safe_join([HIDDEN_EYE_ICON, label]), class: "state-flag", title: title)
+      content_tag(:span, safe_join([ HIDDEN_EYE_ICON, label ]), class: "state-flag", title: title)
     end
 
     # Built-in icon set for plan types (lucide outlines, matching the rest
@@ -53,7 +53,7 @@ module CoPlan
       "map" => %(<path d="M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z"/><path d="M15 5.764v15"/><path d="M9 3.236v15"/>),
       "flask" => %(<path d="M10 2v7.527a2 2 0 0 1-.211.896L4.72 20.55a1 1 0 0 0 .9 1.45h12.76a1 1 0 0 0 .9-1.45l-5.069-10.127A2 2 0 0 1 14 9.527V2"/><path d="M8.5 2h7"/><path d="M7 16h10"/>),
       "shield" => %(<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/>),
-      "wrench" => %(<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>),
+      "wrench" => %(<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>)
     }.freeze
 
     # How many tint classes exist in CSS (.plan-type-icon--0 … --N-1).
@@ -89,8 +89,8 @@ module CoPlan
       # full Commonmarker + Nokogiri parse per plan without an AI summary.
       # The document body itself is fetched only on a cache miss — list pages
       # preload just the stub (id + sha), never the MEDIUMTEXT columns.
-      cache_key = ["coplan/plan-preview", MarkdownHelper::RENDER_CACHE_VERSION, plan.id,
-                   stub.content_sha256 || plan.current_revision]
+      cache_key = [ "coplan/plan-preview", MarkdownHelper::RENDER_CACHE_VERSION, plan.id,
+                   stub.content_sha256 || plan.current_revision ]
       plain = Rails.cache.fetch(cache_key) do
         markdown_to_plain_text(PlanVersion.where(id: stub.id).pick(:content_markdown))
       end

--- a/engine/app/javascript/controllers/coplan/dropzone_controller.js
+++ b/engine/app/javascript/controllers/coplan/dropzone_controller.js
@@ -1,10 +1,14 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Styled replacement for a native file input, attached to the upload form:
-// click the zone (or drag files onto it) and the form submits as soon as
+// click the zone (or drag files onto it) and the upload starts as soon as
 // files are chosen — no separate Upload button.
+//
+// Uploads go over XHR (fetch has no upload progress) so the zone can show a
+// real progress bar, then the server's Turbo Stream response swaps the
+// attachments section in place — the page never reloads or scrolls.
 export default class extends Controller {
-  static targets = ["input", "zone", "label"]
+  static targets = ["input", "zone", "label", "progress", "fill"]
 
   open() {
     this.inputTarget.click()
@@ -33,10 +37,69 @@ export default class extends Controller {
 
   submit() {
     const count = this.inputTarget.files.length
-    if (this.hasLabelTarget) {
-      this.labelTarget.textContent = `Uploading ${count} ${count === 1 ? "file" : "files"}…`
-    }
+    const noun = count === 1 ? "file" : "files"
+    this.originalLabel ??= this.hasLabelTarget ? this.labelTarget.textContent : null
+    if (this.hasLabelTarget) this.labelTarget.textContent = `Uploading ${count} ${noun}… 0%`
     this.zoneTarget.classList.add("dropzone--busy")
-    this.element.requestSubmit()
+    this.#setProgress(0)
+
+    const xhr = new XMLHttpRequest()
+    xhr.open("POST", this.element.action)
+    xhr.setRequestHeader("Accept", "text/vnd.turbo-stream.html, text/html")
+    const token = document.querySelector('meta[name="csrf-token"]')?.content
+    if (token) xhr.setRequestHeader("X-CSRF-Token", token)
+
+    xhr.upload.addEventListener("progress", event => {
+      if (!event.lengthComputable) return
+      const percent = Math.round((event.loaded / event.total) * 100)
+      this.#setProgress(percent)
+      if (this.hasLabelTarget) {
+        this.labelTarget.textContent = percent < 100
+          ? `Uploading ${count} ${noun}… ${percent}%`
+          : "Processing…"
+      }
+    })
+
+    xhr.addEventListener("load", () => {
+      const type = xhr.getResponseHeader("Content-Type") || ""
+      if (xhr.status < 300 && type.includes("turbo-stream") && window.Turbo) {
+        // Replaces #plan-attachments (this form included) and toasts —
+        // nothing to reset here, the fresh render is the reset.
+        window.Turbo.renderStreamMessage(xhr.responseText)
+      } else if (xhr.status < 400 && window.Turbo) {
+        // Non-stream success (redirect followed to HTML): fall back to a
+        // proper visit of wherever we landed.
+        window.Turbo.visit(xhr.responseURL || window.location.href)
+      } else {
+        this.#fail(`Upload failed (${xhr.status}). Try again.`)
+      }
+    })
+
+    xhr.addEventListener("error", () => this.#fail("Upload failed — check your connection and try again."))
+
+    xhr.send(new FormData(this.element))
+  }
+
+  #setProgress(percent) {
+    if (!this.hasProgressTarget) return
+    this.progressTarget.hidden = false
+    if (this.hasFillTarget) this.fillTarget.style.width = `${percent}%`
+  }
+
+  #fail(message) {
+    this.zoneTarget.classList.remove("dropzone--busy")
+    if (this.hasProgressTarget) this.progressTarget.hidden = true
+    if (this.hasLabelTarget && this.originalLabel) this.labelTarget.textContent = this.originalLabel
+    // Clear the selection so picking the same file again re-fires change.
+    this.inputTarget.value = ""
+
+    const container = document.getElementById("coplan-toasts")
+    if (!container) return alert(message)
+    const toast = document.createElement("div")
+    toast.className = "flash flash--alert toasts__toast"
+    toast.setAttribute("role", "status")
+    toast.dataset.controller = "coplan--toast"
+    toast.textContent = message
+    container.appendChild(toast)
   }
 }

--- a/engine/app/javascript/controllers/coplan/dropzone_controller.js
+++ b/engine/app/javascript/controllers/coplan/dropzone_controller.js
@@ -10,6 +10,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["input", "zone", "label", "progress", "fill"]
 
+  disconnect() {
+    // Turbo navigation mid-upload: every plan page has the same
+    // #plan-attachments target, so a late response from plan A would
+    // happily replace plan B's section. Abort — the upload belongs to a
+    // page that no longer exists.
+    this.xhr?.abort()
+    this.xhr = null
+  }
+
   open() {
     this.inputTarget.click()
   }
@@ -61,6 +70,7 @@ export default class extends Controller {
     })
 
     xhr.addEventListener("load", () => {
+      this.xhr = null
       const type = xhr.getResponseHeader("Content-Type") || ""
       if (xhr.status < 300 && type.includes("turbo-stream") && window.Turbo) {
         // Replaces #plan-attachments (this form included) and toasts —
@@ -75,8 +85,12 @@ export default class extends Controller {
       }
     })
 
-    xhr.addEventListener("error", () => this.#fail("Upload failed — check your connection and try again."))
+    xhr.addEventListener("error", () => {
+      this.xhr = null
+      this.#fail("Upload failed — check your connection and try again.")
+    })
 
+    this.xhr = xhr
     xhr.send(new FormData(this.element))
   }
 

--- a/engine/app/javascript/controllers/coplan/folder_dnd_controller.js
+++ b/engine/app/javascript/controllers/coplan/folder_dnd_controller.js
@@ -14,11 +14,69 @@ import { Controller } from "@hotwired/stimulus"
 const PLAN_MIME = "application/x-coplan-plan"
 const FOLDER_MIME = "application/x-coplan-folder"
 const DROP_CLASS = "dnd-drop"
+const BUSY_CLASS = "dnd-drop--busy"
+
+// Spring-loaded folders, Finder-style: hover a drag over a folder, it
+// pulses twice, then springs open.
+//
+// - Sidebar: a collapsed tree branch expands in place (and snaps shut when
+//   the drag moves off it), so you can dive multiple levels while dragging.
+// - Main pane: springing a folder row (or a breadcrumb, to go up) TUNNELS —
+//   the pane temporarily becomes that folder's real level view, exactly as
+//   if you'd navigated, prefetched during the pulses. Keep tunneling deeper
+//   through its folder rows; drop anywhere in the pane (dead space included)
+//   to file right there; end the drag without dropping and the original
+//   pane is restored untouched.
+const SPRING_CLASS = "dnd-spring"
+const SPRING_DELAY = 650 // two 0.3s pulses, then open
 
 export default class extends Controller {
 
+  connect() {
+    // Swallow the click some browsers fire on the source link right after a
+    // drag — press-drag-release must never read as "open the plan".
+    this.element.addEventListener("click", this.#clickGuard, true)
+    // Watch where the drag actually is, workspace-wide: a pending spring is
+    // cancelled and sprung-open sidebar branches snap shut as soon as the
+    // cursor moves somewhere they don't contain. Capture phase: targets
+    // stop dragover propagation (innermost target wins), which must not
+    // starve this sweep.
+    this.element.addEventListener("dragover", this.#springSweep, true)
+    this.springs = []
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this.#clickGuard, true)
+    this.element.removeEventListener("dragover", this.#springSweep, true)
+    this.#cancelPendingSpring()
+    this.#collapseAllSprings()
+    this.#restoreTunnel()
+  }
+
+  #clickGuard = (event) => {
+    if (!this.dragHappened) return
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  #springSweep = (event) => {
+    const over = event.target
+    if (over === this.lastSweepTarget) return
+    this.lastSweepTarget = over
+    if (this.springPendingEl && !this.springPendingEl.contains(over)) this.#cancelPendingSpring()
+    // Close sprung folders newest-first until one still holds the cursor.
+    while (this.springs.length) {
+      const top = this.springs[this.springs.length - 1]
+      if (top.keepAlive.some(el => el.contains(over))) break
+      this.springs.pop().close()
+    }
+  }
+
   dragStart(event) {
     const row = event.currentTarget
+    this.dragHappened = true
+    this.dragActive = true
+    this.dragSourceEl = row
     event.dataTransfer.effectAllowed = "move"
     // The move URL and current folder ride along in the drag payload
     // (readable on drop) — the folder so a drop where the plan already
@@ -35,6 +93,9 @@ export default class extends Controller {
   dragEnd(event) {
     event.currentTarget.classList.remove("plan-row--dragging")
     this.element.classList.remove("workspace--dragging")
+    // The stray post-drag click (when it comes at all) fires before timers,
+    // so a 0ms clear still covers it without eating the next real click.
+    this.#dragCleanup()
   }
 
   folderDragStart(event) {
@@ -42,6 +103,9 @@ export default class extends Controller {
     // bubble into any other draggable ancestor.
     event.stopPropagation()
     const node = event.currentTarget
+    this.dragHappened = true
+    this.dragActive = true
+    this.dragSourceEl = node
     event.dataTransfer.effectAllowed = "move"
     event.dataTransfer.setData(FOLDER_MIME, JSON.stringify({
       url: node.dataset.reparentUrl,
@@ -56,22 +120,192 @@ export default class extends Controller {
   folderDragEnd(event) {
     event.currentTarget.classList.remove("folder-tree__link--dragging")
     this.element.classList.remove("workspace--dragging")
+    this.#dragCleanup()
   }
 
   dragOver(event) {
     if (!this.#accepts(event)) return
     event.preventDefault()
+    // Innermost target wins: a folder row inside the pane highlights alone,
+    // without also lighting up the pane-wide target behind it.
+    event.stopPropagation()
     event.dataTransfer.dropEffect = "move"
-    event.currentTarget.classList.add(DROP_CLASS)
+    const target = event.currentTarget
+    // Exactly one live target at a time (also mops up any highlight a
+    // missed dragleave left behind).
+    this.element.querySelectorAll(`.${DROP_CLASS}`).forEach(el => {
+      if (el !== target) el.classList.remove(DROP_CLASS)
+    })
+    target.classList.add(DROP_CLASS)
+    this.#springHover(target)
   }
 
   dragLeave(event) {
+    // dragleave also fires when the cursor moves onto a *child* of the
+    // target (the folder name, the icon) — dropping the highlight there
+    // makes it flicker while you're hovering dead-center on the folder.
+    if (event.currentTarget.contains(event.relatedTarget)) return
     event.currentTarget.classList.remove(DROP_CLASS)
+    if (this.springPendingEl === event.currentTarget) this.#cancelPendingSpring()
+  }
+
+  // ----- Spring-loading -----
+
+  #springHover(el) {
+    if (this.springPendingEl === el) return                      // pulses already running
+    if (this.springs.some(s => s.owner === el)) return           // already sprung open
+
+    this.#cancelPendingSpring()
+    const action = this.#springAction(el)
+    if (!action) return
+
+    action.prefetch?.()
+    this.springPendingEl = el
+    el.classList.add(SPRING_CLASS)
+    this.springTimer = setTimeout(() => {
+      this.#cancelPendingSpring()
+      const entry = action.open()
+      if (entry) this.springs.push(entry)
+    }, SPRING_DELAY)
+  }
+
+  // What springing this element would do — or null if nothing's behind it.
+  // Sidebar branches return a {owner, keepAlive, close} entry (they revert
+  // as soon as the drag leaves them); tunnels manage their own lifetime
+  // (they persist until the drag ends).
+  #springAction(el) {
+    // Sidebar: the summary link of a collapsed <details> branch.
+    if (el.classList.contains("folder-tree__link")) {
+      const details = el.closest("summary")?.parentElement
+      if (!details || details.open) return null
+      return {
+        open: () => {
+          details.open = true
+          return { owner: el, keepAlive: [details], close: () => { details.open = false } }
+        }
+      }
+    }
+
+    // Main pane: folder rows tunnel in, breadcrumbs tunnel back up — the
+    // pane temporarily becomes that folder's real level view. Any folder
+    // (empty included: tunnel in, drop on the empty pane to file there).
+    if (el.classList.contains("folder-row") ||
+        (el.classList.contains("workspace-crumbs__crumb") &&
+         !el.classList.contains("workspace-crumbs__crumb--current"))) {
+      const url = el.href
+      if (!url) return null
+      return {
+        prefetch: () => this.#prefetchPane(url),
+        open: () => { this.#tunnel(url); return null }
+      }
+    }
+
+    return null
+  }
+
+  // ----- Tunneling (temporary in-drag navigation of the main pane) -----
+
+  #prefetchPane(url) {
+    if (this.paneCache?.url === url) return this.paneCache.promise
+    const promise = fetch(url, { headers: { "Accept": "text/html" } })
+      .then(response => {
+        if (!response.ok) throw new Error(`prefetch ${response.status}`)
+        return response.text()
+      })
+      .then(html => new DOMParser().parseFromString(html, "text/html"))
+    // Swallow here so an abandoned prefetch never surfaces as an unhandled
+    // rejection; #tunnel re-awaits the cached promise and handles failure.
+    promise.catch(() => {})
+    this.paneCache = { url, promise }
+    return promise
+  }
+
+  async #tunnel(url) {
+    let doc
+    try { doc = await this.#prefetchPane(url) } catch { return }
+    // The world may have moved on while the fetch ran.
+    if (!this.dragActive) return
+    const main = this.element.querySelector(".workspace__main")
+    const incoming = doc.querySelector(".workspace__main")
+    if (!main || !incoming) return
+
+    if (!this.tunnelHome) {
+      // Keep the dragged row's node in the document — removing the drag
+      // source mid-drag makes browsers skip dragend entirely, leaking the
+      // whole drag state. It waits out the tunnel in a hidden stash.
+      if (this.dragSourceEl && main.contains(this.dragSourceEl)) {
+        this.sourceHome = { parent: this.dragSourceEl.parentNode, next: this.dragSourceEl.nextSibling }
+        this.#stash().appendChild(this.dragSourceEl)
+      }
+      this.tunnelHome = { nodes: Array.from(main.childNodes) }
+      this.homeFolderId = main.dataset.folderId
+    }
+    main.replaceChildren(...incoming.childNodes)
+    // Swap the pane's own drop identity too — dead-space drops now file
+    // into the tunneled folder.
+    main.dataset.folderId = incoming.dataset.folderId || ""
+    this.tunnelUrl = url
+    // Restart the entrance animation for each level.
+    main.classList.remove("workspace__main--tunneled")
+    void main.offsetWidth
+    main.classList.add("workspace__main--tunneled")
+  }
+
+  #restoreTunnel() {
+    if (!this.tunnelHome) return
+    const main = this.element.querySelector(".workspace__main")
+    if (main) {
+      main.replaceChildren(...this.tunnelHome.nodes)
+      main.dataset.folderId = this.homeFolderId ?? main.dataset.folderId
+      main.classList.remove("workspace__main--tunneled")
+    }
+    if (this.dragSourceEl && this.sourceHome?.parent?.isConnected) {
+      this.sourceHome.parent.insertBefore(this.dragSourceEl, this.sourceHome.next)
+    }
+    this.tunnelHome = null
+    this.tunnelUrl = null
+    this.sourceHome = null
+  }
+
+  #stash() {
+    if (!this.stashEl) {
+      this.stashEl = document.createElement("div")
+      this.stashEl.style.display = "none"
+      this.element.appendChild(this.stashEl)
+    }
+    return this.stashEl
+  }
+
+  #cancelPendingSpring() {
+    clearTimeout(this.springTimer)
+    this.springPendingEl?.classList.remove(SPRING_CLASS)
+    this.springPendingEl = null
+  }
+
+  #collapseAllSprings() {
+    while (this.springs.length) this.springs.pop().close()
+  }
+
+  #dragCleanup() {
+    this.dragActive = false
+    this.#cancelPendingSpring()
+    this.paneCache = null
+    // A committed drop keeps the tunneled pane and its pulsing target on
+    // screen until the refresh lands (or the move fails); an abandoned
+    // drag snaps everything back to where it started.
+    if (!this.dropCommitted) {
+      this.#collapseAllSprings()
+      this.#restoreTunnel()
+    }
+    setTimeout(() => { this.dragHappened = false }, 0)
   }
 
   drop(event) {
     if (!this.#accepts(event)) return
     event.preventDefault()
+    // Same innermost-target-wins rule as dragOver: a drop on a folder row
+    // must not also fire the pane-wide "file here" target behind it.
+    event.stopPropagation()
     const target = event.currentTarget
     target.classList.remove(DROP_CLASS)
 
@@ -85,14 +319,14 @@ export default class extends Controller {
       // no-op, not a PATCH + reload + toast.
       if (payload.id && payload.id === targetFolderId) return
       if ((payload.parentId || "") === targetFolderId) return
-      this.#patch(payload.url, { parent_id: targetFolderId }, "Folder moved.")
+      this.#patch(payload.url, { parent_id: targetFolderId }, "Folder moved.", target)
     } else {
       let payload = {}
       try { payload = JSON.parse(event.dataTransfer.getData(PLAN_MIME)) } catch {}
       if (!payload.url) return
       // Same quiet no-op when the plan is already filed right here.
       if ((payload.folderId || "") === targetFolderId) return
-      this.#patch(payload.url, { folder_id: targetFolderId }, "Plan moved.")
+      this.#patch(payload.url, { folder_id: targetFolderId }, "Plan moved.", target)
     }
   }
 
@@ -101,7 +335,16 @@ export default class extends Controller {
     return types.includes(PLAN_MIME) || types.includes(FOLDER_MIME)
   }
 
-  #patch(url, body, fallbackMessage) {
+  #patch(url, body, fallbackMessage, target) {
+    // The PATCH + page refresh takes a beat — show it immediately: the drop
+    // target pulses, the dragged row stays ghosted, the cursor says busy.
+    // (drop fires before dragend, so the --dragging source is still marked.)
+    this.dropCommitted = true
+    target?.classList.add(BUSY_CLASS)
+    this.element.classList.add("workspace--moving")
+    this.element.querySelector(".plan-row--dragging, .folder-tree__link--dragging")
+      ?.classList.add("dnd-source--moving")
+
     const token = document.querySelector('meta[name="csrf-token"]')?.content
     fetch(url, {
       method: "PATCH",
@@ -120,12 +363,31 @@ export default class extends Controller {
         const message = data.message || fallbackMessage
         if (window.Turbo) {
           document.addEventListener("turbo:load", () => this.#toast(message, "notice"), { once: true })
-          window.Turbo.visit(window.location.href, { action: "replace" })
+          // A drop inside a tunneled folder lands you there for real —
+          // Finder leaves you in the window you sprang into.
+          if (this.tunnelUrl) {
+            window.Turbo.visit(this.tunnelUrl, { action: "advance" })
+          } else {
+            window.Turbo.visit(window.location.href, { action: "replace" })
+          }
         } else {
           this.#toast(message, "notice")
+          this.#clearBusy(target)
         }
       })
-      .catch(error => this.#toast(error.message, "alert"))
+      .catch(error => {
+        this.#clearBusy(target)
+        this.#toast(error.message, "alert")
+      })
+  }
+
+  #clearBusy(target) {
+    this.dropCommitted = false
+    target?.classList.remove(BUSY_CLASS)
+    this.element.classList.remove("workspace--moving")
+    this.element.querySelector(".dnd-source--moving")?.classList.remove("dnd-source--moving")
+    this.#collapseAllSprings()
+    this.#restoreTunnel()
   }
 
   #toast(message, kind) {

--- a/engine/app/javascript/controllers/coplan/plan_bookmark_controller.js
+++ b/engine/app/javascript/controllers/coplan/plan_bookmark_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Mounts the save bookmark into the plan header's title row. The bookmark
+// is viewer-relative (saved state, move URL) so it can't be rendered inside
+// the broadcast-replaced #plan-header partial — instead the show view
+// renders it into a <template> and this controller stamps a fresh copy into
+// #plan-bookmark-slot on load and again after every broadcast replaces the
+// header.
+export default class extends Controller {
+  static targets = ["template"]
+
+  connect() {
+    this.observer = new MutationObserver(() => this.#mount())
+    this.observer.observe(this.element, { childList: true, subtree: true })
+    this.#mount()
+  }
+
+  disconnect() {
+    this.observer.disconnect()
+  }
+
+  #mount() {
+    if (!this.hasTemplateTarget) return
+    const slot = this.element.querySelector("#plan-bookmark-slot")
+    // Stamping into the slot re-fires the observer; the childElementCount
+    // check makes that re-entry a no-op instead of a loop.
+    if (!slot || slot.childElementCount > 0) return
+    slot.append(this.templateTarget.content.cloneNode(true))
+  }
+}

--- a/engine/app/javascript/controllers/coplan/plan_keys_controller.js
+++ b/engine/app/javascript/controllers/coplan/plan_keys_controller.js
@@ -9,6 +9,16 @@ import { Controller } from "@hotwired/stimulus"
 //                (references, attachments)
 //
 // Sections register via data-plan-section attributes, in document order.
+
+// Turbo Drive navigates with pushState + fetch, so document.referrer never
+// updates after the first real page load — it can't answer "did we get here
+// from inside the app?". Track that ourselves: any Turbo visit in this tab
+// means there's in-app history worth going back to. (Module scope survives
+// Turbo navigations; a full reload resets it, but a full reload also sets a
+// real referrer, so the two checks cover each other.)
+let visitedInApp = false
+document.addEventListener("turbo:visit", () => { visitedInApp = true })
+
 export default class extends Controller {
   static values = { fallbackUrl: String }
 
@@ -47,10 +57,12 @@ export default class extends Controller {
   }
 
   _goBack() {
-    // Same-app referrer: real back, preserving scroll and history. A cold
+    // Came from inside the app (Turbo visit or full-load referrer): real
+    // back, preserving the folder you were in, scroll, and history. A cold
     // open (direct link, new tab) has nowhere to go back to — visit the
     // fallback instead.
-    if (document.referrer.startsWith(window.location.origin) && window.history.length > 1) {
+    const cameFromApp = visitedInApp || document.referrer.startsWith(window.location.origin)
+    if (cameFromApp && window.history.length > 1) {
       window.history.back()
     } else if (this.hasFallbackUrlValue && window.Turbo) {
       window.Turbo.visit(this.fallbackUrlValue)

--- a/engine/app/javascript/controllers/coplan/toast_controller.js
+++ b/engine/app/javascript/controllers/coplan/toast_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// A self-dismissing toast. Server-rendered Turbo Stream toasts append into
+// #coplan-toasts with this controller attached; it fades the toast out and
+// removes it. (Client-built toasts in folder_dnd manage their own timer.)
+export default class extends Controller {
+  static values = { duration: { type: Number, default: 4000 } }
+
+  connect() {
+    this.timer = setTimeout(() => this.element.remove(), this.durationValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timer)
+  }
+}

--- a/engine/app/models/coplan/folder.rb
+++ b/engine/app/models/coplan/folder.rb
@@ -94,10 +94,11 @@ module CoPlan
       by_id = folders.index_by(&:id)
       folders.index_with do |folder|
         names = [ folder.name ]
+        seen = Set.new([ folder.id ])
         node = folder
         while node.parent_id && (node = by_id[node.parent_id])
+          break unless seen.add?(node.id) # cycle guard on bad data
           names.unshift(node.name)
-          break if names.length > MAX_DEPTH # cycle guard on bad data
         end
         names.join("/")
       end.transform_keys(&:id)

--- a/engine/app/views/coplan/plans/_attachments.html.erb
+++ b/engine/app/views/coplan/plans/_attachments.html.erb
@@ -72,8 +72,7 @@
       <% end %>
     </ul>
   <% else %>
-    <div class="empty-state">
-      <p>No attachments yet.<% if can_add %> Upload files to share diagrams, screenshots, or documents alongside the plan.<% end %></p>
-    </div>
+    <%# One quiet line, not a padded card — empty is the common case. %>
+    <p class="plan-footnote__empty">None yet<% if can_add %> — use the + to add screenshots, diagrams, or files<% end %>.</p>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/_attachments.html.erb
+++ b/engine/app/views/coplan/plans/_attachments.html.erb
@@ -7,8 +7,9 @@
   <% if can_add %>
     <%= render layout: "coplan/shared/add_modal", locals: { id: "add-attachment-modal", title: "Add files" } do %>
         <%# One designed dropzone instead of the native file input: click to
-            browse or drag files on; choosing files uploads immediately (the
-            upload redirect reloads the page, which closes the lightbox). %>
+            browse or drag files on; choosing files uploads immediately with
+            a live progress bar, then the server's Turbo Stream re-renders
+            this whole section in place — no reload, no scroll jump. %>
         <%= form_with url: plan_attachments_path(plan), method: :post, multipart: true,
               class: "attachments-upload", data: { controller: "coplan--dropzone" } do |f| %>
           <button type="button" class="dropzone" data-coplan--dropzone-target="zone"
@@ -16,6 +17,9 @@
             <svg class="dropzone__icon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M12 12v9"/><path d="m16 16-4-4-4 4"/></svg>
             <span class="dropzone__title" data-coplan--dropzone-target="label">Drop files here, or click to browse</span>
             <span class="dropzone__hint">Images, PDF, text, markdown, CSV, JSON, ZIP · up to <%= CoPlan::Plan::ATTACHMENT_MAX_BYTES / 1.megabyte %> MB each</span>
+            <span class="dropzone__progress" data-coplan--dropzone-target="progress" hidden>
+              <span class="dropzone__progress-fill" data-coplan--dropzone-target="fill"></span>
+            </span>
           </button>
           <%= f.file_field :files, multiple: true, name: "files[]", class: "dropzone__input",
                 accept: CoPlan::Plan::ATTACHMENT_CONTENT_TYPES.join(","),

--- a/engine/app/views/coplan/plans/_footnotes.html.erb
+++ b/engine/app/views/coplan/plans/_footnotes.html.erb
@@ -1,0 +1,32 @@
+<%# Back matter: references and attachments close out the document inside
+    the content column — separated from the prose by a rule, not banished
+    below the sidebar where long outlines made them collide. Each section
+    is one quiet header line (+, title, count); empty sections stay one
+    line tall. %>
+<div class="plan-footnotes">
+  <section class="plan-footnote" id="footnote-references" data-plan-section="references" aria-labelledby="footnote-references-title">
+    <div class="plan-footnote__header">
+      <% if current_user && allowed_to?(plan, :contribute?) %>
+        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a reference" aria-label="Add a reference">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+        </button>
+      <% end %>
+      <h2 class="plan-footnote__title" id="footnote-references-title">References</h2>
+      <span class="section-count" id="references-count"><%= references.size %></span>
+    </div>
+    <%= render partial: "coplan/plans/references", locals: { references: references, plan: plan } %>
+  </section>
+
+  <section class="plan-footnote" id="footnote-attachments" data-plan-section="attachments" aria-labelledby="footnote-attachments-title">
+    <div class="plan-footnote__header">
+      <% if current_user && allowed_to?(plan, :contribute?) %>
+        <button type="button" class="section-add" popovertarget="add-attachment-modal" title="Add files" aria-label="Add files">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+        </button>
+      <% end %>
+      <h2 class="plan-footnote__title" id="footnote-attachments-title">Attachments</h2>
+      <span class="section-count" id="attachments-count"><%= attachments.size %></span>
+    </div>
+    <%= render partial: "coplan/plans/attachments", locals: { attachments: attachments, plan: plan } %>
+  </section>
+</div>

--- a/engine/app/views/coplan/plans/_header.html.erb
+++ b/engine/app/views/coplan/plans/_header.html.erb
@@ -6,11 +6,20 @@
     <div class="page-header__title-row">
       <%= plan_type_icon(plan, size: :lg) %>
       <h1 class="page-header__title"><%= plan.title %></h1>
+      <%# The save bookmark mounts here from outside this partial: it's
+          viewer-relative (needs current_user), and this header re-renders
+          from broadcasts where there is none — plan_bookmark_controller
+          re-stamps it after every replace. %>
+      <span id="plan-bookmark-slot" class="plan-bookmark-slot"></span>
     </div>
     <div class="page-header__byline text-sm text-muted">
       <%= user_avatar(plan.created_by_user) %> <%= profile_link(plan.created_by_user) %> · v<%= plan.current_revision %><%= plan_state_badge(plan) %>
+      <%# A tag on someone's plan reads as "find more like this", not "filter
+          my workspace" (which is what the row chips in YOUR workspace do) —
+          so it's a search, org-wide. search_text indexes tag names. %>
       <% plan.tags.each do |tag| %>
-        <%= link_to tag.name, plans_path(tag: tag.name), class: "badge badge--tag" %>
+        <%= link_to tag.name, search_path(q: tag.name), class: "badge badge--tag",
+              title: "Search plans tagged “#{tag.name}”" %>
       <% end %>
     </div>
   </div>

--- a/engine/app/views/coplan/plans/_plan_row.html.erb
+++ b/engine/app/views/coplan/plans/_plan_row.html.erb
@@ -24,7 +24,12 @@
   <span class="plan-row__icon"><%= plan_type_icon(plan, size: :lg) %></span>
   <div class="plan-row__main">
     <div class="plan-row__line">
-      <%= link_to plan.title, plan_path(plan), class: "plan-row__title", draggable: false, data: { turbo_frame: "_top" } %><%= plan_state_badge(plan) %>
+      <%# Stretched link: the title's ::after covers the whole card, so a
+          click anywhere navigates and a hover anywhere prefetches the plan
+          (Turbo 8 hover prefetch) — native link semantics (middle/cmd
+          click) included. Other links/buttons in the row sit above it. %>
+      <%= link_to plan.title, plan_path(plan), class: "plan-row__title", draggable: false,
+            data: { turbo_frame: "_top", turbo_prefetch: true } %><%= plan_state_badge(plan) %>
       <% if my_folder_id && my_folder_id != local_assigns[:suppress_folder_id] %>
         <%= link_to workspace_path(folder: my_folder_id),
               class: "plan-row__folder", draggable: false, data: { turbo_frame: "_top" } do %>

--- a/engine/app/views/coplan/plans/_plan_row.html.erb
+++ b/engine/app/views/coplan/plans/_plan_row.html.erb
@@ -37,35 +37,18 @@
           <%= folder_paths_by_id[my_folder_id] %>
         <% end %>
       <% end %>
-      <% plan.tags.each do |tag| %>
-        <%= link_to tag.name,
-              workspace_path(tag: tag.name),
-              class: "badge badge--tag #{'badge--tag-active' if params[:tag] == tag.name}",
-              draggable: false,
-              data: { turbo_frame: "_top" } %>
-      <% end %>
-      <span class="plan-row__spacer"></span>
       <% if unread > 0 %>
         <span class="inbox-badge" title="<%= pluralize(unread, "unread comment") %>"><%= unread %></span>
       <% end %>
-      <span class="plan-row__time text-muted" title="<%= plan.updated_at %>"><%= time_ago_in_words(plan.updated_at) %> ago</span>
-      <span class="plan-row__avatar"><%= link_to user_avatar(plan.created_by_user), profile_path_for(plan.created_by_user), title: plan.created_by_user.name, draggable: false, data: { turbo_frame: "_top" } %></span>
-      <%# Bookmark = the keyboard/no-drag path into the folder navigator.
-          Saved rows unsave on the second click, quietly. %>
-      <button type="button"
-              class="plan-row__save<%= " plan-row__save--saved" if my_folder_id %>"
-              data-action="coplan--folder-picker#open"
-              data-move-url="<%= move_to_folder_plan_path(plan) %>"
-              data-current-folder-id="<%= my_folder_id %>"
-              data-saved="<%= my_folder_id.present? %>"
-              data-plan-title="<%= plan.title %>"
-              title="<%= my_folder_id ? "Saved — click to remove from your library" : "Save to a folder in your library" %>"
-              aria-label="<%= my_folder_id ? "Remove “#{plan.title}” from your library" : "Save “#{plan.title}” to your library" %>">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="<%= my_folder_id ? "currentColor" : "none" %>" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/></svg>
-      </button>
     </div>
     <% if summary.present? %>
       <p class="plan-row__summary text-muted"><%= summary %></p>
     <% end %>
+  </div>
+  <%# Byline, anchored to the card's top-right corner regardless of how the
+      title wraps — a floating "author · when" would read as misalignment. %>
+  <div class="plan-row__meta">
+    <span class="plan-row__time text-muted" title="<%= plan.updated_at %>"><%= time_ago_in_words(plan.updated_at) %> ago</span>
+    <span class="plan-row__avatar"><%= link_to user_avatar(plan.created_by_user), profile_path_for(plan.created_by_user), title: plan.created_by_user.name, draggable: false, data: { turbo_frame: "_top" } %></span>
   </div>
 </article>

--- a/engine/app/views/coplan/plans/_references.html.erb
+++ b/engine/app/views/coplan/plans/_references.html.erb
@@ -55,8 +55,7 @@
       <% end %>
     </ul>
   <% else %>
-    <div class="empty-state">
-      <p>No references yet. Links in the plan content are auto-extracted, or add one manually.</p>
-    </div>
+    <%# One quiet line, not a padded card — empty is the common case. %>
+    <p class="plan-footnote__empty">None yet — links in the document are picked up automatically.</p>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/_shelves.html.erb
+++ b/engine/app/views/coplan/plans/_shelves.html.erb
@@ -2,10 +2,10 @@
     rendered Drive-style — a quiet folder chip with just the folder name.
     Whose library it is lives in the tooltip (and the link target). Lives
     outside the broadcast #plan-header region — it's viewer-relative
-    (needs current_user). %>
-<% my_placement = placements.find { |p| p.library.writable_by?(current_user) } %>
-
-<% if current_user || placements.any? %>
+    (needs current_user). The save bookmark itself lives beside the title
+    (see plan_bookmark_controller), so this strip is chips-only and
+    disappears entirely when the plan sits on no one's shelf. %>
+<% if placements.any? %>
   <div class="plan-shelves">
     <% placements.each do |placement| %>
       <% mine = placement.library.writable_by?(current_user) %>
@@ -30,23 +30,5 @@
       <% end %>
     <% end %>
 
-    <% if current_user %>
-      <%# The bookmark: click to save this plan into your own library via
-          the folder navigator; click again to quietly unsave it (your own
-          plans just return to My Plans, unfiled). Filled once shelved —
-          exactly a bookmark star. %>
-      <button type="button"
-              class="plan-shelves__bookmark<%= " plan-shelves__bookmark--saved" if my_placement %>"
-              data-action="coplan--folder-picker#open"
-              data-move-url="<%= move_to_folder_plan_path(plan) %>"
-              data-current-folder-id="<%= my_placement&.folder_id %>"
-              data-saved="<%= my_placement.present? %>"
-              data-plan-title="<%= plan.title %>"
-              title="<%= my_placement ? "Saved in #{my_placement.folder.path} — click to remove" : "Save to a folder in your library" %>"
-              aria-label="<%= my_placement ? "Remove from your library" : "Save to your library" %>">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="<%= my_placement ? "currentColor" : "none" %>" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/></svg>
-        <% unless my_placement %><span class="plan-shelves__bookmark-label">Save</span><% end %>
-      </button>
-    <% end %>
   </div>
 <% end %>

--- a/engine/app/views/coplan/plans/_sidebar.html.erb
+++ b/engine/app/views/coplan/plans/_sidebar.html.erb
@@ -111,15 +111,20 @@
       <h3 class="sidebar__heading">Hidden</h3>
       <ul class="sidebar__list">
         <li>
+          <%# These read as reveals, not filters: private and archived plans
+              are excluded by default, and clicking opts IN to seeing them
+              ("show me my private plans"), click again to tuck them away. %>
           <%# "Private" is visibility, not workflow: not shared with the org,
               still readable by link. Stored as visibility=draft. %>
-          <%= link_to "Private", workspace_path(filter: @filter == "draft" ? nil : "private"),
+          <%= link_to @filter == "draft" ? "Showing private" : "Show my private plans",
+                workspace_path(filter: @filter == "draft" ? nil : "private"),
                 class: "sidebar__item #{'sidebar__item--active' if @filter == 'draft'}" %>
         </li>
         <li>
           <%# Archived plans are hidden everywhere else — this is the explicit
               opt-in view. %>
-          <%= link_to "Archived", workspace_path(filter: @filter == "archived" ? nil : "archived"),
+          <%= link_to @filter == "archived" ? "Showing archived" : "Show archived",
+                workspace_path(filter: @filter == "archived" ? nil : "archived"),
                 class: "sidebar__item sidebar__item--archived #{'sidebar__item--active' if @filter == 'archived'}" %>
         </li>
       </ul>

--- a/engine/app/views/coplan/plans/_viewers.html.erb
+++ b/engine/app/views/coplan/plans/_viewers.html.erb
@@ -4,12 +4,18 @@
       <% viewers.first(8).each do |viewer| %>
         <% is_you = defined?(current_user) && current_user&.id == viewer.id %>
         <% tooltip = is_you ? "#{viewer.name} (you)" : viewer.name %>
-        <% if viewer.avatar_url.present? %>
-          <img src="<%= viewer.avatar_url %>" alt="<%= viewer.name %>" class="plan-viewers__avatar<%= ' plan-viewers__avatar--you' if is_you %>" data-tooltip="<%= tooltip %>" loading="lazy">
-        <% else %>
-          <span class="plan-viewers__avatar<%= ' plan-viewers__avatar--you' if is_you %>" data-tooltip="<%= tooltip %>">
-            <%= viewer.name.split.map { |w| w[0] }.first(2).join.upcase %>
-          </span>
+        <%# Each viewer is a person — their avatar links to their profile
+            (and library). The tooltip lives on the link: ::after can't
+            render on a replaced element like <img>. %>
+        <%= link_to profile_path_for(viewer), class: "plan-viewers__avatar-link",
+              data: { tooltip: tooltip }, aria: { label: "#{viewer.name}’s profile" } do %>
+          <% if viewer.avatar_url.present? %>
+            <img src="<%= viewer.avatar_url %>" alt="<%= viewer.name %>" class="plan-viewers__avatar<%= ' plan-viewers__avatar--you' if is_you %>" loading="lazy">
+          <% else %>
+            <span class="plan-viewers__avatar<%= ' plan-viewers__avatar--you' if is_you %>">
+              <%= viewer.name.split.map { |w| w[0] }.first(2).join.upcase %>
+            </span>
+          <% end %>
         <% end %>
       <% end %>
       <% if viewers.size > 8 %>

--- a/engine/app/views/coplan/plans/index.html.erb
+++ b/engine/app/views/coplan/plans/index.html.erb
@@ -9,7 +9,13 @@
   <%= render "coplan/plans/sidebar" %>
   <%= render partial: "coplan/shared/folder_picker", locals: { folders: @folders } %>
 
-  <div class="workspace__main">
+  <%# The whole pane is a drop target for the folder you're looking at —
+      Finder semantics: drop on empty space to file right here. Specific
+      targets inside (folder rows, crumbs) win via stopPropagation. It also
+      carries the pane's own URL so drag-tunneling can restore/advance. %>
+  <div class="workspace__main"
+       data-folder-id="<%= @folder&.id %>"
+       data-action="dragover->coplan--folder-dnd#dragOver dragleave->coplan--folder-dnd#dragLeave drop->coplan--folder-dnd#drop">
     <%# Drive-style breadcrumb: where you are in your library. Segments are
         drop targets — drag a plan or folder onto one to move it up. %>
     <nav class="workspace-crumbs" aria-label="Folder location">

--- a/engine/app/views/coplan/plans/index.html.erb
+++ b/engine/app/views/coplan/plans/index.html.erb
@@ -5,9 +5,10 @@
   <meta name="turbo-cache-control" content="no-cache">
 <% end %>
 
-<div class="workspace" data-controller="coplan--folder-dnd coplan--workspace-keys coplan--folder-picker">
+<%# No folder picker here: rows file via drag & drop, and the plan page's
+    title bookmark covers the click path. %>
+<div class="workspace" data-controller="coplan--folder-dnd coplan--workspace-keys">
   <%= render "coplan/plans/sidebar" %>
-  <%= render partial: "coplan/shared/folder_picker", locals: { folders: @folders } %>
 
   <%# The whole pane is a drop target for the folder you're looking at —
       Finder semantics: drop on empty space to file right here. Specific

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -111,8 +111,10 @@
         <%# The document's back matter, one hop below the outline — slightly
             set apart so it reads as "after the document", not part of it. %>
         <ul class="content-nav__list content-nav__list--footnotes">
-          <li><a href="#footnote-references" class="content-nav__footnote-link">References <span class="section-count"><%= @references.size %></span></a></li>
-          <li><a href="#footnote-attachments" class="content-nav__footnote-link">Attachments <span class="section-count"><%= @attachments.size %></span></a></li>
+          <%# ids: the reference/attachment Turbo Streams keep these counts
+              live alongside the footnote headers' own counters. %>
+          <li><a href="#footnote-references" class="content-nav__footnote-link">References <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
+          <li><a href="#footnote-attachments" class="content-nav__footnote-link">Attachments <span class="section-count" id="nav-attachments-count"><%= @attachments.size %></span></a></li>
         </ul>
       </nav>
       <button type="button" class="content-nav-show-btn" data-action="coplan--content-nav#toggle" data-coplan--content-nav-target="showBtn" title="Show table of contents (t)">☰ <kbd>t</kbd></button>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -121,21 +121,29 @@
           re-run anchor highlighting once each diagram settles so comments
           anchored to diagram labels get their marks (and pending ?thread=
           deep links can resolve). %>
-      <div class="plan-layout__content" data-coplan--text-selection-target="content" data-coplan--content-nav-target="content" data-action="coplan:mermaid-settled->coplan--text-selection#handleMermaidSettled">
-        <div id="plan-content-body"
-             data-controller="coplan--live-update"
-             data-coplan--live-update-revision-value="<%= @plan.current_revision %>">
-          <%= render partial: "coplan/plans/content_body", locals: { plan: @plan } %>
+      <div class="plan-layout__content">
+        <%# Selection-to-comment is scoped to this inner wrapper: the back
+            matter below shares the column but must not offer comment
+            anchors — they'd never resolve against the document body. %>
+        <div data-coplan--text-selection-target="content" data-coplan--content-nav-target="content" data-action="coplan:mermaid-settled->coplan--text-selection#handleMermaidSettled">
+          <div id="plan-content-body"
+               data-controller="coplan--live-update"
+               data-coplan--live-update-revision-value="<%= @plan.current_revision %>">
+            <%= render partial: "coplan/plans/content_body", locals: { plan: @plan } %>
+          </div>
+
+          <div class="comment-popover" data-coplan--text-selection-target="popover" style="display: none;">
+            <button type="button" class="btn btn--primary btn--sm" data-action="coplan--text-selection#openCommentForm">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg>
+              Comment
+            </button>
+          </div>
+
+          <%= render partial: "coplan/comment_threads/new_comment_form", locals: { plan: @plan } %>
         </div>
 
-        <div class="comment-popover" data-coplan--text-selection-target="popover" style="display: none;">
-          <button type="button" class="btn btn--primary btn--sm" data-action="coplan--text-selection#openCommentForm">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></svg>
-            Comment
-          </button>
-        </div>
-
-        <%= render partial: "coplan/comment_threads/new_comment_form", locals: { plan: @plan } %>
+        <%= render partial: "coplan/plans/footnotes",
+              locals: { plan: @plan, references: @references, attachments: @attachments } %>
       </div>
 
       <div id="plan-threads" data-coplan--text-selection-target="threads"
@@ -150,37 +158,10 @@
     <div class="empty-state">
       <p>This plan has no content yet.</p>
     </div>
+    <%# No content, no layout columns — back matter still belongs on the page. %>
+    <%= render partial: "coplan/plans/footnotes",
+          locals: { plan: @plan, references: @references, attachments: @attachments } %>
   <% end %>
-</div>
-
-<%# Back matter: references and attachments live under the document like
-    footnotes — same page, quieter surface, each with a one-click "+". %>
-<div class="plan-footnotes">
-  <section class="plan-footnote" id="footnote-references" data-plan-section="references" aria-labelledby="footnote-references-title">
-    <div class="plan-footnote__header">
-      <% if current_user && allowed_to?(@plan, :contribute?) %>
-        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a reference" aria-label="Add a reference">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
-        </button>
-      <% end %>
-      <h2 class="plan-footnote__title" id="footnote-references-title">References</h2>
-      <span class="section-count" id="references-count"><%= @references.size %></span>
-    </div>
-    <%= render partial: "coplan/plans/references", locals: { references: @references, plan: @plan } %>
-  </section>
-
-  <section class="plan-footnote" id="footnote-attachments" data-plan-section="attachments" aria-labelledby="footnote-attachments-title">
-    <div class="plan-footnote__header">
-      <% if current_user && allowed_to?(@plan, :contribute?) %>
-        <button type="button" class="section-add" popovertarget="add-attachment-modal" title="Add files" aria-label="Add files">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
-        </button>
-      <% end %>
-      <h2 class="plan-footnote__title" id="footnote-attachments-title">Attachments</h2>
-      <span class="section-count" id="attachments-count"><%= @attachments.size %></span>
-    </div>
-    <%= render partial: "coplan/plans/attachments", locals: { attachments: @attachments, plan: @plan } %>
-  </section>
 </div>
 
 <%= render partial: "coplan/shared/folder_picker", locals: { folders: @my_folders } %>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -11,13 +11,35 @@
 
 <%= turbo_stream_from @plan %>
 
-<%# plan-keys: Backspace goes back to wherever you came from; [ / ] jump
-    between the document and its footnote sections. %>
-<div data-controller="coplan--plan-keys coplan--folder-picker"
-     data-coplan--plan-keys-fallback-url-value="<%= plans_path %>">
+<% my_placement = current_user && @shelf_placements.find { |p| p.library.writable_by?(current_user) } %>
 
-<div data-controller="coplan--presence" data-coplan--presence-plan-id-value="<%= @plan.id %>" data-plan-section="top">
+<%# plan-keys: Backspace goes back to wherever you came from; [ / ] jump
+    between the document and its footnote sections. Cold opens (direct link,
+    new tab) have no history — fall back to where the plan lives in the
+    viewer's library, not the workspace root. %>
+<div data-controller="coplan--plan-keys coplan--folder-picker"
+     data-coplan--plan-keys-fallback-url-value="<%= my_placement&.folder_id ? plans_path(folder: my_placement.folder_id) : plans_path %>">
+
+<div data-controller="coplan--presence coplan--plan-bookmark" data-coplan--presence-plan-id-value="<%= @plan.id %>" data-plan-section="top">
   <%= render partial: "coplan/plans/header", locals: { plan: @plan } %>
+  <% if current_user %>
+    <%# The bookmark that mounts beside the title (see #plan-bookmark-slot
+        in the header partial). Rendered here because it's viewer-relative —
+        broadcast re-renders of the header can't know who's looking. %>
+    <template data-coplan--plan-bookmark-target="template">
+      <button type="button"
+              class="plan-bookmark<%= " plan-bookmark--saved" if my_placement %>"
+              data-action="coplan--folder-picker#open"
+              data-move-url="<%= move_to_folder_plan_path(@plan) %>"
+              data-current-folder-id="<%= my_placement&.folder_id %>"
+              data-saved="<%= my_placement.present? %>"
+              data-plan-title="<%= @plan.title %>"
+              title="<%= my_placement ? "Saved in #{my_placement.folder.path} — click to remove" : "Save to a folder in your library" %>"
+              aria-label="<%= my_placement ? "Remove from your library" : "Save to your library" %>">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="<%= my_placement ? "currentColor" : "none" %>" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/></svg>
+      </button>
+    </template>
+  <% end %>
 </div>
 
 <%# Owner affordances live outside the broadcast-replaced #plan-header so
@@ -36,7 +58,7 @@
     sides are viewer-relative / policy-gated (broadcast renders have no
     current_user). %>
 <div class="plan-meta-row">
-  <%= render partial: "coplan/plans/shelves", locals: { plan: @plan, placements: @shelf_placements, my_folders: @my_folders } %>
+  <%= render partial: "coplan/plans/shelves", locals: { placements: @shelf_placements } %>
   <div class="plan-actions">
     <% if allowed_to?(@plan, :publish?) || allowed_to?(@plan, :hide?) %>
       <%# The visibility eye: open eye = shared with everyone, slashed = Private.

--- a/engine/app/views/layouts/coplan/application.html.erb
+++ b/engine/app/views/layouts/coplan/application.html.erb
@@ -93,6 +93,10 @@
       <% end %>
       <%= yield %>
     </main>
+    <%# Toast rail: client JS and server Turbo Streams both land feedback
+        here (bottom-right), so in-place actions never scroll the page to a
+        top-of-page flash. %>
+    <div id="coplan-toasts" class="toasts"></div>
     <%= render "coplan/shared/web_push_banner" %>
     <% if signed_in? %>
       <%= render "coplan/search/modal" %>

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -204,5 +204,28 @@ RSpec.describe CoPlan::Folder, type: :model do
         other.id => "Infra"
       )
     end
+
+    it "renders the full path for hierarchies deeper than MAX_DEPTH" do
+      # Creation is capped at MAX_DEPTH, but data deeper than the cap (seeds,
+      # imports, a future cap raise) must still render its whole path — the
+      # guard in the walk is for cycles, not depth.
+      parent = nil
+      chain = ("A".."F").map do |name|
+        folder = described_class.new(name: name, parent: parent, library: library, created_by_user: user)
+        folder.save!(validate: false)
+        parent = folder
+      end
+
+      expect(described_class.paths_by_id[chain.last.id]).to eq("A/B/C/D/E/F")
+    end
+
+    it "does not loop forever on cyclic bad data" do
+      a = create(:folder, name: "A", created_by_user: user)
+      b = create(:folder, name: "B", parent: a, created_by_user: user)
+      a.update_columns(parent_id: b.id)
+
+      paths = described_class.paths_by_id
+      expect(paths[b.id]).to eq("A/B")
+    end
   end
 end

--- a/spec/requests/attachments_spec.rb
+++ b/spec/requests/attachments_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe "Attachments (web)", type: :request do
       expect(event.actor_id).to eq(author.id)
     end
 
+    it "swaps the attachments section in place (no redirect) for Turbo requests" do
+      sign_in_as(author)
+
+      post plan_attachments_path(plan),
+        params: { files: [ fixture_file_upload("sample.png", "image/png") ] },
+        headers: { "Accept" => "text/vnd.turbo-stream.html, text/html" }
+
+      # In-place UX: replace #plan-attachments where it stands + a toast —
+      # never a full-page redirect that scrolls the reader to the top.
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('target="plan-attachments"')
+      expect(response.body).to include('target="coplan-toasts"')
+      expect(response.body).to include("1 file uploaded")
+      expect(response.body).to include("sample.png")
+    end
+
     it "surfaces per-file validation errors" do
       sign_in_as(author)
 
@@ -83,6 +100,19 @@ RSpec.describe "Attachments (web)", type: :request do
       expect(response).to redirect_to(plan_path(plan, anchor: "footnote-attachments"))
       event = plan.plan_events.find_by(event_type: "attachment_removed")
       expect(event.before_value).to eq("sample.png")
+    end
+
+    it "removes in place (no redirect) for Turbo requests" do
+      sign_in_as(author)
+      attachment = plan.attachments_attachments.first
+
+      delete plan_attachment_path(plan, attachment),
+        headers: { "Accept" => "text/vnd.turbo-stream.html, text/html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('target="plan-attachments"')
+      expect(response.body).to include("Attachment removed.")
     end
 
     it "rejects deletes from non-authors" do

--- a/spec/requests/attachments_spec.rb
+++ b/spec/requests/attachments_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe "Attachments (web)", type: :request do
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
       expect(response.body).to include('target="plan-attachments"')
       expect(response.body).to include('target="coplan-toasts"')
+      # Both visible counts update too: the footnote header and the outline.
+      expect(response.body).to include('target="attachments-count"')
+      expect(response.body).to include('target="nav-attachments-count"')
       expect(response.body).to include("1 file uploaded")
       expect(response.body).to include("sample.png")
     end
@@ -112,6 +115,8 @@ RSpec.describe "Attachments (web)", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
       expect(response.body).to include('target="plan-attachments"')
+      expect(response.body).to include('target="attachments-count"')
+      expect(response.body).to include('target="nav-attachments-count"')
       expect(response.body).to include("Attachment removed.")
     end
 

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -41,12 +41,14 @@ RSpec.describe "Plans", type: :request do
     expect(response.body).not_to include("Other Plan")
   end
 
-  it "index shows tag badges on plan cards" do
+  it "index lists tags in the sidebar, not as chips on the rows" do
     plan.tag_names = [ "infra", "api" ]
     get plans_path
-    expect(response.body).to include("badge--tag")
-    expect(response.body).to include("infra")
-    expect(response.body).to include("api")
+    expect(response.body).to include("#infra")
+    expect(response.body).to include("#api")
+    # Row tag chips were dropped: they crowded the byline off its corner
+    # and the sidebar already filters by tag.
+    expect(response.body).not_to include("badge--tag")
   end
 
   it "index shows active tag filter bar" do
@@ -850,7 +852,7 @@ RSpec.describe "Plans", type: :request do
       }.not_to change(CoPlan::PlanEvent, :count)
     end
 
-    it "renders drag handles and save bookmarks on every row" do
+    it "renders every row draggable into the viewer's library" do
       plan # alice's plan
       bobs_plan = create(:plan, :considering, created_by_user: bob, title: "Bobs Plan")
       get plans_path(scope: "all")
@@ -860,9 +862,11 @@ RSpec.describe "Plans", type: :request do
       # Anyone can shelve any visible plan into their own library.
       expect(alice_row).to include('draggable="true"')
       expect(bob_row).to include('draggable="true"')
-      expect(response.body.scan("plan-row__save").size).to be >= 2
-      # One shared navigator popover per page, with the folder tree inside.
-      expect(response.body.scan('id="folder-picker-modal"').size).to eq(1)
+      # No per-row bookmark (and so no navigator popover) on the workspace:
+      # rows file via drag & drop; the plan page's title bookmark is the
+      # click path.
+      expect(response.body).not_to include("plan-row__save")
+      expect(response.body).not_to include('id="folder-picker-modal"')
     end
   end
 

--- a/spec/system/checkbox_spec.rb
+++ b/spec/system/checkbox_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe "Interactive checkboxes", type: :system do
     first_cb = all('input[type="checkbox"]')[0]
     first_cb.click
     wait_for_version(plan, 2)
+    # The version bump broadcasts a whole-body re-render (Broadcaster
+    # .replace_plan_content) that the DB poll above can't see. Grab the
+    # second checkbox only after the swap lands, or the handle can detach
+    # between find and click.
+    wait_for_content_refresh(2)
 
     second_cb = all('input[type="checkbox"]')[1]
     second_cb.click
@@ -186,6 +191,15 @@ RSpec.describe "Interactive checkboxes", type: :system do
   end
 
   private
+
+  # The live-update broadcast replaces the children of #plan-content-body and
+  # stamps the new revision on it — waiting for the stamp is the only
+  # race-free way to know the swap has already happened.
+  def wait_for_content_refresh(revision)
+    expect(page).to have_css(
+      "#plan-content-body[data-coplan--live-update-revision-value='#{revision}']"
+    )
+  end
 
   def wait_for_version(plan, expected_revision, timeout: 5)
     Timeout.timeout(timeout) do

--- a/spec/system/folders_workspace_spec.rb
+++ b/spec/system/folders_workspace_spec.rb
@@ -48,6 +48,31 @@ RSpec.describe "Folders workspace", type: :system do
       expect(page).to have_css(".plan-row[data-plan-id='#{developing_plan.id}']")
     end
 
+    it "returns to the folder you came from with Backspace on a plan page" do
+      # Turbo navigations never update document.referrer, so this relies on
+      # the controller's own in-app visit tracking — a regression here sends
+      # Backspace to the workspace root, losing your place.
+      visit plans_path
+      find(".folder-row", text: "Team EBT").click
+      find(".folder-row", text: "Q3").click
+      find(".plan-row", text: "Q3 Launch Plan").click
+      expect(page).to have_css("h1", text: "Q3 Launch Plan")
+
+      find("body").send_keys(:backspace)
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Q3")
+    end
+
+    it "falls back to the plan's folder on Backspace after a cold open" do
+      # Direct visit = no in-app history. Backspace should land where the
+      # plan lives in the viewer's library, not the workspace root.
+      visit plan_path(foldered_plan)
+      expect(page).to have_css("h1", text: "Q3 Launch Plan")
+
+      find("body").send_keys(:backspace)
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Q3")
+      expect(page).to have_current_path(plans_path(folder: q3.id))
+    end
+
     it "quietly flags private plans in the level view" do
       visit plans_path
       row = find(".plan-row[data-plan-id='#{brainstorm_plan.id}']")
@@ -98,7 +123,7 @@ RSpec.describe "Folders workspace", type: :system do
     end
 
     it "filters by tag from the sidebar" do
-      developing_plan.tag_names = ["security"]
+      developing_plan.tag_names = [ "security" ]
       visit plans_path
 
       within(".workspace__sidebar") { click_link "#security" }
@@ -198,6 +223,22 @@ RSpec.describe "Folders workspace", type: :system do
       expect(author.library.placements.find_by(plan_id: developing_plan.id).folder).to eq(q3)
     end
 
+    it "saves from the plan page via the bookmark beside the title" do
+      visit plan_path(developing_plan)
+
+      # The bookmark mounts into the title row (it's stamped client-side —
+      # the broadcast-replaced header can't render viewer state itself).
+      find(".page-header__title-row .plan-bookmark").click
+      within("#folder-picker-modal") do
+        find(".folder-picker__option", text: "Infra").click
+      end
+
+      expect(page).to have_css(".flash--notice", text: "Infra", wait: 5)
+      expect(author.library.placements.find_by(plan_id: developing_plan.id).folder).to eq(infra)
+      # After the reload the bookmark reads as saved.
+      expect(page).to have_css(".plan-bookmark--saved")
+    end
+
     it "unsaves a filed plan with a second bookmark click — no dialog, no toast" do
       CoPlan::Plans::Place.call(plan: developing_plan, folder: q3, actor: author)
       visit plans_path(folder: q3.id)
@@ -220,6 +261,89 @@ RSpec.describe "Folders workspace", type: :system do
       row = find(".plan-row[data-plan-id='#{other_plan.id}']")
       expect(row["draggable"]).to eq("true")
       expect(row).to have_css(".plan-row__save", visible: :all)
+    end
+  end
+
+  describe "spring-loaded folders" do
+    let!(:q3sub) { create(:folder, name: "Q3 Sub", parent: q3, created_by_user: author) }
+
+    # Capybara's drag_to is atomic — no way to hover mid-drag — so these
+    # drive the controller with synthetic DragEvents sharing one
+    # DataTransfer, exactly the objects the real drag hands it.
+    def fire_drag_event(element, type)
+      page.execute_script(<<~JS, element)
+        if (#{(type == "dragstart").to_json}) window.__springDT = new DataTransfer()
+        arguments[0].dispatchEvent(new DragEvent(#{type.to_json}, {
+          bubbles: true, cancelable: true, dataTransfer: window.__springDT
+        }))
+      JS
+    end
+
+    it "springs a collapsed sidebar branch open after a hover, and shut when the drag moves away" do
+      visit plans_path
+
+      row = find(".plan-row[data-plan-id='#{developing_plan.id}']")
+      branch_link = find(".folder-tree__link", text: "Team EBT")
+
+      # Q3 is buried in a collapsed <details> branch.
+      expect(page).not_to have_css(".folder-tree__link", text: "Q3")
+
+      fire_drag_event(row, "dragstart")
+      fire_drag_event(branch_link, "dragover")
+
+      # Two pulses first, then the branch springs open (650ms).
+      expect(branch_link[:class]).to include("dnd-spring")
+      expect(page).to have_css(".folder-tree__branch[open] .folder-tree__link", text: "Q3", wait: 2)
+
+      # Drag away — the sprung branch snaps shut ("temporarily there").
+      fire_drag_event(find(".folder-tree__link", text: "Infra"), "dragover")
+      expect(page).not_to have_css(".folder-tree__link", text: "Q3")
+
+      fire_drag_event(row, "dragend")
+    end
+
+    it "tunnels the pane into a hovered folder, level by level, and files a dead-space drop right there" do
+      visit plans_path
+
+      row = find(".plan-row[data-plan-id='#{developing_plan.id}']")
+      fire_drag_event(row, "dragstart")
+      fire_drag_event(find(".folder-row", text: "Team EBT"), "dragover")
+
+      # Two pulses later the pane IS Team EBT's level view — real crumbs,
+      # real rows — while the drag is still in flight.
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Team EBT", wait: 4)
+      expect(page).to have_css(".folder-row", text: "Q3")
+
+      # Keep diving: hover Q3 to tunnel one level deeper.
+      fire_drag_event(find(".folder-row", text: "Q3"), "dragover")
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Q3", wait: 4)
+      expect(page).to have_css(".folder-row", text: "Q3 Sub")
+
+      # Dead space in the pane files into the folder you're looking at.
+      fire_drag_event(find(".workspace__main"), "drop")
+      fire_drag_event(row, "dragend")
+
+      expect(page).to have_css(".flash--notice", wait: 5)
+      expect(author.library.placements.find_by(plan_id: developing_plan.id).folder).to eq(q3)
+      # The drop leaves you where you dropped — inside Q3, for real.
+      expect(page).to have_current_path(plans_path(folder: q3.id), wait: 5)
+    end
+
+    it "restores the original pane when a tunneled drag ends without a drop" do
+      visit plans_path
+
+      row = find(".plan-row[data-plan-id='#{developing_plan.id}']")
+      fire_drag_event(row, "dragstart")
+      fire_drag_event(find(".folder-row", text: "Team EBT"), "dragover")
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Team EBT", wait: 4)
+
+      # Abandon the drag: everything snaps back — root crumb, root rows,
+      # and the dragged row itself.
+      fire_drag_event(row, "dragend")
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "My Plans")
+      expect(page).to have_css(".folder-row", text: "Team EBT")
+      expect(page).to have_css(".plan-row[data-plan-id='#{developing_plan.id}']")
+      expect(author.library.placements.where(plan_id: developing_plan.id)).to be_empty
     end
   end
 

--- a/spec/system/folders_workspace_spec.rb
+++ b/spec/system/folders_workspace_spec.rb
@@ -207,29 +207,17 @@ RSpec.describe "Folders workspace", type: :system do
       expect(infra.reload.parent).to eq(team)
     end
 
-    it "files a plan via the row bookmark's folder navigator" do
-      visit plans_path
-
-      row = find(".plan-row[data-plan-id='#{developing_plan.id}']")
-      row.find(".plan-row__save", visible: :all).click
-
-      within("#folder-picker-modal") do
-        # The tree is hierarchical: Q3 nests under Team EBT.
-        expect(page).to have_css(".folder-picker__tree--nested .folder-picker__name", text: "Q3")
-        find(".folder-picker__option", text: "Q3").click
-      end
-
-      expect(page).to have_css(".flash--notice", text: "Team EBT/Q3", wait: 5)
-      expect(author.library.placements.find_by(plan_id: developing_plan.id).folder).to eq(q3)
-    end
-
     it "saves from the plan page via the bookmark beside the title" do
       visit plan_path(developing_plan)
 
       # The bookmark mounts into the title row (it's stamped client-side —
       # the broadcast-replaced header can't render viewer state itself).
+      # It's also the only click path into the folder navigator: workspace
+      # rows file via drag & drop and carry no bookmark of their own.
       find(".page-header__title-row .plan-bookmark").click
       within("#folder-picker-modal") do
+        # The tree is hierarchical: Q3 nests under Team EBT.
+        expect(page).to have_css(".folder-picker__tree--nested .folder-picker__name", text: "Q3")
         find(".folder-picker__option", text: "Infra").click
       end
 
@@ -241,26 +229,29 @@ RSpec.describe "Folders workspace", type: :system do
 
     it "unsaves a filed plan with a second bookmark click — no dialog, no toast" do
       CoPlan::Plans::Place.call(plan: developing_plan, folder: q3, actor: author)
-      visit plans_path(folder: q3.id)
+      visit plan_path(developing_plan)
 
-      row = find(".plan-row[data-plan-id='#{developing_plan.id}']")
-      row.find(".plan-row__save--saved", visible: :all).click
+      find(".page-header__title-row .plan-bookmark--saved").click
 
       # The bookmark just lets go: no navigator, no confirmation, no toast —
-      # the page re-renders and the plan is out of the folder.
+      # the page re-renders with the bookmark back in its unsaved state.
       expect(page).not_to have_css("#folder-picker-modal:popover-open")
-      expect(page).not_to have_css(".plan-row[data-plan-id='#{developing_plan.id}']", wait: 5)
+      expect(page).to have_css(".page-header__title-row .plan-bookmark:not(.plan-bookmark--saved)", wait: 5)
       expect(page).not_to have_css(".flash--notice")
       expect(author.library.placements.where(plan_id: developing_plan.id)).to be_empty
     end
 
-    it "offers save controls on other users' plans too (shelving)" do
+    it "offers shelving on other users' plans too" do
       other_plan = create(:plan, :considering, created_by_user: other, title: "Someone Elses Plan")
       visit plans_path(scope: "all")
 
+      # The row drags into your library like any of your own…
       row = find(".plan-row[data-plan-id='#{other_plan.id}']")
       expect(row["draggable"]).to eq("true")
-      expect(row).to have_css(".plan-row__save", visible: :all)
+
+      # …and the plan page offers the bookmark.
+      visit plan_path(other_plan)
+      expect(page).to have_css(".page-header__title-row .plan-bookmark")
     end
   end
 

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "Plan references", type: :system do
       visit plan_path(plan)
 
       expect(page).to have_content("Some content here")
-      expect(page).to have_content("No references yet")
+      # Empty state is one quiet line, scoped to the section (attachments
+      # has its own "None yet").
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None yet")
       expect(page).to have_css("#footnote-references .plan-footnote__title", text: /references/i)
     end
   end
@@ -66,7 +68,7 @@ RSpec.describe "Plan references", type: :system do
 
       # Turbo Stream replaces the list — reference appears without navigation
       expect(page).to have_link("My Repo", href: "https://github.com/org/repo")
-      expect(page).not_to have_content("No references yet")
+      expect(page).not_to have_css("#footnote-references .plan-footnote__empty")
 
       # Count span updated in-place via Turbo Stream (separate stream target)
       expect(page).to have_css("#references-count", text: "1")
@@ -119,7 +121,7 @@ RSpec.describe "Plan references", type: :system do
       # Turbo Stream removes the reference and updates count
       expect(page).not_to have_content("Doomed")
       expect(page).to have_css("#references-count", text: "0")
-      expect(page).to have_content("No references yet")
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None yet")
     end
   end
 

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -70,8 +70,10 @@ RSpec.describe "Plan references", type: :system do
       expect(page).to have_link("My Repo", href: "https://github.com/org/repo")
       expect(page).not_to have_css("#footnote-references .plan-footnote__empty")
 
-      # Count span updated in-place via Turbo Stream (separate stream target)
+      # Count spans updated in-place via Turbo Stream (separate stream
+      # targets) — the footnote header and the document outline.
       expect(page).to have_css("#references-count", text: "1")
+      expect(page).to have_css("#nav-references-count", text: "1")
 
       # The document is still right there — same page, no tabs.
       expect(page).to have_content("Some content here")


### PR DESCRIPTION
Follow-up to #153, from staging review feedback.

## Drag & drop grows Finder semantics
- **Spring-loaded folders**: hover a folder mid-drag → two pulses → it opens. In the sidebar, branches expand multi-level and snap shut when the cursor leaves.
- **Tunneling in the main pane**: springing on a folder row or breadcrumb navigates the pane *into* that folder mid-drag (prefetched during the hover dwell). Abandon the drag and the pane snaps back home; drop and it commits with a Turbo visit.
- The whole pane is a drop target ("file right here"); folder rows and crumbs inside win via stopPropagation.
- Loud drop-target highlight, busy pulse + ghosted source while a move is in flight, `user-select: none` on draggables (selectable text was hijacking press-and-drag into a navigation).

## Rows and navigation
- Whole plan-row card is clickable (stretched title link) and prefetches on hover for instant navigation.
- **Backspace on a plan page returns to the folder you came from.** Turbo Drive never updates `document.referrer`, so the same-origin check always failed and Backspace dumped you at the workspace root; the controller now tracks in-app visits itself. Cold opens (direct link/new tab) fall back to the plan's folder in your library.
- `Folder.paths_by_id`'s walk guard is now a real cycle guard (visited set) instead of a depth clamp, so deeper-than-cap hierarchies render full paths.

## Native feel, secretly HTML (now a hard requirement in AGENTS.md)
- `scrollbar-gutter: stable` kills the page-width jiggle between workspace and plan pages.
- Attachments upload **in place**: XHR progress bar, Turbo Stream section update, self-dismissing toasts — no more scroll-to-top reload.
- Save bookmark sits beside the plan title (stamped from outside the broadcast-rendered header, which can't know the viewer).
- Presence avatars link to profiles; plan tag chips link to search (not your workspace); sidebar hidden filters read as opt-in reveals ("Show my private plans").

## Testing
- Full suite: 1313 examples, 0 failures.
- New system specs: spring/tunnel flows via synthetic DragEvents, bookmark-beside-title, Backspace-back-to-folder (both warm and cold open); request specs for the Turbo Stream attachment flow; model specs for deep/cyclic folder paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)