### PR TITLE
Make the inbox panel solid — its glass could never blur

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2350,16 +2350,17 @@ img.avatar {
   padding: 0 4px;
 }
 
-/* Floating inbox panel */
+/* Floating inbox panel. Solid, not glass: it lives inside the nav,
+   whose own backdrop-filter blocks a descendant's backdrop-filter from
+   sampling the page — translucency here would just let the page bleed
+   through unblurred. */
 .inbox-panel {
   position: absolute;
   top: calc(100% + var(--space-sm));
   right: 0;
   width: 420px;
   max-height: 480px;
-  background: var(--glass-bg-strong);
-  -webkit-backdrop-filter: var(--glass-blur);
-  backdrop-filter: var(--glass-blur);
+  background: var(--color-surface);
   border: 1px solid var(--glass-edge);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);


### PR DESCRIPTION
The inbox dropdown let the page title bleed through legibly. Its 'glass' was fake: the panel is a descendant of the nav, whose own `backdrop-filter` prevents a child's backdrop-filter from sampling the page behind it — so the blur did nothing and the panel was raw 66%-alpha over sharp text. Dropdowns get a solid elevated surface (`--color-surface`) instead. Verified in light and dark.

Note: this same commit is currently also on #160 (`10b83f2`). Whichever merges first makes the other a no-op — if #160 lands with it, close this.