### PR TITLE
Refuse comments whose anchor doesn't resolve — no pin, no comment

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1859,6 +1859,16 @@ img.avatar {
   border-radius: 0 var(--radius) var(--radius) 0;
 }
 
+/* Server-side create errors (e.g. an anchor that doesn't resolve).
+   Empty until a failed submit fills it, so it takes no space at rest. */
+.comment-form__error {
+  color: var(--color-danger);
+}
+
+.comment-form__error:not(:empty) {
+  margin-bottom: var(--space-sm);
+}
+
 .comment-form__actions {
   display: flex;
   gap: var(--space-sm);

--- a/engine/app/controllers/coplan/comment_threads_controller.rb
+++ b/engine/app/controllers/coplan/comment_threads_controller.rb
@@ -3,7 +3,7 @@ module CoPlan
     include ActionView::RecordIdentifier
 
     before_action :set_plan
-    before_action :set_thread, only: [:resolve, :accept, :discard, :reopen]
+    before_action :set_thread, only: [ :resolve, :accept, :discard, :reopen ]
 
     def create
       authorize!(@plan, :show?)
@@ -30,13 +30,21 @@ module CoPlan
       # Atomic: a thread without its first comment is an empty orphan whose
       # anchor still highlights.
       comment = nil
-      ActiveRecord::Base.transaction do
-        thread.save!
-        comment = thread.comments.create!(
-          author_type: "human",
-          author_id: current_user.id,
-          body_markdown: thread_params[:body_markdown]
-        )
+      begin
+        ActiveRecord::Base.transaction do
+          thread.save!
+          comment = thread.comments.create!(
+            author_type: "human",
+            author_id: current_user.id,
+            body_markdown: thread_params[:body_markdown]
+          )
+        end
+      rescue ActiveRecord::RecordInvalid => e
+        # Most likely an anchor that doesn't resolve — a thread that would
+        # render nowhere. Refused here rather than created invisible. The
+        # selection form stays open (its reset checks for success) and
+        # shows the message; the 422 lets programmatic clients fall back.
+        return render_comment_error(e.record.errors.full_messages.to_sentence)
       end
 
       CreateNotificationsJob.perform_later(
@@ -54,7 +62,7 @@ module CoPlan
         # authenticity tokens. The inline copy for the actor stays
         # request-scoped.
         Broadcaster.append_to(@plan, target: "plan-threads", partial: "coplan/comment_threads/thread_popover", locals: locals)
-        html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [:html])
+        html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [ :html ])
         inline_streams << turbo_stream.append("plan-threads", html)
       end
 
@@ -66,7 +74,7 @@ module CoPlan
       @thread.resolve!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
       stream = broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread resolved.", streams: [stream])
+      respond_with_stream_or_redirect("Thread resolved.", streams: [ stream ])
     end
 
     def accept
@@ -74,7 +82,7 @@ module CoPlan
       @thread.accept!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
       stream = broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread accepted.", streams: [stream])
+      respond_with_stream_or_redirect("Thread accepted.", streams: [ stream ])
     end
 
     def discard
@@ -82,7 +90,7 @@ module CoPlan
       @thread.discard!(current_user)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
       stream = broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread discarded.", streams: [stream])
+      respond_with_stream_or_redirect("Thread discarded.", streams: [ stream ])
     end
 
     def reopen
@@ -90,10 +98,20 @@ module CoPlan
       @thread.update!(status: "pending", resolved_by_user: nil)
       CreateNotificationsJob.perform_later(comment_thread_id: @thread.id, actor_id: current_user.id, reason: "status_change")
       stream = broadcast_thread_replace(@thread)
-      respond_with_stream_or_redirect("Thread reopened.", streams: [stream])
+      respond_with_stream_or_redirect("Thread reopened.", streams: [ stream ])
     end
 
     private
+
+    def render_comment_error(message)
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.update("new-comment-form-error", message),
+            status: :unprocessable_content
+        end
+        format.html { redirect_to plan_path(@plan), alert: message }
+      end
+    end
 
     def set_plan
       @plan = Plan.find(params[:plan_id])
@@ -123,7 +141,7 @@ module CoPlan
     def broadcast_thread_replace(thread)
       locals = { thread: thread, plan: @plan }
       Broadcaster.replace_to(@plan, target: dom_id(thread), partial: "coplan/comment_threads/thread_popover", locals: locals)
-      html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [:html])
+      html = render_to_string(partial: "coplan/comment_threads/thread_popover", locals: locals, formats: [ :html ])
       turbo_stream.replace(dom_id(thread), html)
     end
   end

--- a/engine/app/javascript/controllers/coplan/text_selection_controller.js
+++ b/engine/app/javascript/controllers/coplan/text_selection_controller.js
@@ -229,6 +229,9 @@ export default class extends Controller {
     this.anchorPreviewTarget.style.display = "none"
     const textarea = this.formTarget.querySelector("textarea")
     if (textarea) textarea.value = ""
+    // A create error from the previous attempt shouldn't greet the next one.
+    const error = this.formTarget.querySelector("#new-comment-form-error")
+    if (error) error.textContent = ""
     this.selectedText = null
     this.selectedContext = null
     this.selectedOccurrence = null

--- a/engine/app/models/coplan/comment_thread.rb
+++ b/engine/app/models/coplan/comment_thread.rb
@@ -17,7 +17,14 @@ module CoPlan
 
     validates :status, presence: true, inclusion: { in: STATUSES }
 
-    before_create :resolve_anchor_position
+    # Resolution runs before validation so validation can see its result:
+    # a thread whose anchor never resolved renders nowhere — no highlight,
+    # no popover, no way to reach it from the page — so it is refused at
+    # the door rather than created invisible. Create-only on both: a
+    # resolved thread whose content later drifts is the out_of_date flow,
+    # not a validity problem.
+    before_validation :resolve_anchor_position, on: :create
+    validate :anchor_must_resolve, on: :create
 
     scope :open_threads, -> { where(status: OPEN_STATUSES) }
     scope :current, -> { where(out_of_date: false) }
@@ -67,7 +74,7 @@ module CoPlan
 
         begin
           new_range = Plans::TransformRange.transform_through_versions(
-            [thread.anchor_start, thread.anchor_end],
+            [ thread.anchor_start, thread.anchor_end ],
             intervening
           )
           thread.update_columns(
@@ -166,8 +173,8 @@ module CoPlan
       content = plan.current_content
       return nil unless content.present?
 
-      context_start = [anchor_start - chars, 0].max
-      context_end = [anchor_end + chars, content.length].min
+      context_start = [ anchor_start - chars, 0 ].max
+      context_end = [ anchor_end + chars, content.length ].min
 
       before = content[context_start...anchor_start]
       anchor = content[anchor_start...anchor_end]
@@ -181,6 +188,12 @@ module CoPlan
     end
 
     private
+
+    def anchor_must_resolve
+      return if anchor_text.blank? || anchor_start.present?
+
+      errors.add(:anchor_text, "doesn't match the plan content — the comment would have nowhere to appear")
+    end
 
     def resolve_anchor_position
       return unless anchor_text.present?
@@ -205,11 +218,20 @@ module CoPlan
         normalized_anchor = anchor_text.gsub("\t", " ")
         stripped_ranges = find_all_occurrences(stripped, normalized_anchor)
 
+        # Mermaid labels line-break on literal <br/> tags, and the browser
+        # reads the label back without them — "first<br/>fetching" renders
+        # (and gets selected) as "firstfetching". Drop the tags from the
+        # search text; the position map keeps pointing at the source.
+        if stripped_ranges.empty?
+          stripped, pos_map = remove_break_tags(stripped, pos_map)
+          stripped_ranges = find_all_occurrences(stripped, normalized_anchor)
+        end
+
         ranges = stripped_ranges.map do |s, e|
           raw_start = first_real_pos(pos_map, s, :forward)
           raw_end = first_real_pos(pos_map, e - 1, :backward)
           next nil unless raw_start && raw_end
-          [raw_start, raw_end + 1]
+          [ raw_start, raw_end + 1 ]
         end.compact
       end
 
@@ -219,6 +241,23 @@ module CoPlan
         self.anchor_end = range[1]
         self.anchor_revision = plan.current_revision
       end
+    end
+
+    # Removes <br>/<br/> tags from stripped text, carrying the position
+    # map along so matches still resolve to raw source positions.
+    def remove_break_tags(text, pos_map)
+      kept = +""
+      map = []
+      last = 0
+      text.scan(/<br\s*\/?>/i) do
+        m = Regexp.last_match
+        kept << text[last...m.begin(0)]
+        map.concat(pos_map[last...m.begin(0)])
+        last = m.end(0)
+      end
+      kept << text[last..]
+      map.concat(pos_map[last..])
+      [ kept, map ]
     end
 
     # Finds the nearest non-sentinel (-1) position in the pos_map,
@@ -236,7 +275,7 @@ module CoPlan
       ranges = []
       start_pos = 0
       while (idx = text.index(search, start_pos))
-        ranges << [idx, idx + search.length]
+        ranges << [ idx, idx + search.length ]
         start_pos = idx + search.length
       end
       ranges

--- a/engine/app/views/coplan/comment_threads/_new_comment_form.html.erb
+++ b/engine/app/views/coplan/comment_threads/_new_comment_form.html.erb
@@ -12,6 +12,9 @@
         data-controller="coplan--comment-form"
         data-coplan--comment-form-search-url-value="<%= search_users_path %>"></textarea>
     </div>
+    <%# Server-side create errors land here (turbo_stream.update) — e.g. a
+        selection whose anchor doesn't resolve against the plan source. %>
+    <div class="comment-form__error text-sm" id="new-comment-form-error"></div>
     <div class="comment-form__actions">
       <button type="submit" class="btn btn--primary btn--sm">Comment</button>
       <button type="button" class="btn btn--secondary btn--sm" data-action="coplan--text-selection#cancelComment">Cancel</button>

--- a/spec/factories/comment_threads.rb
+++ b/spec/factories/comment_threads.rb
@@ -6,8 +6,11 @@ FactoryBot.define do
     status { "pending" }
     out_of_date { false }
 
+    # Threads refuse anchors that don't resolve against the plan content,
+    # so the anchor here is a real substring of the plan factory's default
+    # content_markdown.
     trait :with_anchor do
-      anchor_text { "some anchor text" }
+      anchor_text { "Some content here" }
     end
 
     trait :with_positioned_anchor do

--- a/spec/models/comment_thread_anchor_spec.rb
+++ b/spec/models/comment_thread_anchor_spec.rb
@@ -13,6 +13,48 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
     plan
   end
 
+  describe "anchor_must_resolve on create" do
+    # A thread whose anchor never resolved renders nowhere: no highlight,
+    # no popover, no path to it from the page. Refused at the door rather
+    # than created invisible.
+    it "refuses a thread whose anchor resolves nowhere" do
+      expect {
+        plan.comment_threads.create!(
+          plan_version: plan.current_plan_version,
+          created_by_user: user, anchor_text: "text the plan never says"
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid, /nowhere to appear/)
+    end
+
+    it "refuses an occurrence beyond the ones that exist" do
+      expect {
+        plan.comment_threads.create!(
+          plan_version: plan.current_plan_version,
+          created_by_user: user, anchor_text: "unit tests", anchor_occurrence: 3
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows a thread with no anchor at all" do
+      thread = plan.comment_threads.create!(
+        plan_version: plan.current_plan_version, created_by_user: user
+      )
+      expect(thread).to be_persisted
+    end
+
+    # Content drift after creation is the out_of_date flow, not a validity
+    # problem — an old thread must stay updatable.
+    it "does not re-litigate the anchor on update" do
+      thread = plan.comment_threads.create!(
+        plan_version: plan.current_plan_version,
+        created_by_user: user, anchor_text: "unit tests"
+      )
+      thread.update_columns(anchor_text: "text no longer in the plan", anchor_start: nil, anchor_end: nil)
+
+      expect(thread.reload.update(status: "todo")).to be true
+    end
+  end
+
   describe "resolve_anchor_position on create" do
     it "resolves anchor_text to character positions" do
       thread = plan.comment_threads.create!(
@@ -153,6 +195,13 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
         assert_anchor_resolves(md, "run", "run")
       end
 
+      it "mermaid label text broken by <br/> tags" do
+        md = "```mermaid\nflowchart LR\n  Queue[\"assignment — first<br/>fetching device wins\"] --> Printer\n```"
+        # The browser reads the rendered label back without the tag —
+        # "first<br/>fetching" is selected as "firstfetching".
+        assert_anchor_resolves(md, "firstfetching device wins", "first<br/>fetching device wins")
+      end
+
       it "heading text (strips # markers)" do
         assert_anchor_resolves(
           "# My Heading\n\nContent here.",
@@ -238,7 +287,7 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
       version2 = CoPlan::PlanVersion.create!(
         plan: plan, revision: 2,
         content_markdown: new_content, actor_type: "human", actor_id: user.id,
-        operations_json: [{ "op" => "replace_exact", "resolved_range" => [anchor_pos, anchor_pos + 7], "new_range" => [anchor_pos, anchor_pos + 7], "delta" => 0 }]
+        operations_json: [ { "op" => "replace_exact", "resolved_range" => [ anchor_pos, anchor_pos + 7 ], "new_range" => [ anchor_pos, anchor_pos + 7 ], "delta" => 0 } ]
       )
       plan.update!(current_plan_version: version2, current_revision: 2)
 
@@ -259,7 +308,7 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
       version2 = CoPlan::PlanVersion.create!(
         plan: plan, revision: 2,
         content_markdown: new_content, actor_type: "human", actor_id: user.id,
-        operations_json: [{ "op" => "replace_exact", "resolved_range" => [unit_test_pos, unit_test_pos + 10], "new_range" => [unit_test_pos, unit_test_pos + 17], "delta" => 7 }]
+        operations_json: [ { "op" => "replace_exact", "resolved_range" => [ unit_test_pos, unit_test_pos + 10 ], "new_range" => [ unit_test_pos, unit_test_pos + 17 ], "delta" => 7 } ]
       )
       plan.update!(current_plan_version: version2, current_revision: 2)
 
@@ -283,7 +332,7 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
       version2 = CoPlan::PlanVersion.create!(
         plan: plan, revision: 2,
         content_markdown: new_content, actor_type: "human", actor_id: user.id,
-        operations_json: [{ "op" => "replace_exact", "resolved_range" => [first_pos, first_pos + first_len], "new_range" => [first_pos, first_pos + new_len], "delta" => new_len - first_len }]
+        operations_json: [ { "op" => "replace_exact", "resolved_range" => [ first_pos, first_pos + first_len ], "new_range" => [ first_pos, first_pos + new_len ], "delta" => new_len - first_len } ]
       )
       plan.update!(current_plan_version: version2, current_revision: 2)
 
@@ -305,7 +354,7 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
       version2 = CoPlan::PlanVersion.create!(
         plan: plan, revision: 2,
         content_markdown: new_content, actor_type: "human", actor_id: user.id,
-        operations_json: [{ "op" => "replace_exact", "resolved_range" => [anchor_pos, anchor_pos + 7], "new_range" => [anchor_pos, anchor_pos + 7], "delta" => 0 }]
+        operations_json: [ { "op" => "replace_exact", "resolved_range" => [ anchor_pos, anchor_pos + 7 ], "new_range" => [ anchor_pos, anchor_pos + 7 ], "delta" => 0 } ]
       )
       plan.update!(current_plan_version: version2, current_revision: 2)
 
@@ -317,12 +366,12 @@ RSpec.describe CoPlan::CommentThread, "anchor tracking" do
 
   describe "#anchor_valid?" do
     it "returns true for non-outdated thread" do
-      thread = create(:comment_thread, plan: plan, anchor_text: "some text")
+      thread = create(:comment_thread, plan: plan, anchor_text: "First section")
       expect(thread.anchor_valid?).to be true
     end
 
     it "returns false for outdated thread" do
-      thread = create(:comment_thread, plan: plan, anchor_text: "some text", out_of_date: true)
+      thread = create(:comment_thread, plan: plan, anchor_text: "First section", out_of_date: true)
       expect(thread.anchor_valid?).to be false
     end
 

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -276,13 +276,13 @@ RSpec.describe "Api::V1::Plans", type: :request do
 
   it "comments returns thread list with anchor_text" do
     thread = create(:comment_thread, :with_anchor, plan: plan,
-      plan_version: plan.current_plan_version, created_by_user: alice, anchor_text: "original roadmap text")
+      plan_version: plan.current_plan_version, created_by_user: alice)
     get comments_api_v1_plan_path(plan), headers: headers
     expect(response).to have_http_status(:success)
     threads = JSON.parse(response.body)
     expect(threads).to be_a(Array)
     matching = threads.find { |t| t["id"] == thread.id }
-    expect(matching["anchor_text"]).to eq("original roadmap text")
+    expect(matching["anchor_text"]).to eq("Some content here")
   end
 
   describe "GET /api/v1/plans/:id/snapshot" do

--- a/spec/requests/comment_threads_spec.rb
+++ b/spec/requests/comment_threads_spec.rb
@@ -3,7 +3,16 @@ require "rails_helper"
 RSpec.describe "CommentThreads", type: :request do
   let(:alice) { create(:coplan_user, :admin) }
   let(:bob) { create(:coplan_user) }
-  let(:plan) { create(:plan, :considering, created_by_user: alice) }
+
+  # Threads refuse anchors that don't resolve, so the plan has to actually
+  # say the thing these specs anchor to.
+  let(:plan) do
+    create(:plan, :considering, created_by_user: alice).tap do |p|
+      version = create(:plan_version, plan: p, revision: 2, actor_id: alice.id,
+        content_markdown: "## Ambition\n\nOur goal is world domination by Q3.\n")
+      p.update_columns(current_plan_version_id: version.id, current_revision: 2)
+    end
+  end
 
   before { sign_in_as(alice) }
 
@@ -19,8 +28,35 @@ RSpec.describe "CommentThreads", type: :request do
     expect(response).to redirect_to(plan_path(plan))
     thread = CoPlan::CommentThread.last
     expect(thread.anchor_text).to eq("world domination")
+    expect(thread.anchor_start).to be_present # resolved at the door
     expect(thread.status).to eq("todo") # author's own comments start as todo
     expect(thread.plan_version_id).to eq(plan.current_plan_version_id)
+  end
+
+  # A thread whose anchor never resolved renders nowhere — no highlight, no
+  # popover, no way to reach it. "Comment posted" followed by nothing
+  # visible is worse than a refusal.
+  describe "when the anchor doesn't resolve against the plan" do
+    it "refuses to create the thread" do
+      expect {
+        post plan_comment_threads_path(plan), params: {
+          comment_thread: { anchor_text: "text the plan never says", body_markdown: "Lost forever." }
+        }
+      }.not_to change { [ CoPlan::CommentThread.count, CoPlan::Comment.count ] }
+
+      expect(response).to redirect_to(plan_path(plan))
+      expect(flash[:alert]).to include("nowhere to appear")
+    end
+
+    it "tells a turbo-stream client with a 422 so it can fall back" do
+      post plan_comment_threads_path(plan),
+        params: { comment_thread: { anchor_text: "text the plan never says", body_markdown: "Lost." } },
+        headers: { "Accept" => "text/vnd.turbo-stream.html, text/html" }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("new-comment-form-error")
+      expect(response.body).to include("nowhere to appear")
+    end
   end
 
   it "broadcasts the popover via requestless partial render, never request-scoped HTML" do

--- a/spec/system/mermaid_anchor_spec.rb
+++ b/spec/system/mermaid_anchor_spec.rb
@@ -57,8 +57,11 @@ RSpec.describe "Comment anchors and Mermaid diagrams", type: :system do
       # An anchor that carries stylesheet text — the shape of anchors captured
       # by sweeping a selection across a diagram before capture excluded
       # non-rendered text. This string appears verbatim in the <style> of
-      # every Mermaid SVG and nowhere in the rendered text.
-      poisoned = create(:comment_thread, plan: plan, anchor_text: 'font-family:"trebuchet ms"')
+      # every Mermaid SVG and nowhere in the rendered text. Creation now
+      # refuses anchors that don't resolve, so this legacy row is written
+      # past validation, the way it actually exists in old data.
+      poisoned = create(:comment_thread, plan: plan)
+      poisoned.update_columns(anchor_text: 'font-family:"trebuchet ms"')
       create(:comment, comment_thread: poisoned, author_id: user.id)
 
       # A legitimate anchor on a diagram node label — marks inside rendered


### PR DESCRIPTION
## The hole

A comment thread whose anchor never resolved to source positions renders **nowhere** — no highlight, no popover, no path to it from the page. Yet `create` happily persisted it and told the user "Comment added." The comment went into the void, and nothing anywhere said so.

This is easy to hit: any anchor captured from rendered text that the resolver can't map back to the markdown source (or an `anchor_occurrence` past the ones that exist) produced an invisible thread.

## The rule

**No pin, no comment.** `CommentThread` now validates on create that a present anchor actually resolved:

- Resolution moves from `before_create` to `before_validation, on: :create` so validation can see its result.
- Both stay create-only: content drift *after* creation is the existing `out_of_date` flow, not a validity problem — old threads stay updatable.
- Anchor-less (general) threads are unaffected.

On refusal:
- The selection form keeps the draft and shows the error inline (new `#new-comment-form-error` region updated via turbo stream with a 422; the form's reset already checks `event.detail.success`, so nothing is lost).
- A plain HTML post redirects back with an alert.
- The JSON API already returned 422 for `RecordInvalid`, so programmatic clients were covered.

## The resolver gap the rule surfaced

Mermaid labels line-break on literal `<br/>` tags, and the browser reads the rendered label back without them — `first<br/>fetching` gets selected as `firstfetching`. That never matched the source, so these were exactly the invisible-position threads described above (client-side highlighting made them *look* pinned until the next edit unconditionally expired them). The resolver gains a pass that drops the tags from the stripped text, carrying the position map along — these anchors now resolve to real positions and survive edits through OT like everything else.

## Tests

The specs that had to change are the proof of the hole: the factory's `:with_anchor` trait and several request specs anchored to text their plans never contained, and nothing ever noticed. New coverage for the validation (model + both response shapes), the occurrence-out-of-range case, the update-doesn't-re-litigate case, and the `<br/>` resolution.

Full suite: 1334 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)