### PR TITLE
Put author details first in Slack unfurls

### DIFF
--- a/integrations/slack/app/services/coplan/slack/renderer.rb
+++ b/integrations/slack/app/services/coplan/slack/renderer.rb
@@ -45,11 +45,20 @@ module CoPlan
 
       def self.decorated_context(preview)
         context = escape(preview.context)
-        context = context.sub("by #{escape(preview.author_name)}", "by *#{escape(preview.author_name)}*") if preview.author_name.present?
-        return "📦 *Archived*#{context.delete_prefix("Archived")}" if preview.context.to_s.start_with?("Archived")
-        return "🔒 *Private*#{context.delete_prefix("Private")}" if preview.context.to_s.start_with?("Private")
+        return "📄 #{context}" if preview.author_name.blank?
 
-        "📄 #{context}"
+        author = escape(preview.author_name)
+        details = context.delete_suffix(" · by #{author}").delete_suffix("by #{author}")
+        if preview.context.to_s.start_with?("Archived")
+          details = details.delete_prefix("Archived").delete_prefix(" · ")
+          return [ "*#{author}*", details.presence, "📦 Archived" ].compact.join(" · ")
+        end
+        if preview.context.to_s.start_with?("Private")
+          details = details.delete_prefix("Private").delete_prefix(" · ")
+          return [ "*#{author}*", details.presence, "🔒 Private" ].compact.join(" · ")
+        end
+
+        [ "*#{author}*", details.presence ].compact.join(" · ")
       end
 
       def self.context_elements(preview)

--- a/spec/services/slack_renderer_spec.rb
+++ b/spec/services/slack_renderer_spec.rb
@@ -6,12 +6,20 @@ RSpec.describe CoPlan::Slack::Renderer do
     result = described_class.call(preview, url: "https://example.test/p?thread=123&view=full")
     expect(result[:blocks][0][:text][:text]).to include("A &lt; B &amp; C", "&gt; hello")
     expect(result[:blocks][1][:elements][0]).to eq(type: "image", image_url: preview.author_avatar_url, alt_text: "Ada")
-    expect(result[:blocks][1][:elements][1][:text]).to eq("📄 Live &amp; ready · by *Ada*")
+    expect(result[:blocks][1][:elements][1][:text]).to eq("*Ada* · Live &amp; ready")
     expect(result[:blocks][0][:text][:text]).to include("https://example.test/p?thread=123&amp;view=full")
     expect(result[:blocks][0][:accessory][:image_url]).to eq(preview.image_url)
     expect(result[:color]).to eq("#136FF5")
     expect(result[:fallback]).to include(preview.title)
     expect(result.dig(:preview, :title, :text)).to eq(preview.title)
+  end
+
+  it "does not duplicate an author-only context" do
+    preview = CoPlan::LinkPreview.new(kind: "plan", external_id: "id", canonical_url: "https://example.test/p", title: "Untyped Plan", description: nil, context: "by Ada", image_url: nil, author_name: "Ada", author_avatar_url: nil, cache_key: "x")
+
+    result = described_class.call(preview)
+
+    expect(result.dig(:blocks, 1, :elements, 0, :text)).to eq("*Ada*")
   end
 
   it "visually distinguishes private and archived plans" do
@@ -22,8 +30,8 @@ RSpec.describe CoPlan::Slack::Renderer do
     archived_result = described_class.call(archived_preview)
 
     expect(private_result[:color]).to eq("#8C4AF6")
-    expect(private_result.dig(:blocks, 1, :elements, 0, :text)).to eq("🔒 *Private* · EDD · by *Ada*")
+    expect(private_result.dig(:blocks, 1, :elements, 0, :text)).to eq("*Ada* · EDD · 🔒 Private")
     expect(archived_result[:color]).to eq("#64748B")
-    expect(archived_result.dig(:blocks, 1, :elements, 0, :text)).to eq("📦 *Archived* · EDD · by *Ada*")
+    expect(archived_result.dig(:blocks, 1, :elements, 0, :text)).to eq("*Ada* · EDD · 📦 Archived")
   end
 end


### PR DESCRIPTION
## Why
PR #157 merged before its final author-first metadata update reached the branch. This follow-up makes the unfurl match the reviewed visual preview.

## What
- Reorder metadata to author, plan type, then visibility
- Keep missing plan types compact without empty separators

## Risk Assessment
Low — presentation-only change to the Slack unfurl context row.

## References
- Follow-up to #157
- `bundle exec rspec spec/services/slack_renderer_spec.rb spec/jobs/slack_unfurl_job_spec.rb` (5 examples, 0 failures)
- RuboCop passed for both touched files

---
**Update Jul 23, 17:08:** Handle author-only context from review feedback
- Remove bare `by Author` metadata before rendering the author-first row
- Added regression coverage; 6 focused examples pass

Generated with Amp