### PR TITLE
Nav hierarchy: scroll-aware title, calmer bar, one menu

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -384,73 +384,119 @@ img, svg {
   color: var(--color-primary);
 }
 
-.site-nav__links {
-  display: flex;
-  align-items: center;
-  gap: var(--space-lg);
-  list-style: none;
-  margin-left: var(--space-sm);
-  margin-right: auto;
-  flex-shrink: 0;
-}
-
-.site-nav__links a {
-  color: var(--color-text-muted);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  transition: color 0.15s;
-}
-
-.site-nav__links a:hover {
-  color: var(--color-text);
-  text-decoration: none;
-}
-
-.site-nav__links a.site-nav__link--active {
-  color: var(--color-text);
-  font-weight: 600;
-}
-
-.site-nav__profile-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.site-nav__profile-link:hover {
-  color: var(--color-text);
-}
-
-/* The controls may compress as a group (the user's name truncates), but
-   the icons themselves never shrink — a gear crushed to a sliver, or a
-   bell whose badge outlives it, reads as breakage. */
+/* The right cluster — search, notifications, menu — pinned to the right so
+   the bar reads left-to-right as identity → context → tools. Nothing here
+   shrinks: a search crushed to a sliver or a ☰ that drifts reads as breakage
+   (search folds to an icon at ≤900px, the bell into the menu at ≤640px). */
 .site-nav__right {
   display: flex;
   align-items: center;
-  gap: var(--space-lg);
+  gap: var(--space-md);
   margin-left: auto;
   min-width: 0;
 }
 
-.site-nav__icon-link,
-.site-nav__bell,
+.site-nav__menu,
 .inbox-dropdown {
   flex-shrink: 0;
 }
 
-.site-nav__user {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  color: var(--color-text-muted);
-  font-size: var(--text-sm);
-  white-space: nowrap;
-  min-width: 0;
+.site-nav__menu {
+  position: relative;
 }
 
-.site-nav__profile-link {
+.site-nav__menu-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: none;
+  background: none;
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.site-nav__menu-btn:hover {
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+/* When the bell has folded into the menu (phone widths), the ☰ carries a
+   small unread dot so a waiting notification is still visible at a glance.
+   coplan--inbox-badge toggles .site-nav--has-unread from the live count;
+   the dot itself only shows once the bell is gone (see the phone block). */
+.site-nav__menu-btn::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: var(--color-danger);
+  display: none;
+}
+
+/* Scroll-aware document title in the top nav. Collapsed to zero width when
+   inactive so it steals no space and causes no reflow at the top of a plan;
+   coplan--nav-title flips --visible once the header scrolls behind the bar.
+   It lives in the left "where am I?" cluster (see .site-nav__inner). */
+.site-nav__doc-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  /* Barely shrinkable itself; the search box (below) yields first and far
+     faster, down to a usable floor. So a short title shows in full, and a
+     long one only ellipsizes once the search has already given up its
+     slack — never the other way round. */
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  text-decoration: none;
+  pointer-events: none;
+  /* Grow a touch slower than the fade, so it reads as sliding in from the
+     links rather than shoving the search box aside. */
+  transition: max-width 0.28s ease, opacity 0.18s ease;
+}
+
+.site-nav__doc-title--visible {
+  max-width: 22rem;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.site-nav__doc-title:hover {
+  color: var(--color-text);
+}
+
+.site-nav__doc-title-text {
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.site-nav__doc-title .plan-type-icon {
+  flex-shrink: 0;
+}
+
+/* The title sits in the left cluster right after the brand; .site-nav__right
+   is pushed away by its own margin-left:auto, so the title simply grows into
+   the free space between them — no margin juggling needed now that the bar
+   holds nothing else on the left. On a phone it's the ONLY plan context (the
+   Contents sidebar is hidden < 1024px), so let it take more of the row. */
+@media (max-width: 640px) {
+  .site-nav__doc-title--visible {
+    max-width: 58vw;
+  }
 }
 
 /* Main content */
@@ -2185,21 +2231,13 @@ img.avatar {
   margin-right: 0;
 }
 
+/* No label anymore — just the collapse control, nudged to the right edge
+   above the outline. No border/separator: there's nothing to separate. */
 .content-nav__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding-bottom: var(--space-sm);
-  margin-bottom: var(--space-sm);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.content-nav__title {
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  justify-content: flex-end;
+  margin-bottom: var(--space-xs);
 }
 
 .content-nav__toggle {
@@ -2369,23 +2407,6 @@ img.avatar {
 .inbox-dropdown {
   position: relative;
   display: inline-flex;
-}
-
-.site-nav__icon-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-muted);
-  padding: var(--space-xs);
-  border-radius: var(--radius);
-  line-height: normal;
-  transition: color 0.15s, background 0.15s;
-}
-
-.site-nav__icon-link:hover {
-  color: var(--color-text);
-  background: var(--color-bg);
-  text-decoration: none;
 }
 
 .site-nav__bell {
@@ -3842,7 +3863,7 @@ img.avatar {
   align-items: center;
   gap: var(--space-sm);
   padding: 6px 10px;
-  margin: 0 var(--space-md);
+  margin: 0;
   flex: 0 1 320px;
   min-width: 0;
   background: var(--color-bg);
@@ -4137,6 +4158,30 @@ img.avatar {
   height: 1px;
   margin: var(--space-xs) calc(-1 * var(--space-xs));
   background: var(--color-border);
+}
+
+/* Unread count pill on a menu row (Notifications), pushed to the trailing
+   edge so the label stays left-aligned with its siblings. */
+.menu__badge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--color-text-inverse);
+  background: var(--color-danger);
+  border-radius: 9999px;
+  line-height: 1;
+}
+
+/* Notifications is a bar control (the bell) whenever there's room; this menu
+   copy is the phone fallback, revealed only once the bell folds away. */
+.menu__item--notifications {
+  display: none;
 }
 
 /* Full-width state banner on the plan page (e.g. archived notice). */
@@ -5358,13 +5403,28 @@ img.avatar {
     margin: 0;
     border-radius: 9999px;
   }
+}
 
-  .site-nav__right {
+/* ---- Touch devices (any width) ----
+   A finger needs a bigger target than a cursor. On coarse pointers the bar's
+   icon controls and the menu rows grow to ~44px regardless of screen width,
+   so a touch tablet with the bell still on the bar is just as tappable. */
+@media (pointer: coarse) {
+  .site-nav__menu-btn,
+  .site-nav__bell {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .menu__item {
+    min-height: 44px;
+    padding: 10px var(--space-sm);
     gap: var(--space-md);
   }
 
-  .site-nav__profile-link {
-    max-width: 9rem;
+  .menu__item svg {
+    width: 18px;
+    height: 18px;
   }
 }
 
@@ -5378,21 +5438,55 @@ img.avatar {
     gap: var(--space-sm);
   }
 
-  /* Icons over labels: brand text, the settings gear, and the sign-out
-     link all yield to the things a phone visit is actually for. */
-  .site-nav__brand-text,
-  .site-nav__icon-link,
-  .site-nav__user a[data-turbo-method="delete"] {
+  /* Icons over labels: the brand wordmark yields to the logo alone, since
+     search and the ☰ menu are what a phone visit reaches for. */
+  .site-nav__brand-text {
     display: none;
   }
 
-  .site-nav__links {
-    margin-left: var(--space-xs);
+  /* No room for the bell + its peek panel — the whole control folds into the
+     menu (its row is revealed there, linking to the full page), and the
+     unread signal moves to a dot on the ☰. */
+  .inbox-dropdown {
+    display: none;
+  }
+
+  .menu__item--notifications {
+    display: flex;
+  }
+
+  .site-nav--has-unread .site-nav__menu-btn::after {
+    display: block;
+  }
+
+  /* Finger-sized tap targets: the ☰ and the folded search icon each fill a
+     44px hit area, and menu rows get real height + spacing so they're not a
+     pixel-hunt to tap. */
+  .site-nav__menu-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .site-nav__search {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 12px;
+  }
+
+  .menu {
+    min-width: 15rem;
+    padding: var(--space-sm);
+  }
+
+  .menu__item {
+    min-height: 44px;
+    padding: 10px var(--space-sm);
     gap: var(--space-md);
   }
 
-  .site-nav__profile-link {
-    max-width: 6.5rem;
+  .menu__item svg {
+    width: 18px;
+    height: 18px;
   }
 
   .main-content {

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2231,13 +2231,12 @@ img.avatar {
   margin-right: 0;
 }
 
-/* No label anymore — just the collapse control, nudged to the right edge
-   above the outline. No border/separator: there's nothing to separate. */
+/* No label anymore — the lone collapse control floats into the top-right
+   corner so the outline starts at the very top (no empty header band where
+   "Contents" used to sit) and the first item's text flows beside it. */
 .content-nav__header {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  margin-bottom: var(--space-xs);
+  float: right;
+  margin-left: var(--space-xs);
 }
 
 .content-nav__toggle {

--- a/engine/app/javascript/controllers/coplan/inbox_badge_controller.js
+++ b/engine/app/javascript/controllers/coplan/inbox_badge_controller.js
@@ -16,6 +16,10 @@ export default class extends Controller {
 
   updateVisibility() {
     const count = parseInt(this.element.textContent.trim(), 10)
-    this.element.classList.toggle("inbox-badge--hidden", !count || count === 0)
+    const hasUnread = !!count && count > 0
+    this.element.classList.toggle("inbox-badge--hidden", !hasUnread)
+    // Flag the nav so the menu button can show an unread dot on phone
+    // widths, where the bell itself folds into the menu.
+    this.element.closest(".site-nav")?.classList.toggle("site-nav--has-unread", hasUnread)
   }
 }

--- a/engine/app/javascript/controllers/coplan/nav_title_controller.js
+++ b/engine/app/javascript/controllers/coplan/nav_title_controller.js
@@ -28,6 +28,15 @@ export default class extends Controller {
     this._setVisible(false)
   }
 
+  // Return to the top of the plan. A bare #plan-header jump lands the header
+  // under the sticky bar (and reads as "nothing moved"); scroll all the way
+  // up instead, so the full masthead is back in view — at which point the
+  // observer hides this title on its own.
+  scrollToTop(event) {
+    event.preventDefault()
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }
+
   _setVisible(visible) {
     this.element.classList.toggle("site-nav__doc-title--visible", visible)
   }

--- a/engine/app/javascript/controllers/coplan/nav_title_controller.js
+++ b/engine/app/javascript/controllers/coplan/nav_title_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Fades the plan title into the sticky top nav once the document's own
+// header has scrolled up behind the bar. Persistent wayfinding —
+// especially on mobile and on comment deep links, where you land centered
+// on an anchor with the masthead already off-screen — that costs zero
+// space while the header is still visible.
+export default class extends Controller {
+  static values = { anchor: { type: String, default: "plan-header" } }
+
+  connect() {
+    const anchor = document.getElementById(this.anchorValue)
+    // No header to track (empty doc, unexpected markup) — stay hidden
+    // rather than showing a title that never has a home to return to.
+    if (!anchor) return
+
+    this._observer = new IntersectionObserver(
+      ([entry]) => this._setVisible(!entry.isIntersecting),
+      // Trip the moment the header clears the sticky nav, not the very top
+      // of the viewport — otherwise the title would linger under the bar.
+      { rootMargin: `-${this._navHeightPx()}px 0px 0px 0px`, threshold: 0 }
+    )
+    this._observer.observe(anchor)
+  }
+
+  disconnect() {
+    this._observer?.disconnect()
+    this._setVisible(false)
+  }
+
+  _setVisible(visible) {
+    this.element.classList.toggle("site-nav__doc-title--visible", visible)
+  }
+
+  // --nav-height is authored in rem; resolve it to px for rootMargin.
+  _navHeightPx() {
+    const root = document.documentElement
+    const rem = parseFloat(getComputedStyle(root).getPropertyValue("--nav-height")) || 3.5
+    return rem * parseFloat(getComputedStyle(root).fontSize)
+  }
+}

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -9,6 +9,16 @@
   <meta name="twitter:description" content="<%= plan_og_description(@plan) %>">
 <% end %>
 
+<%# Fills the sticky nav's title slot (see layouts/coplan/application). The
+    icon + title mirror the masthead's #plan-header; coplan--nav-title fades
+    it in once that header scrolls behind the bar. %>
+<% content_for :nav_title do %>
+  <a href="#plan-header" class="site-nav__doc-title" data-controller="coplan--nav-title" aria-hidden="true" tabindex="-1">
+    <%= plan_type_icon(@plan, size: :sm) %>
+    <span class="site-nav__doc-title-text"><%= @plan.title %></span>
+  </a>
+<% end %>
+
 <%= turbo_stream_from @plan %>
 
 <% my_placement = current_user && @shelf_placements.find { |p| p.library.writable_by?(current_user) } %>
@@ -39,8 +49,9 @@
   <% if @plan.current_content.present? %>
     <div class="plan-layout" data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections" data-coplan--text-selection-focus-thread-value="<%= params[:thread] %>" data-action="keydown.esc@document->coplan--text-selection#dismiss" data-coplan--checkbox-revision-value="<%= @plan.current_revision %>" data-coplan--checkbox-toggle-url-value="<%= toggle_checkbox_plan_path(@plan) %>" data-coplan--changed-sections-keys-value="<%= @changed_section_keys.to_json %>">
       <nav class="content-nav" data-coplan--content-nav-target="sidebar" aria-label="Document outline">
+        <%# No "Contents" label — the outline speaks for itself, and the plan
+            title now lives in the sticky nav. Just the collapse control. %>
         <div class="content-nav__header">
-          <span class="content-nav__title">Contents</span>
           <button type="button" class="content-nav__toggle" data-action="coplan--content-nav#toggle" data-coplan--content-nav-target="toggleBtn" aria-label="Hide table of contents" title="Toggle (t)">✕</button>
         </div>
         <ul class="content-nav__list" data-coplan--content-nav-target="list"></ul>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -13,7 +13,7 @@
     icon + title mirror the masthead's #plan-header; coplan--nav-title fades
     it in once that header scrolls behind the bar. %>
 <% content_for :nav_title do %>
-  <a href="#plan-header" class="site-nav__doc-title" data-controller="coplan--nav-title" aria-hidden="true" tabindex="-1">
+  <a href="#plan-header" class="site-nav__doc-title" data-controller="coplan--nav-title" data-action="click->coplan--nav-title#scrollToTop" aria-hidden="true" tabindex="-1">
     <%= plan_type_icon(@plan, size: :sm) %>
     <span class="site-nav__doc-title-text"><%= @plan.title %></span>
   </a>

--- a/engine/app/views/layouts/coplan/application.html.erb
+++ b/engine/app/views/layouts/coplan/application.html.erb
@@ -24,39 +24,46 @@
   <body>
     <nav class="site-nav">
       <div class="site-nav__inner">
-        <%= link_to coplan.root_path, class: "site-nav__brand" do %>
+        <%# The logo is the Workspace home — that's where signed-in work
+            lives, so there's no separate "Workspace" link. Signed-out
+            visitors land on the public root instead. %>
+        <%= link_to(signed_in? ? coplan.plans_path : coplan.root_path, class: "site-nav__brand") do %>
           <%= image_tag "coplan/coplan-logo-sm.png", alt: "CoPlan",
                 class: "site-nav__logo#{coplan_environment_logo_modifier}",
                 title: coplan_environment_logo_title %>
           <span class="site-nav__brand-text">CoPlan</span>
         <% end %>
         <% if signed_in? %>
-          <div class="site-nav__links">
-            <%# Two surfaces: Workspace is where you work (and where you
-                land), Feed is what's happening across the org. Libraries
-                are browsed on profiles, not a place. %>
-            <%= link_to "Workspace", coplan.plans_path,
-                  class: "site-nav__link #{'site-nav__link--active' if request.path == coplan.plans_path}" %>
-            <%= link_to "Feed", coplan.home_path,
-                  class: "site-nav__link #{'site-nav__link--active' if request.path == coplan.home_path}" %>
-          </div>
-          <button type="button"
-                  class="site-nav__search"
-                  aria-label="Search plans and people"
-                  popovertarget="search-modal">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-            <span class="site-nav__search-label">Search plans and people…</span>
-            <kbd class="site-nav__search-kbd">/</kbd>
-          </button>
+          <%# Context slot: a plan show page fills this (see plans/show.html.erb)
+              with the document title, which fades in once the plan's own header
+              scrolls behind the bar. Empty — and inert — everywhere else, so the
+              bar reads the same on every surface. %>
+          <%= yield :nav_title %>
           <div class="site-nav__right">
-            <%= link_to coplan.settings_root_path, class: "site-nav__icon-link", aria: { label: "Settings" } do %>
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-            <% end %>
+            <%# Two persistent controls plus notifications: Search (jump to a
+                doc/person), the notifications bell, and the menu. Everything
+                that isn't reading, searching, or a live alert lives in the
+                menu, so the bar stays calm while you read. %>
+            <button type="button"
+                    class="site-nav__search"
+                    aria-label="Search plans and people"
+                    popovertarget="search-modal">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+              <span class="site-nav__search-label">Search plans and people…</span>
+              <kbd class="site-nav__search-kbd">/</kbd>
+            </button>
+            <%= turbo_stream_from "coplan_notifications:#{current_user.id}" %>
+            <% unread = current_user.notifications.unread.count %>
+            <%# Notifications is a first-class bar control whenever there's room:
+                the bell opens an inline peek panel (lazy turbo-frame). Below the
+                phone breakpoint the whole control folds into the menu — where
+                Notifications links to the full page instead — and the unread
+                count reappears as a dot on ☰. The live #inbox-badge rides the
+                bell; coplan--inbox-badge also flags the nav so the collapsed ☰
+                dot tracks the same count. %>
             <div class="inbox-dropdown" data-controller="coplan--inbox">
-              <%= turbo_stream_from "coplan_notifications:#{current_user.id}" %>
               <button type="button" class="site-nav__bell" data-action="coplan--inbox#toggle" data-coplan--inbox-target="button" aria-label="Notifications" aria-expanded="false">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-                <% unread = current_user.notifications.unread.count %>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
                 <span id="inbox-badge" class="inbox-badge<%= ' inbox-badge--hidden' if unread == 0 %>" data-controller="coplan--inbox-badge"><%= unread %></span>
               </button>
               <div class="inbox-panel" data-coplan--inbox-target="panel" hidden>
@@ -65,12 +72,45 @@
                 <% end %>
               </div>
             </div>
-            <div class="site-nav__user">
-              <%= link_to current_user.name, coplan.profile_path(current_user.username.presence || current_user.id), class: "site-nav__profile-link" %>
-              <% if main_app.respond_to?(:sign_out_path) %>
-                <%= link_to "Sign out", main_app.sign_out_path, data: { turbo_method: :delete } %>
-              <% end %>
-            </div>
+            <%# One menu for the low-priority surface (Feed) and account.
+                Reuses the app's popover menu (native light-dismiss + Esc). %>
+            <span class="site-nav__menu" data-controller="coplan--menu">
+              <button type="button" class="site-nav__menu-btn"
+                      popovertarget="nav-menu" data-coplan--menu-target="trigger"
+                      aria-label="Menu" title="Menu">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+              </button>
+              <div id="nav-menu" popover="auto" class="menu" data-coplan--menu-target="menu"
+                   data-action="toggle->coplan--menu#reposition" role="menu" aria-label="Menu">
+                <%= link_to coplan.home_path, class: "menu__item", role: "menuitem" do %>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 5h16"/><path d="M4 12h16"/><path d="M4 19h10"/></svg>
+                  <span>Feed</span>
+                <% end %>
+                <%# Notifications also lives here as the phone fallback — hidden
+                    while the bell is on the bar (see .menu__item--notifications). %>
+                <%= link_to coplan.notifications_path, class: "menu__item menu__item--notifications", role: "menuitem" do %>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+                  <span>Notifications</span>
+                  <% if unread > 0 %><span class="menu__badge"><%= unread %></span><% end %>
+                <% end %>
+                <div class="menu__separator" role="separator"></div>
+                <%= link_to coplan.profile_path(current_user.username.presence || current_user.id), class: "menu__item", role: "menuitem" do %>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                  <span>Profile</span>
+                <% end %>
+                <%= link_to coplan.settings_root_path, class: "menu__item", role: "menuitem" do %>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                  <span>Settings</span>
+                <% end %>
+                <% if main_app.respond_to?(:sign_out_path) %>
+                  <div class="menu__separator" role="separator"></div>
+                  <%= link_to main_app.sign_out_path, data: { turbo_method: :delete }, class: "menu__item", role: "menuitem" do %>
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                    <span>Sign out</span>
+                  <% end %>
+                <% end %>
+              </div>
+            </span>
           </div>
         <% elsif main_app.respond_to?(:sign_in_path) %>
           <%# Signed-out visitors need a way in when the host exposes its own

--- a/spec/system/checkbox_spec.rb
+++ b/spec/system/checkbox_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Interactive checkboxes", type: :system do
     fill_in "Email address", with: user.email
     click_button "Sign In"
     expect(page).to have_current_path(root_path)
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   before { sign_in(author) }

--- a/spec/system/comment_anchoring_spec.rb
+++ b/spec/system/comment_anchoring_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Comment anchoring", type: :system do
     fill_in "Email address", with: user.email
     click_button "Sign In"
     expect(page).to have_current_path(root_path)
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   describe "creating a comment via the form" do

--- a/spec/system/comment_ux_spec.rb
+++ b/spec/system/comment_ux_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Comment UX", type: :system do
     # node from the sign-in page mid-navigation, causing "Node with given id
     # does not belong to the document".
     expect(page).to have_current_path(root_path)
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   def create_anchored_thread(plan:, anchor_text:, body:, user:)

--- a/spec/system/folders_workspace_spec.rb
+++ b/spec/system/folders_workspace_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Folders workspace", type: :system do
     visit sign_in_path
     fill_in "Email address", with: user.email
     click_button "Sign In"
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   before { sign_in(author) }

--- a/spec/system/human_editing_spec.rb
+++ b/spec/system/human_editing_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Human plan editing", type: :system do
     visit sign_in_path
     fill_in "Email address", with: user.email
     click_button "Sign In"
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   before { sign_in(author) }
@@ -127,6 +127,7 @@ RSpec.describe "Human plan editing", type: :system do
 
   it "hides owner controls from non-authors" do
     other = create(:coplan_user, email: "viewer@example.com")
+    click_button "Menu"
     click_link "Sign out"
     sign_in(other)
 

--- a/spec/system/nav_stimulus_spec.rb
+++ b/spec/system/nav_stimulus_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Navigation chrome", type: :system do
     visit sign_in_path
     fill_in "Email address", with: u.email
     click_button "Sign In"
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   before { sign_in(user) }

--- a/spec/system/tokens_spec.rb
+++ b/spec/system/tokens_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Token management", type: :system do
     fill_in "Email address", with: "testuser@example.com"
     click_button "Sign In"
     expect(page).to have_current_path(root_path)
-    expect(page).to have_content("Sign out")
+    expect(page).to have_button("Menu")
   end
 
   it "creates a token and displays the raw value via Turbo Stream" do


### PR DESCRIPTION
## Why

The signed-in nav had no clear order of importance — Workspace, Feed, a search box, a settings gear, a notifications bell, the user's name, and sign-out all competed for the bar at once. And a plan's title scrolled away entirely: following a comment notification dropped you into the doc with nothing telling you *where am I?*

## What changed

The bar now reads as three legible zones — **identity → context → tools**:

```
≥641px:   [◧ CoPlan]  [📄 title while reading]  ·····  🔍 Search   🔔  ☰
≤640px:   [◧]         [📄 title]                ·····  🔍          ☰•
```

- **Logo is the Workspace home** — the redundant "Workspace" link is gone. Signed-out visitors still land on the public root.
- **Scroll-aware document title.** A plan's title fades into the bar (IntersectionObserver on `#plan-header`) once the plan's own header scrolls behind it — persistent wayfinding that costs zero space until you need it, which matters most on mobile and on comment deep links. The now-pointless "Contents" label leaves the outline sidebar too.
- **One ☰ menu** for the low-priority surface (Feed) and account (Profile, Settings, Sign out). Reuses the app's existing popover menu (native light-dismiss + Esc).
- **Notifications stays first-class on the bar whenever there's room** — the bell keeps its inline peek panel. Below the phone breakpoint the whole control folds into the menu (Notifications links to the full page there) and the unread count reappears as a **dot on ☰** (driven by the same live `#inbox-badge` count).
- **Touch targets:** the ☰, the folded search icon, and menu rows are all ≥44px hit areas on phones and any coarse pointer.

## Testing

VQA with the agent browser across light + dark, desktop + mobile:

| Check | ✓ |
|---|---|
| Desktop top — calm three-zone bar | ✅ |
| Desktop scrolled — title fades in beside the brand | ✅ |
| Bell → inline peek panel (turbo-frame) opens | ✅ |
| ☰ menu popover, anchored under the button | ✅ light + dark |
| Mobile — logo-only, search icon, ☰ | ✅ |
| Mobile scrolled — title at 58vw, all zones fit | ✅ |
| Mobile — bell folds into menu, ☰ shows unread dot | ✅ |
| Tap targets (☰ / search / menu rows) = 44px | ✅ |

Live notification updates preserved: `#inbox-badge` and its `turbo_stream_from` subscription are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)