### PR TITLE
Voice commenting: push-to-talk dictation pinned to what you were reading

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -762,6 +762,103 @@ img, svg {
   white-space: nowrap;
 }
 
+/* Voice push-to-talk — mic button + transient transcript/status text. */
+/* The mic follows the scroll. A dictated comment is pinned to whatever
+   passage is on screen when you speak, so a control that lives in the
+   masthead would make you scroll away from the thing you're talking
+   about in order to say anything about it. */
+.voice-control {
+  position: fixed;
+  right: var(--space-lg);
+  bottom: var(--space-lg);
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  flex-direction: row-reverse;
+  gap: var(--space-sm);
+}
+
+.voice-control .voice-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  color: var(--color-text-muted, currentColor);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 2px 12px rgb(0 0 0 / 12%);
+  backdrop-filter: blur(8px);
+  transition: transform 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.voice-control .voice-btn:hover {
+  background: var(--color-surface-raised, var(--color-surface));
+  color: var(--color-text, currentColor);
+  transform: scale(1.06);
+}
+
+/* Recording reads as recording: the button fills red, and a ring grows
+   with how loud you are. The fill says "the mic is open"; only the ring
+   says "it can hear you", which is the question you actually have while
+   talking to a button. */
+.voice-control .voice-btn--listening,
+.voice-control .voice-btn--listening:hover {
+  color: #fff;
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+  transform: scale(1.06);
+  animation: voice-btn-pulse 1.2s ease-in-out infinite;
+  box-shadow:
+    0 2px 12px rgb(0 0 0 / 18%),
+    0 0 0 calc(var(--voice-level, 0) * 0.55rem) rgb(from var(--color-danger) r g b / 25%);
+  transition: box-shadow 90ms ease-out, transform 120ms ease;
+}
+
+@keyframes voice-btn-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.35; transform: scale(0.8); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-btn--listening {
+    animation: none;
+  }
+}
+
+/* Status sits to the left of the button, and only takes up room when it
+   has something to say. */
+.voice-status {
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-status:not(:empty) {
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 2px 12px rgb(0 0 0 / 12%);
+}
+
+@media (max-width: 640px) {
+  .voice-control {
+    right: var(--space-md);
+    bottom: calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
+  }
+
+  .voice-status {
+    max-width: 10rem;
+  }
+}
+
+.voice-status--error {
+  color: var(--color-danger);
+}
+
 /* Flash messages */
 .flash {
   padding: var(--space-md) var(--space-lg);

--- a/engine/app/controllers/coplan/comment_threads_controller.rb
+++ b/engine/app/controllers/coplan/comment_threads_controller.rb
@@ -43,7 +43,8 @@ module CoPlan
         # Most likely an anchor that doesn't resolve — a thread that would
         # render nowhere. Refused here rather than created invisible. The
         # selection form stays open (its reset checks for success) and
-        # shows the message; the 422 lets programmatic clients fall back.
+        # shows the message; the voice client retries on this status with
+        # its viewport fallback.
         return render_comment_error(e.record.errors.full_messages.to_sentence)
       end
 

--- a/engine/app/controllers/coplan/dictations_controller.rb
+++ b/engine/app/controllers/coplan/dictations_controller.rb
@@ -1,0 +1,197 @@
+module CoPlan
+  # "What did I just say, and what was I looking at?" — asked by the voice
+  # control after recording, before it posts the comment.
+  #
+  # Takes either a transcript the browser produced itself or the recorded
+  # audio, which is transcribed here. Deliberately a separate request from
+  # creating the comment: these are the slow, failure-prone calls, and the
+  # comment must not depend on them.
+  class DictationsController < ApplicationController
+    before_action :set_plan
+
+    # Long enough for a few minutes of Opus, short enough that a stuck
+    # recorder can't post a file the size of a video.
+    MAX_AUDIO_BYTES = 20.megabytes
+
+    # Nobody speaks faster than this. Conversational English runs about
+    # 14 characters a second; auctioneers manage roughly double. A
+    # transcript past the ceiling contains words there was no time to
+    # say — it was generated, not heard. The slack absorbs very short
+    # clips, where rate estimates are mostly rounding.
+    MAX_TRANSCRIPT_CHARS_PER_SECOND = 30
+    TRANSCRIPT_SLACK_CHARS = 80
+
+    # OpenAI infers the audio format from the filename, so an uploaded
+    # blob needs an extension it recognises. Chrome records WebM/Opus,
+    # Safari records MP4/AAC.
+    AUDIO_EXTENSIONS = {
+      "audio/webm" => ".webm", "video/webm" => ".webm",
+      "audio/ogg" => ".ogg", "audio/oga" => ".oga",
+      "audio/mp4" => ".mp4", "video/mp4" => ".mp4",
+      "audio/x-m4a" => ".m4a", "audio/aac" => ".m4a",
+      "audio/mpeg" => ".mp3", "audio/mp3" => ".mp3",
+      "audio/wav" => ".wav", "audio/x-wav" => ".wav", "audio/wave" => ".wav"
+    }.freeze
+
+    def create
+      authorize!(@plan, :show?)
+
+      transcript = spoken_text
+      result = Comments::InterpretDictation.call(
+        excerpt: excerpt,
+        # The span has to resolve against the markdown, not against the
+        # rendered text the model was shown.
+        document: @plan.current_content,
+        transcript: transcript,
+        # Dictation is conversational in a way typing isn't: the next
+        # remark after "it should be main" is "oh, I meant both of them",
+        # and without the earlier comment there is no "it" to resolve.
+        recent_comments: recent_comments
+      )
+
+      # Which copy of the span it is stays the client's job — it can see
+      # the rendered document and where in it the person was looking,
+      # which is how selection-anchored comments already work.
+      # body/anchor_text are the first comment, kept for anything reading
+      # the old singular shape; comments is the real answer ("rename both
+      # of these" is two placements).
+      render json: {
+        transcript: transcript,
+        body: result.body,
+        anchor_text: result.anchor_text,
+        comments: result.comments.map { |c| { body: c.body, anchor_text: c.anchor_text } }
+      }
+    rescue Transcription::Inaudible
+      render json: { error: "Didn't hear anything" }, status: :unprocessable_content
+    rescue Transcription::Fabricated
+      render json: { error: "Didn't catch that — try saying it again" }, status: :unprocessable_content
+    rescue Ai::Error => e
+      # Only reachable when there was audio and nothing else: interpreting
+      # has its own fallbacks, but an untranscribed recording is not a
+      # comment, and saying so beats posting silence.
+      Rails.logger.warn("[coplan] transcription failed: #{e.message}")
+      render json: { error: "Couldn't make out the recording" }, status: :bad_gateway
+    end
+
+    module Transcription
+      # Silence in, prompt out — see #reject_prompt_echo.
+      class Inaudible < StandardError; end
+      # More words out than went in — see #reject_fabrication.
+      class Fabricated < StandardError; end
+    end
+
+    private
+
+    def set_plan
+      @plan = Plan.find(params[:plan_id])
+    end
+
+    # The browser's own recognition when it has any, otherwise the audio
+    # it recorded. Server-side transcription is the better of the two even
+    # where both exist — see the voice controller for who sends what.
+    def spoken_text
+      typed = params[:transcript].to_s
+      return typed unless typed.strip.empty?
+      return "" if params[:audio].blank?
+
+      transcribe(params[:audio])
+    end
+
+    def transcribe(upload)
+      raise Ai::Error, "recording is #{upload.size} bytes" if upload.size > MAX_AUDIO_BYTES
+
+      Tempfile.create([ "dictation", extension_for(upload) ], binmode: true) do |file|
+        IO.copy_stream(upload.tempfile, file)
+        file.flush
+        file.rewind
+        # What was on screen doubles as a pronunciation hint: it is where
+        # the jargon, product names and figures being spoken about live.
+        transcript = reject_prompt_echo(Ai.transcribe(file: file, context: excerpt))
+        return transcript unless fabricated?(transcript)
+
+        # The transcriber is a chat model with ears, and given an
+        # instruction-shaped remark plus a prompt full of context it will
+        # sometimes answer instead of transcribing — "add some content
+        # about how editing works" once came back as a whole essay,
+        # complete with figures lifted from the prompt. The prompt is
+        # what it builds the answer from, so the retry goes without one:
+        # worse at jargon, but it can only write down what it heard.
+        Rails.logger.info(
+          "[coplan] dictation rejected as fabricated (#{transcript.length} chars " \
+          "in #{duration_ms}ms), retrying without the prompt"
+        )
+        file.rewind
+        transcript = reject_prompt_echo(Ai.transcribe(file: file))
+        raise Transcription::Fabricated if fabricated?(transcript)
+
+        transcript
+      end
+    end
+
+    # More characters than the recording had seconds to hold. Only
+    # checkable when the client said how long the take was; without a
+    # duration the transcript is taken at its word, as before.
+    def fabricated?(transcript)
+      return false unless duration_ms.positive?
+
+      transcript.length > (duration_ms / 1000.0) * MAX_TRANSCRIPT_CHARS_PER_SECOND + TRANSCRIPT_SLACK_CHARS
+    end
+
+    def duration_ms
+      params[:duration_ms].to_i
+    end
+
+    # Whisper-family models answer silence by repeating their own prompt.
+    # Given two seconds of digital silence and a page about trunk-based
+    # development, the "transcript" comes back as the page's first
+    # heading — which then reads as a comment nobody wrote, pinned to the
+    # very text it was copied from.
+    #
+    # Anything wholly contained in what we sent is treated as an echo.
+    # Reading a sentence off the page aloud trips this too; being told
+    # "didn't hear anything" and repeating yourself is a far better
+    # outcome than a comment putting words in your mouth.
+    def reject_prompt_echo(transcript)
+      if normalize(excerpt).include?(normalize(transcript))
+        # Logged because this guard has eaten real speech before (a
+        # too-late capture posts only the tail of a sentence): the next
+        # false rejection should be diagnosable from the log line alone.
+        Rails.logger.info("[coplan] dictation rejected as prompt echo: #{transcript.truncate(120).inspect}")
+        raise Transcription::Inaudible
+      end
+
+      transcript
+    end
+
+    def recent_comments
+      Comment.joins(:comment_thread)
+        .where(comment_thread: { plan_id: @plan.id })
+        .order(created_at: :desc).limit(3)
+        .includes(:comment_thread)
+        .map { |c| { body: c.body_markdown, anchor: c.comment_thread.anchor_text } }
+    end
+
+    def normalize(text)
+      text.to_s.downcase.gsub(/\s+/, " ").strip
+    end
+
+    def extension_for(upload)
+      mime = upload.content_type.to_s.split(";").first
+      AUDIO_EXTENSIONS[mime] ||
+        File.extname(upload.original_filename.to_s).presence ||
+        ".webm"
+    end
+
+    # Only what the person could actually see. Narrower is better on
+    # every axis: the model picks the passage more accurately, has the
+    # right context for repairing mis-transcribed jargon, the call is
+    # cheaper, and less of the document leaves the building. Falls back
+    # to the whole plan when the client can't say what was on screen.
+    def excerpt
+      visible = params[:excerpt].to_s
+      return @plan.current_content.to_s if visible.strip.empty?
+
+      visible.truncate(8_000, omission: "")
+    end
+  end
+end

--- a/engine/app/controllers/coplan/dictations_controller.rb
+++ b/engine/app/controllers/coplan/dictations_controller.rb
@@ -164,7 +164,9 @@ module CoPlan
     end
 
     def recent_comments
-      Comment.joins(:comment_thread)
+      # kept: a deleted comment's text was removed on purpose, and this
+      # context leaves the building — it must not resurface there.
+      Comment.kept.joins(:comment_thread)
         .where(comment_thread: { plan_id: @plan.id })
         .order(created_at: :desc).limit(3)
         .includes(:comment_thread)

--- a/engine/app/javascript/controllers/coplan/text_selection_controller.js
+++ b/engine/app/javascript/controllers/coplan/text_selection_controller.js
@@ -270,6 +270,14 @@ export default class extends Controller {
     if (this._pendingThreadId) this._openLinkedThread()
   }
 
+  // Another controller created a thread on the person's behalf (voice
+  // dictation) and wants them shown where it landed — same scroll-and-
+  // open treatment as arriving via ?thread=ID.
+  openThread(event) {
+    this._pendingThreadId = event.detail.threadId
+    this._openLinkedThread()
+  }
+
   async copyThreadLink(event) {
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
 

--- a/engine/app/javascript/controllers/coplan/voice_controller.js
+++ b/engine/app/javascript/controllers/coplan/voice_controller.js
@@ -39,6 +39,10 @@ export default class extends Controller {
   // past 20. Anything under this never made it to the microphone.
   static SILENCE_PEAK = 6
 
+  // How long Shift must be held before the press means "talk" — a tap
+  // that short is someone typing a capital letter.
+  static HOLD_DELAY = 350
+
   connect() {
     this.mode = this._chooseMode()
     if (!this.mode) {
@@ -50,15 +54,22 @@ export default class extends Controller {
 
     this.listening = false
     this._watchAgentPill()
-    this._enablePushToTalk()
   }
 
   disconnect() {
+    // A capture can be mid-flight — _startRecording awaiting the
+    // microphone, the hold timer still deciding. Mark the take dead
+    // first, so a promise that resumes after this teardown bails out
+    // through its own cleanup instead of starting a recorder nobody
+    // can see or stop.
+    this.listening = false
+    this.discarded = true
+    clearTimeout(this.holdTimer)
+    this.pushToTalk = false
     this._closeEar()
     this._releaseMic()
     this.recognition?.abort()
     this.pillObserver?.disconnect()
-    this._disablePushToTalk()
     clearInterval(this.tickTimer)
   }
 
@@ -87,77 +98,73 @@ export default class extends Controller {
     this.listening ? this._stop() : this._start()
   }
 
-  // Hold Shift to talk, release to send.
+  // Hold Shift to talk, release to send. Bound declaratively on the
+  // control's element (keydown@document / keyup@document / blur@window)
+  // — document and window are stable targets, so Stimulus owns the
+  // listener lifecycle.
   //
   // Shift is also held while typing capitals and extending a selection,
   // so a bare press isn't enough of a signal. Three guards keep it from
   // firing by accident: it must be Shift alone with no other key down, it
   // must be held past a short delay (capitals are a tap), and any other
   // keystroke or a text selection cancels without posting.
-  _enablePushToTalk() {
-    this.HOLD_DELAY = 350
+  keyDown(event) {
+    if (!this.mode) return
 
-    this._onKeyDown = (event) => {
-      if (event.key !== "Shift") {
-        // Shift+something is a shortcut or a capital letter, not talking.
-        if (this.pushToTalk) this._cancel()
-        else if (this.ear) {
-          clearTimeout(this.holdTimer)
-          this._closeEar()
-        }
-        return
-      }
-      if (event.repeat || this.pushToTalk || this.listening) return
-      if (this._isTyping() || event.metaKey || event.ctrlKey || event.altKey) return
-
-      // Capture from the instant of the press. Deciding whether the press
-      // means "talk" takes 350ms and opening the microphone takes a couple
-      // hundred more — people start talking at the press, and "oh, I meant
-      // both of them" is over before a capture that waits for both. If
-      // this turns out to be a tap or a selection, the take is discarded
-      // unheard.
-      if (this.mode === "record") this._openEar()
-
-      this.holdTimer = setTimeout(() => {
-        // Extending a selection with Shift+arrow or Shift+click also
-        // holds Shift; if text got selected, that's what was happening.
-        if (!window.getSelection()?.isCollapsed) {
-          this._closeEar()
-          return
-        }
-        this.pushToTalk = true
-        this._start()
-      }, this.HOLD_DELAY)
-    }
-
-    this._onKeyUp = (event) => {
-      if (event.key !== "Shift") return
-      clearTimeout(this.holdTimer)
-      if (!this.pushToTalk) {
-        this._closeEar() // a tap: whatever the ear caught is dropped
-        return
-      }
-
-      this.pushToTalk = false
-      this._stop()
-    }
-
-    // Losing the window means we never see the keyup — don't leave the
-    // mic open, and don't post something half-said.
-    this._onInterrupt = () => {
+    if (event.key !== "Shift") {
+      // Shift+something is a shortcut or a capital letter, not talking.
       if (this.pushToTalk) this._cancel()
+      else if (this.ear) {
+        clearTimeout(this.holdTimer)
+        this._closeEar()
+      }
+      return
     }
+    if (event.repeat || this.pushToTalk || this.listening) return
+    if (this._isTyping() || event.metaKey || event.ctrlKey || event.altKey) return
 
-    document.addEventListener("keydown", this._onKeyDown)
-    document.addEventListener("keyup", this._onKeyUp)
-    window.addEventListener("blur", this._onInterrupt)
+    // Capture from the instant of the press. Deciding whether the press
+    // means "talk" takes 350ms and opening the microphone takes a couple
+    // hundred more — people start talking at the press, and "oh, I meant
+    // both of them" is over before a capture that waits for both. If
+    // this turns out to be a tap or a selection, the take is discarded
+    // unheard.
+    if (this.mode === "record") this._openEar()
+
+    this.holdTimer = setTimeout(() => {
+      // Extending a selection with Shift+arrow or Shift+click also
+      // holds Shift; if text got selected, that's what was happening.
+      if (!window.getSelection()?.isCollapsed) {
+        this._closeEar()
+        return
+      }
+      this.pushToTalk = true
+      this._start()
+    }, this.constructor.HOLD_DELAY)
   }
 
-  _disablePushToTalk() {
+  keyUp(event) {
+    if (!this.mode || event.key !== "Shift") return
+
     clearTimeout(this.holdTimer)
-    document.removeEventListener("keydown", this._onKeyDown)
-    document.removeEventListener("keyup", this._onKeyUp)
-    window.removeEventListener("blur", this._onInterrupt)
+    if (!this.pushToTalk) {
+      this._closeEar() // a tap: whatever the ear caught is dropped
+      return
+    }
+
+    this.pushToTalk = false
+    this._stop()
+  }
+
+  // Losing the window means we never see the keyup — don't leave the
+  // mic open, and don't post something half-said. That includes losing
+  // it during the hold delay, before push-to-talk is confirmed: the
+  // pending timer would otherwise start a take whose keyup can never
+  // arrive, recording indefinitely.
+  interrupt() {
+    clearTimeout(this.holdTimer)
+    if (this.pushToTalk) this._cancel()
+    else this._closeEar()
   }
 
   _isTyping() {

--- a/engine/app/javascript/controllers/coplan/voice_controller.js
+++ b/engine/app/javascript/controllers/coplan/voice_controller.js
@@ -1,0 +1,792 @@
+import { Controller } from "@hotwired/stimulus"
+
+/*
+ * coplan--voice
+ *
+ * Push-to-talk commenting. Hold Shift (or tap the mic), say "this section
+ * is way too formal", and what you said is posted as a comment pinned to
+ * the passage you were looking at.
+ *
+ * Two ways to capture, and which one is in play matters:
+ *
+ *   record    MediaRecorder captures audio and the server transcribes it.
+ *             Works in every browser with a microphone, and the
+ *             transcription is far better — it gets a hint of what was on
+ *             screen, so jargon, product names and figures come through
+ *             instead of being guessed at phonetically. Costs a round
+ *             trip and gives no live captions.
+ *   recognize The browser's own SpeechRecognition. Instant and free, with
+ *             interim text as you speak, but Chrome-only in practice and
+ *             noticeably worse at anything domain-specific.
+ *
+ * Recording wins when the server can transcribe, because accuracy is the
+ * whole ballgame: a comment that says something you didn't is worse than
+ * no comment. Recognition is the fallback, and with neither the control
+ * hides itself.
+ *
+ * It promises nothing about agents. If one happens to be attached the
+ * comment wakes it through the normal event inbox, its pill flips to
+ * active, and this controller speaks a short acknowledgment ("Got it.")
+ * at that moment. With nobody attached it's simply a dictated comment,
+ * which stays in the durable inbox for whichever agent attaches next.
+ */
+export default class extends Controller {
+  static targets = ["button", "status"]
+  static values = { url: String, dictationUrl: String, transcription: Boolean }
+
+  // Peak deviation from silence, on the 0–128 scale of the time-domain
+  // samples. Room tone sits in the low single digits; speech is well
+  // past 20. Anything under this never made it to the microphone.
+  static SILENCE_PEAK = 6
+
+  connect() {
+    this.mode = this._chooseMode()
+    if (!this.mode) {
+      this.element.style.display = "none"
+      return
+    }
+
+    if (this.mode === "recognize") this._setUpRecognition()
+
+    this.listening = false
+    this._watchAgentPill()
+    this._enablePushToTalk()
+  }
+
+  disconnect() {
+    this._closeEar()
+    this._releaseMic()
+    this.recognition?.abort()
+    this.pillObserver?.disconnect()
+    this._disablePushToTalk()
+    clearInterval(this.tickTimer)
+  }
+
+  _chooseMode() {
+    const canRecord = !!(navigator.mediaDevices?.getUserMedia && window.MediaRecorder)
+    if (this.transcriptionValue && canRecord) return "record"
+    if (window.SpeechRecognition || window.webkitSpeechRecognition) return "recognize"
+    return null
+  }
+
+  _setUpRecognition() {
+    const Recognition = window.SpeechRecognition || window.webkitSpeechRecognition
+    this.recognition = new Recognition()
+    this.recognition.continuous = false
+    this.recognition.interimResults = true
+    this.recognition.lang = document.documentElement.lang || "en-US"
+    this.recognition.onresult = (e) => this._onResult(e)
+    this.recognition.onend = () => this._onRecognitionEnd()
+    this.recognition.onerror = (e) =>
+      this._setStatus(e.error === "no-speech" ? "Didn't catch that" : "Mic error", true)
+  }
+
+  // ── The gesture ────────────────────────────────────────────────────
+
+  toggle() {
+    this.listening ? this._stop() : this._start()
+  }
+
+  // Hold Shift to talk, release to send.
+  //
+  // Shift is also held while typing capitals and extending a selection,
+  // so a bare press isn't enough of a signal. Three guards keep it from
+  // firing by accident: it must be Shift alone with no other key down, it
+  // must be held past a short delay (capitals are a tap), and any other
+  // keystroke or a text selection cancels without posting.
+  _enablePushToTalk() {
+    this.HOLD_DELAY = 350
+
+    this._onKeyDown = (event) => {
+      if (event.key !== "Shift") {
+        // Shift+something is a shortcut or a capital letter, not talking.
+        if (this.pushToTalk) this._cancel()
+        else if (this.ear) {
+          clearTimeout(this.holdTimer)
+          this._closeEar()
+        }
+        return
+      }
+      if (event.repeat || this.pushToTalk || this.listening) return
+      if (this._isTyping() || event.metaKey || event.ctrlKey || event.altKey) return
+
+      // Capture from the instant of the press. Deciding whether the press
+      // means "talk" takes 350ms and opening the microphone takes a couple
+      // hundred more — people start talking at the press, and "oh, I meant
+      // both of them" is over before a capture that waits for both. If
+      // this turns out to be a tap or a selection, the take is discarded
+      // unheard.
+      if (this.mode === "record") this._openEar()
+
+      this.holdTimer = setTimeout(() => {
+        // Extending a selection with Shift+arrow or Shift+click also
+        // holds Shift; if text got selected, that's what was happening.
+        if (!window.getSelection()?.isCollapsed) {
+          this._closeEar()
+          return
+        }
+        this.pushToTalk = true
+        this._start()
+      }, this.HOLD_DELAY)
+    }
+
+    this._onKeyUp = (event) => {
+      if (event.key !== "Shift") return
+      clearTimeout(this.holdTimer)
+      if (!this.pushToTalk) {
+        this._closeEar() // a tap: whatever the ear caught is dropped
+        return
+      }
+
+      this.pushToTalk = false
+      this._stop()
+    }
+
+    // Losing the window means we never see the keyup — don't leave the
+    // mic open, and don't post something half-said.
+    this._onInterrupt = () => {
+      if (this.pushToTalk) this._cancel()
+    }
+
+    document.addEventListener("keydown", this._onKeyDown)
+    document.addEventListener("keyup", this._onKeyUp)
+    window.addEventListener("blur", this._onInterrupt)
+  }
+
+  _disablePushToTalk() {
+    clearTimeout(this.holdTimer)
+    document.removeEventListener("keydown", this._onKeyDown)
+    document.removeEventListener("keyup", this._onKeyUp)
+    window.removeEventListener("blur", this._onInterrupt)
+  }
+
+  _isTyping() {
+    const el = document.activeElement
+    if (!el) return false
+    return el.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName)
+  }
+
+  // ── Capture ────────────────────────────────────────────────────────
+
+  _start() {
+    // The remark is about what was on screen while it was being said —
+    // all of it. People start talking about one paragraph and scroll to
+    // another mid-sentence, so the excerpt accumulates: sampled here, on
+    // every tick while listening, and once more when the take ends.
+    this.seenBlocks = new Set(this._visibleBlocks())
+    this.finalTranscript = ""
+    this.awaitingAck = false
+    this.discarded = false
+    this.recorder = null
+    this.peakLevel = 0
+    this.meterLive = false
+    this.stopRequested = false
+    this.listening = true
+    this.buttonTarget.classList.add("voice-btn--listening")
+    this._startTicking()
+
+    if (this.mode === "record") this._startRecording()
+    else this.recognition.start()
+  }
+
+  _stop() {
+    if (!this.listening) return
+
+    if (this.mode !== "record") {
+      this.recognition?.stop() // → onend posts
+      return
+    }
+
+    // Released while the microphone is still opening (the permission
+    // prompt, usually). The take isn't lost — as soon as the recorder
+    // exists it is stopped and whatever was captured goes out.
+    if (!this.recorder) {
+      this.stopRequested = true
+      return
+    }
+
+    this.recorder.stop() // → onstop posts
+  }
+
+  // Discards whatever was captured rather than posting it.
+  _cancel() {
+    clearTimeout(this.holdTimer)
+    this.pushToTalk = false
+    this._closeEar()
+    if (!this.listening) return
+
+    this.discarded = true
+    if (this.mode === "record") this.recorder?.stop()
+    else this.recognition?.abort()
+
+    this._stopListening()
+    this._setStatus("")
+  }
+
+  _stopListening() {
+    this.listening = false
+    this.buttonTarget.classList.remove("voice-btn--listening")
+    clearInterval(this.tickTimer)
+  }
+
+  // No live captions in record mode, so the elapsed count is the whole of
+  // the "yes, it can hear you" signal.
+  _startTicking() {
+    if (this.mode !== "record") {
+      this._setStatus("Listening…")
+      return
+    }
+
+    let seconds = 0
+    this._setStatus("Listening…")
+    clearInterval(this.tickTimer)
+    this.tickTimer = setInterval(() => {
+      seconds += 1
+      this._setStatus(`Listening… ${seconds}s`)
+      this._visibleBlocks().forEach((block) => this.seenBlocks.add(block))
+    }, 1000)
+  }
+
+  // A capture begun before the decision to keep it: stream + recorder,
+  // buffering silently, no UI. Adopted by _startRecording when the hold
+  // is confirmed; discarded unheard by _closeEar when it turns out to be
+  // a tap, a selection, or a shortcut. The cost of a false start is a
+  // blink of the browser's recording indicator.
+  _openEar() {
+    if (this.ear) return
+
+    const ear = { chunks: [], closed: false }
+    ear.ready = (async () => {
+      try {
+        ear.stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      } catch {
+        ear.error = true
+        return
+      }
+      if (ear.closed) {
+        ear.stream.getTracks().forEach((track) => track.stop())
+        ear.stream = null
+        return
+      }
+      ear.recorder = new MediaRecorder(ear.stream, this._recorderOptions())
+      ear.recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) ear.chunks.push(event.data)
+      }
+      ear.recorder.start()
+      ear.startedAt = performance.now()
+    })()
+    this.ear = ear
+  }
+
+  _closeEar() {
+    const ear = this.ear
+    this.ear = null
+    if (!ear) return
+
+    ear.closed = true
+    if (ear.recorder && ear.recorder.state !== "inactive") ear.recorder.stop()
+    ear.stream?.getTracks().forEach((track) => track.stop())
+  }
+
+  async _startRecording() {
+    const ear = this.ear
+    this.ear = null
+    let chunks = []
+
+    if (ear) {
+      // Push-to-talk: the ear has been capturing since the keydown.
+      await ear.ready
+    } else {
+      // The button path has no press-to-decide gap, so it captures from
+      // the click itself. A fresh stream per recording either way:
+      // holding one open leaves the recording indicator lit while
+      // nobody is talking.
+      try {
+        this.stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      } catch {
+        this._stopListening()
+        this._reportMiss("Mic blocked")
+        return
+      }
+    }
+
+    if (ear?.error) {
+      this._stopListening()
+      this._reportMiss("Mic blocked")
+      return
+    }
+
+    // Cancelled while the permission prompt was up.
+    if (!this.listening) {
+      if (ear) {
+        ear.closed = true
+        ear.recorder?.stop()
+        ear.stream?.getTracks().forEach((track) => track.stop())
+      }
+      this._releaseMic()
+      return
+    }
+
+    if (ear) {
+      this.stream = ear.stream
+      this.recorder = ear.recorder
+      this.recordingStartedAt = ear.startedAt ?? performance.now()
+      chunks = ear.chunks
+    } else {
+      this.recorder = new MediaRecorder(this.stream, this._recorderOptions())
+      this.recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunks.push(event.data)
+      }
+    }
+
+    this._meterLevels()
+
+    this.recorder.onstop = () => {
+      // The silence verdict is only trustworthy if the meter actually
+      // ran. A dead meter reads 0 for a recording full of speech — when
+      // in doubt, send it; the server's echo check is the backstop.
+      const heardSomething = !this.meterLive || this.peakLevel >= this.constructor.SILENCE_PEAK
+      // How long the take was bounds how many words can be in it — the
+      // server uses this to spot a "transcript" the model made up.
+      const durationMs = Math.round(performance.now() - this.recordingStartedAt)
+      this._releaseMic()
+      this._stopListening()
+      if (this.discarded) return
+
+      const blob = new Blob(chunks, { type: this.recorder.mimeType })
+      // Sending silence is worse than sending nothing: the transcriber
+      // answers it by repeating the context we gave it, which arrives
+      // looking like a real remark. Catch it here, before the round trip.
+      if (blob.size === 0 || !heardSomething) {
+        this._reportMiss("Hmm — didn't hear anything")
+        return
+      }
+      this._submit({ audio: blob, durationMs })
+    }
+
+    if (this.recorder.state !== "recording") {
+      this.recorder.start()
+      this.recordingStartedAt = performance.now()
+    }
+
+    // Released while the microphone was still opening: finish the take
+    // now that there is one, posting whatever the ear caught.
+    if (this.stopRequested) {
+      this.stopRequested = false
+      this.recorder.stop()
+    }
+  }
+
+  // Tracks the loudest thing in the recording, and drives the button's
+  // pulse so there is some sign it can hear you — the recording path has
+  // no interim captions to show.
+  //
+  // The meter's verdict only counts while `meterLive` is true. An
+  // AudioContext starts suspended unless the browser saw a qualifying
+  // user gesture, and Chrome does not count a bare Shift keydown as one —
+  // so on the push-to-talk path the context routinely comes up dead, and
+  // a suspended analyser reads as perfect silence. Trusting that reading
+  // meant refusing recordings people were audibly speaking into.
+  _meterLevels() {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext
+    this.meterLive = false
+
+    try {
+      this.audioContext = new AudioContextClass()
+      if (this.audioContext.state !== "running") this.audioContext.resume()?.catch?.(() => {})
+
+      const analyser = this.audioContext.createAnalyser()
+      analyser.fftSize = 512
+      this.audioContext.createMediaStreamSource(this.stream).connect(analyser)
+
+      const samples = new Uint8Array(analyser.fftSize)
+      const sample = () => {
+        if (!this.listening) return
+
+        // Only a running context produces real samples; a suspended one
+        // is indistinguishable from a silent room.
+        if (this.audioContext.state === "running") this.meterLive = true
+
+        analyser.getByteTimeDomainData(samples)
+        let peak = 0
+        for (const value of samples) peak = Math.max(peak, Math.abs(value - 128))
+
+        this.peakLevel = Math.max(this.peakLevel, peak)
+        this.buttonTarget.style.setProperty("--voice-level", Math.min(peak / 40, 1).toFixed(2))
+        requestAnimationFrame(sample)
+      }
+      requestAnimationFrame(sample)
+    } catch {
+      // Metering is a check on the recording, not part of making it. If
+      // it can't run, assume there was speech — refusing to post what
+      // somebody said is a worse failure than sending silence.
+      this.meterLive = false
+    }
+  }
+
+  // Opus in WebM where it exists (small and well handled), MP4/AAC in
+  // Safari, and whatever the browser prefers if it likes neither.
+  _recorderOptions() {
+    const preferred = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"]
+    const supported = preferred.find((type) => MediaRecorder.isTypeSupported?.(type))
+    return supported ? { mimeType: supported } : {}
+  }
+
+  _releaseMic() {
+    this.stream?.getTracks().forEach((track) => track.stop())
+    this.stream = null
+    this.audioContext?.close()
+    this.audioContext = null
+    this.buttonTarget.style.removeProperty("--voice-level")
+  }
+
+  _onResult(event) {
+    let interim = ""
+    for (const result of event.results) {
+      if (result.isFinal) this.finalTranscript += result[0].transcript
+      else interim += result[0].transcript
+    }
+    this._setStatus(`“${(this.finalTranscript + interim).trim().slice(-80)}”`)
+  }
+
+  _onRecognitionEnd() {
+    this._stopListening()
+    if (this.discarded) return
+
+    const text = this.finalTranscript.trim()
+    if (text.length === 0) return
+
+    this._submit({ transcript: text })
+  }
+
+  // ── Posting ────────────────────────────────────────────────────────
+
+  async _submit({ transcript, audio, durationMs }) {
+    this._setStatus(audio ? "Transcribing…" : "Tidying up…")
+    this.excerpt = this._excerpt()
+
+    // One round trip does every slow job: transcribe if it was audio,
+    // clean up the words, and work out which passage they were about.
+    const interpreted = await this._interpret({ transcript, audio, durationMs })
+
+    // One remark is usually one comment, but "rename both of these" is
+    // two placements, each with its own pin.
+    let comments = interpreted?.comments || []
+    if (comments.length === 0) {
+      if (!transcript) {
+        // Audio with nothing to show for it — there is no comment to post.
+        // The server distinguishes "heard nothing" from "couldn't reach
+        // the transcriber", and which one it was changes what you'd do next.
+        this._reportMiss(interpreted?.error || "Couldn't make that out")
+        return
+      }
+      comments = [{ body: this._stripFillers(transcript), anchor: null }]
+    }
+
+    const posted = []
+    for (const [index, comment] of comments.entries()) {
+      // The heading fallback is for the remark as a whole; only the first
+      // comment takes it. A second unanchorable comment posts unpinned
+      // rather than piling onto the same heading.
+      let anchor = comment.anchor || (index === 0 ? this._viewportAnchor() : null)
+
+      let response = await this._postComment(comment.body, anchor)
+
+      // 422 means the server refused the pin: the anchor renders on
+      // screen but doesn't resolve in the plan source, so the comment
+      // would have been invisible. The words are still good — pin them to
+      // the nearest heading instead, which always resolves.
+      if (response?.status === 422 && anchor) {
+        const fallback = this._viewportAnchor()
+        anchor = fallback && fallback.text !== anchor.text ? fallback : null
+        response = await this._postComment(comment.body, anchor)
+      }
+      if (!response?.ok) continue
+
+      const streams = await response.text()
+      window.Turbo?.renderStreamMessage(streams)
+      posted.push({ anchor, threadId: streams.match(/comment_thread_([0-9a-f-]{36})/)?.[1] })
+    }
+
+    if (posted.length === 0) {
+      this._setStatus("Couldn't send", true)
+      return
+    }
+
+    // Show where it landed. The speaker never picked a spot on the page —
+    // the model did — so "comment posted" alone leaves them hunting for
+    // it (or, pinned below the fold, believing it never posted). With
+    // several, the first opens and the count says to look for the rest.
+    const first = posted.find((p) => p.threadId)
+    if (first) {
+      this.dispatch("open-thread", { prefix: "coplan", detail: { threadId: first.threadId } })
+    }
+
+    // State what happened, and nothing more. Whether an agent picks this
+    // up isn't ours to promise — if one does, its pill says so, and the
+    // observer below speaks the acknowledgment.
+    this.awaitingAck = true
+    this._setStatus(posted.length > 1
+      ? `${posted.length} comments added`
+      : (posted[0].anchor ? `Comment added to “${this._truncate(posted[0].anchor.text)}”` : "Comment added"))
+    setTimeout(() => {
+      this.awaitingAck = false
+      this._setStatus("")
+    }, 12000)
+  }
+
+  async _postComment(commentBody, anchor) {
+    const token = document.querySelector('meta[name="csrf-token"]')?.content
+    const body = new FormData()
+    body.append("comment_thread[body_markdown]", `🎙️ ${commentBody}`)
+    if (anchor) {
+      body.append("comment_thread[anchor_text]", anchor.text)
+      body.append("comment_thread[anchor_occurrence]", anchor.occurrence)
+    }
+
+    try {
+      return await fetch(this.urlValue, {
+        method: "POST",
+        headers: { "X-CSRF-Token": token, "Accept": "text/vnd.turbo-stream.html, text/html" },
+        body
+      })
+    } catch {
+      return null
+    }
+  }
+
+  // Transcribe, clean up and locate the passage, in one time-boxed
+  // request. A failure with a transcript in hand leaves the fallbacks in
+  // place; a failure with only audio has nothing to fall back to.
+  async _interpret({ transcript, audio, durationMs }) {
+    const controller = new AbortController()
+    // Uploading and transcribing audio is a different order of work from
+    // rewriting a sentence, and giving up early on it means giving up on
+    // the comment entirely.
+    const timer = setTimeout(() => controller.abort(), audio ? 25000 : 8000)
+
+    try {
+      const token = document.querySelector('meta[name="csrf-token"]')?.content
+      const form = new FormData()
+      if (transcript) form.append("transcript", transcript)
+      if (audio) form.append("audio", audio, `dictation.${this._extensionFor(audio)}`)
+      if (audio && durationMs > 0) form.append("duration_ms", durationMs)
+      if (this.excerpt) form.append("excerpt", this.excerpt)
+
+      const response = await fetch(this.dictationUrlValue, {
+        method: "POST",
+        headers: { "X-CSRF-Token": token, Accept: "application/json" },
+        body: form,
+        signal: controller.signal
+      })
+      if (!response.ok) {
+        const { error } = await response.json().catch(() => ({}))
+        return { comments: [], error }
+      }
+
+      const data = await response.json()
+      const seen = new Map()
+      const comments = (data.comments || [])
+        .filter((c) => c.body)
+        .map((c) => ({ body: c.body, anchor: this._resolveAnchor(c.anchor_text, seen) }))
+      return { comments }
+    } catch {
+      return null
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  _extensionFor(blob) {
+    const type = (blob.type || "").split(";")[0]
+    if (type.includes("mp4")) return "mp4"
+    if (type.includes("ogg")) return "ogg"
+    if (type.includes("wav")) return "wav"
+    if (type.includes("mpeg")) return "mp3"
+    return "webm"
+  }
+
+  // The span has to exist in the rendered document to be highlighted,
+  // and we need to know which copy of it we mean. When one dictation
+  // pins the same span twice ("rename both of these"), each repeat takes
+  // the next copy — that's what repeating a span means.
+  _resolveAnchor(anchorText, seen = new Map()) {
+    if (!anchorText) return null
+
+    const content = document.getElementById("plan-content-body")
+    if (!content?.textContent?.includes(anchorText)) return null
+
+    const priorUses = seen.get(anchorText) || 0
+    seen.set(anchorText, priorUses + 1)
+    return { text: anchorText, occurrence: this._occurrenceOfNearViewport(content, anchorText) + priorUses }
+  }
+
+  // Fallback tidy-up for when the interpret call fails: drop the tics
+  // that stand alone as words and collapse stutters. Conservative on
+  // purpose — "like" is a real word ("looks like the API"), so it only
+  // goes when it's clearly filler, and nothing here reorders or rewrites.
+  _stripFillers(text) {
+    const cleaned = (text || "")
+      .replace(/\b(?:um+|uh+|er+|hmm+)\b[,]?\s*/gi, "")
+      .replace(/\b(?:you know|i mean|sort of|kind of|basically)\b[,]?\s*/gi, "")
+      .replace(/\blike\b[,]?\s+(?=like\b)/gi, "")
+      .replace(/\b(\w+)(\s+\1\b)+/gi, "$1")
+      .replace(/\s{2,}/g, " ")
+      .replace(/\s+([,.!?])/g, "$1")
+      .trim()
+
+    if (cleaned.length === 0) return text
+    return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
+  }
+
+  // Every text block that was readably on screen at some point during the
+  // take, in document order: what the remark is about, the hint that makes
+  // transcription get the jargon right, and the only part of the document
+  // we send anywhere. Filtering the fresh block list against the seen set
+  // (rather than serializing the set) keeps document order and drops any
+  // element a live update has since replaced.
+  _excerpt() {
+    this._visibleBlocks().forEach((block) => this.seenBlocks?.add(block))
+
+    const blocks = this._allBlocks()
+    const seen = blocks.filter((block) => this.seenBlocks?.has(block))
+    const text = (seen.length > 0 ? seen : blocks.slice(0, 20))
+      .map((el) => el.textContent.trim())
+      .filter(Boolean)
+      .join("\n")
+
+    return text.length > 0 ? text : null
+  }
+
+  _allBlocks() {
+    const content = document.getElementById("plan-content-body")
+    if (!content) return []
+    return Array.from(content.querySelectorAll("h1, h2, h3, h4, h5, h6, p, li, blockquote, pre, td"))
+  }
+
+  _visibleBlocks() {
+    return this._allBlocks().filter((el) => this._readablyVisible(el))
+  }
+
+  // On screen enough to be read, not merely intersecting the viewport. A
+  // paragraph with one line poking over the fold used to count, the model
+  // would quote it, and the comment pinned somewhere the person had never
+  // seen. A block qualifies when what's in view is most of the block or a
+  // real slice of the screen — a full-viewport paragraph passes, a
+  // two-pixel sliver doesn't.
+  _readablyVisible(el) {
+    const rect = el.getBoundingClientRect()
+    const visibleHeight = Math.min(rect.bottom, window.innerHeight) - Math.max(rect.top, 0)
+    if (visibleHeight <= 0) return false
+    return visibleHeight >= Math.min(rect.height * 0.5, window.innerHeight * 0.2)
+  }
+
+  // Which copy of the span to highlight: the first one at or after the
+  // top of the viewport. Picking the wrong copy highlights text the
+  // person was never looking at, which is worse than not pinning at all.
+  _occurrenceOfNearViewport(content, text) {
+    const firstVisible = Array.from(content.querySelectorAll("h1, h2, h3, h4, h5, h6, p, li, blockquote, pre, td"))
+      .find((el) => el.getBoundingClientRect().bottom > 0)
+    if (!firstVisible) return 0
+
+    const range = document.createRange()
+    range.setStart(content, 0)
+    range.setEndBefore(firstVisible)
+    return this._countOccurrences(range.toString(), text)
+  }
+
+  // The heading of the section currently in view. Uses the last heading
+  // above the reading line, so scrolling mid-section still pins to that
+  // section rather than to the one coming up.
+  _viewportAnchor() {
+    const content = document.getElementById("plan-content-body")
+    if (!content) return null
+
+    const headings = Array.from(content.querySelectorAll("h1, h2, h3, h4, h5, h6"))
+    if (headings.length === 0) return null
+
+    const readingLine = window.innerHeight * 0.4
+    let chosen = null
+    for (const heading of headings) {
+      if (heading.getBoundingClientRect().top <= readingLine) chosen = heading
+      else break
+    }
+    // Above the first heading: pin to whatever is coming into view.
+    chosen ||= headings.find((h) => h.getBoundingClientRect().bottom > 0) || headings[0]
+
+    const text = chosen.textContent.trim()
+    if (!text) return null
+
+    return { text, occurrence: this._occurrenceBefore(content, chosen, text) }
+  }
+
+  // Which copy of this text it is — headings repeat ("Rollout" under two
+  // sections), and the server resolves an anchor by text plus index.
+  _occurrenceBefore(content, element, text) {
+    const range = document.createRange()
+    range.setStart(content, 0)
+    range.setEndBefore(element)
+    return this._countOccurrences(range.toString(), text)
+  }
+
+  // Occurrence is 1-based server-side (resolve_anchor_position treats
+  // anything below 1 as "don't resolve"), so this counts the copies that
+  // come before the target and numbers the target itself.
+  _countOccurrences(prefix, needle) {
+    let count = 0
+    let index = prefix.indexOf(needle)
+    while (index !== -1) {
+      count += 1
+      index = prefix.indexOf(needle, index + needle.length)
+    }
+    return count + 1
+  }
+
+  _truncate(text, max = 40) {
+    return text.length > max ? `${text.slice(0, max)}…` : text
+  }
+
+  // The agent session pill is broadcast-replaced whole; watch it and turn
+  // its state changes into speech. active → "Got it." (once per request),
+  // pill gone/complete → "Done — take a look."
+  _watchAgentPill() {
+    const pillHost = document.getElementById("plan-agent-sessions")?.parentNode
+    if (!pillHost) return
+
+    this.pillObserver = new MutationObserver(() => {
+      const active = document.querySelector(".agent-pill--active, .agent-pill--pending")
+      if (this.awaitingAck && active) {
+        this.awaitingAck = false
+        this.spokeAck = true
+        this._speak("Got it.")
+        this._setStatus("Agent picked it up…")
+      } else if (this.spokeAck && !active) {
+        this.spokeAck = false
+        this._speak("Done — take a look.")
+        this._setStatus("")
+      }
+    })
+    this.pillObserver.observe(pillHost, { childList: true, subtree: true })
+  }
+
+  _speak(text) {
+    if (!window.speechSynthesis) return
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.rate = 1.1
+    window.speechSynthesis.speak(utterance)
+  }
+
+  // A miss in a voice flow is reported by voice: you were talking, not
+  // watching a status chip in the corner. Same words on screen and out
+  // loud, so neither channel contradicts the other.
+  _reportMiss(text) {
+    this._setStatus(text, true)
+    this._speak(text.replace("—", ","))
+  }
+
+  _setStatus(text, isError = false) {
+    if (!this.hasStatusTarget) return
+    this.statusTarget.textContent = text
+    this.statusTarget.classList.toggle("voice-status--error", isError)
+  }
+}

--- a/engine/app/services/coplan/ai.rb
+++ b/engine/app/services/coplan/ai.rb
@@ -14,5 +14,21 @@ module CoPlan
     rescue AiProviders::OpenAi::Error => e
       raise Error, e.message
     end
+
+    # Speech to text. `context` is surrounding material the speaker was
+    # looking at; passing it makes the difference between "CoPlan" and
+    # "co-plan", or "Turbo Streams" and "turbo streets".
+    def self.transcribe(file:, context: nil)
+      AiProviders::OpenAi.transcribe(file: file, context: context)
+    rescue AiProviders::OpenAi::Error => e
+      raise Error, e.message
+    end
+
+    # Whether a provider is reachable at all, for callers that need to
+    # choose a different route rather than fail (the voice control picks
+    # how to capture based on this).
+    def self.available?
+      AiProviders::OpenAi.configured?
+    end
   end
 end

--- a/engine/app/services/coplan/ai_providers/open_ai.rb
+++ b/engine/app/services/coplan/ai_providers/open_ai.rb
@@ -6,8 +6,66 @@ module CoPlan
       DEFAULT_MODEL = "gpt-4o".freeze
       DEFAULT_BASE_URL = "https://api.openai.com/v1".freeze
 
+      # Speech-to-text. Worth a round trip: markedly better than any
+      # browser's built-in recognition, and in Safari and Firefox it is
+      # the only option there is.
+      TRANSCRIBE_MODEL = ENV.fetch("COPLAN_TRANSCRIBE_MODEL", "gpt-4o-transcribe")
+
+      # The prompt biases the decoder toward words it can see in context —
+      # jargon, product names, figures from a table. Short on purpose:
+      # models cap how much of this they will read.
+      MAX_PROMPT_LENGTH = 600
+
       def self.call(system_prompt:, user_content:, model: nil)
         new(system_prompt:, user_content:, model:).call
+      end
+
+      # `file` must respond to #path with a usable extension — the audio
+      # format is inferred from the filename, not sniffed from the bytes.
+      def self.transcribe(file:, context: nil)
+        response = client.audio.transcribe(
+          parameters: {
+            model: TRANSCRIBE_MODEL,
+            file: file,
+            prompt: context.presence&.truncate(MAX_PROMPT_LENGTH, omission: "")
+          }.compact
+        )
+
+        text = response.is_a?(Hash) ? response["text"] : response.to_s
+        raise Error, "No transcript returned from OpenAI" if text.blank?
+
+        text.strip
+      rescue Faraday::Error => e
+        raise Error, "Transcription failed: #{e.message}"
+      end
+
+      # Whether server-side calls are possible at all. The voice control
+      # asks before choosing how to capture: recording audio with nowhere
+      # to send it is worse than not offering to record.
+      def self.configured?
+        api_key.present?
+      rescue Error
+        false
+      end
+
+      def self.client
+        OpenAI::Client.new(access_token: api_key, uri_base: base_url)
+      end
+
+      # Anything speaking the OpenAI wire protocol: Azure OpenAI, LiteLLM,
+      # vLLM, Ollama, an internal gateway. The gem appends its own "/v1"
+      # only when the base URL doesn't already carry one.
+      def self.base_url
+        CoPlan.configuration.ai_base_url.presence || DEFAULT_BASE_URL
+      end
+
+      def self.api_key
+        key = CoPlan.configuration.ai_api_key ||
+          Rails.application.credentials.dig(:openai, :api_key) ||
+          ENV["OPENAI_API_KEY"]
+        raise Error, "OpenAI API key not configured" if key.blank?
+
+        key
       end
 
       def initialize(system_prompt:, user_content:, model: nil)
@@ -19,9 +77,7 @@ module CoPlan
       end
 
       def call
-        client = OpenAI::Client.new(access_token: api_key, uri_base: base_url)
-
-        response = client.chat(
+        response = self.class.client.chat(
           parameters: {
             model: @model,
             messages: [
@@ -35,21 +91,6 @@ module CoPlan
         raise Error, "No response content from OpenAI" if content.blank?
 
         content
-      end
-
-      private
-
-      # Anything speaking the OpenAI wire protocol: Azure OpenAI, LiteLLM,
-      # vLLM, Ollama, an internal gateway. The gem appends its own "/v1"
-      # only when the base URL doesn't already carry one.
-      def base_url
-        CoPlan.configuration.ai_base_url.presence || DEFAULT_BASE_URL
-      end
-
-      def api_key
-        key = CoPlan.configuration.ai_api_key || Rails.application.credentials.dig(:openai, :api_key) || ENV["OPENAI_API_KEY"]
-        raise Error, "OpenAI API key not configured" if key.blank?
-        key
       end
 
       class Error < StandardError; end

--- a/engine/app/services/coplan/comments/interpret_dictation.rb
+++ b/engine/app/services/coplan/comments/interpret_dictation.rb
@@ -1,0 +1,267 @@
+module CoPlan
+  module Comments
+    # Turns what somebody said into a comment worth reading: the words
+    # tidied up, and the passage they were talking about.
+    #
+    # Both halves need the same two inputs — the transcript and what was
+    # on screen — so they're one call. Speech is full of false starts
+    # ("put the medium weight latency I put the like the speed"), and a
+    # remark like "this bit is too cautious" only means something next to
+    # the text it's pointing at.
+    #
+    # Neither half is trusted:
+    #   - a span that isn't in the excerpt character-for-character is a
+    #     paraphrase, and a paraphrase can't be highlighted
+    #   - a rewrite that changes length dramatically has stopped being a
+    #     cleanup and started being a summary
+    # Anything that fails a check falls back to what the person said.
+    class InterpretDictation
+      Comment = Struct.new(:body, :anchor_text, keyword_init: true)
+
+      # One remark is usually one comment, but "rename both of these" is
+      # two placements. The first comment doubles as the whole result for
+      # callers that predate the plural.
+      Result = Struct.new(:comments, keyword_init: true) do
+        def body = comments.first&.body
+        def anchor_text = comments.first&.anchor_text
+      end
+
+      # A spoken remark that genuinely makes more points than this has
+      # stopped being a remark; past the cap the rest is folded away.
+      MAX_COMMENTS = 4
+
+      # Standing alone costs words: "rename both of them" becomes two full
+      # sentences. The cost is roughly a short sentence per split — a
+      # constant, not a multiple of however long the remark was.
+      PER_COMMENT_HEADROOM = 40
+
+      # Long enough to be unambiguous, short enough that the highlight
+      # reads as a pointer rather than a block quote.
+      MAX_ANCHOR_LENGTH = 300
+
+      # A tidy-up keeps roughly the same words. Outside this band it's
+      # either dropping content or padding it.
+      MIN_LENGTH_RATIO = 0.4
+      MAX_LENGTH_RATIO = 1.6
+
+      # The floor for a salvaged fragment of a span. Below this it's a
+      # stray "is" or "the" — a pin on one of those points at noise.
+      MIN_ANCHOR_LENGTH = 8
+
+      SYSTEM_PROMPT = <<~PROMPT.freeze
+        You process a spoken remark somebody made about a document.
+
+        You are given an excerpt of what was on their screen and a raw
+        speech-to-text transcript. Return JSON of this shape:
+
+        {"comments": [{"text": "...", "span": "..."}]}
+
+        Almost always one comment. Split into several ONLY when the remark
+        clearly makes the same point about more than one passage ("rename
+        both of these", "each of these headings") or makes clearly
+        separate points about separate passages. Never more than four. To
+        point at two copies of the same text, repeat the span in two
+        comments.
+
+        "text": the remark cleaned up into a readable comment.
+        - Remove filler words and verbal tics: um, uh, like, you know,
+          I mean, sort of, kind of, basically, actually.
+        - Repair false starts and repetitions into what they meant to say.
+        - Fix obvious mis-transcriptions using the excerpt as context
+          (technical terms in the excerpt are almost certainly what they
+          said).
+        - Keep their meaning, their voice, and their brevity. Do not make
+          it formal, do not expand it, do not add points they did not
+          make, do not answer or act on it.
+
+        "span": the exact text from the excerpt the remark is about.
+        - Copied character-for-character from the excerpt.
+        - The smallest span that identifies the target: a phrase or
+          sentence, not a whole section.
+        - Use null if the remark is about the document as a whole, or you
+          cannot identify a specific passage.
+
+        Speech is conversational: the remark may be a follow-up to one of
+        the recent comments, if any are given ("oh, I meant both of
+        them"). Use them to resolve what "it", "them" or "that one"
+        refers to, and fold the reference into "text" so each comment
+        stands alone. Spans must still come from the excerpt.
+
+        Reply with the JSON object and nothing else.
+      PROMPT
+
+      def self.call(...) = new(...).call
+
+      def initialize(excerpt:, transcript:, document: nil, recent_comments: [])
+        @excerpt = excerpt.to_s
+        # What the anchor ultimately has to resolve against. Defaults to
+        # the excerpt so callers that only have the one string still work.
+        @document = document.to_s.presence || @excerpt
+        @transcript = transcript.to_s.strip
+        # [{ body:, anchor: }, ...], newest first — the conversation the
+        # remark may be continuing.
+        @recent_comments = recent_comments
+      end
+
+      def call
+        return Result.new(comments: [ Comment.new(body: @transcript, anchor_text: nil) ]) if @transcript.empty?
+
+        parsed = parse(Ai.call(system_prompt: SYSTEM_PROMPT, user_content: user_content))
+        Result.new(comments: comments_from(parsed))
+      rescue Ai::Error => e
+        # Both halves are enhancements; a local tidy-up of what they said
+        # is still better than nothing.
+        Rails.logger.info("[coplan] dictation interpretation unavailable: #{e.message}")
+        Result.new(comments: [ Comment.new(body: fallback_text, anchor_text: nil) ])
+      end
+
+      private
+
+      def user_content
+        <<~CONTENT
+          Excerpt:
+          ---
+          #{@excerpt}
+          ---
+          #{comments_section}
+          Transcript: #{@transcript}
+        CONTENT
+      end
+
+      def comments_section
+        return "" if @recent_comments.blank?
+
+        lines = @recent_comments.map.with_index(1) do |comment, i|
+          anchor = comment[:anchor].presence
+          body = comment[:body].to_s.truncate(200)
+          anchor ? %(#{i}. (on "#{anchor.truncate(60)}") #{body}) : "#{i}. #{body}"
+        end
+
+        <<~SECTION
+
+          Recent comments on this document, newest first:
+          ---
+          #{lines.join("\n")}
+          ---
+        SECTION
+      end
+
+      def parse(response)
+        # Models wrap JSON in code fences regardless of instructions.
+        json = response.to_s.strip.gsub(/\A```(?:json)?\s*|\s*```\z/, "")
+        parsed = JSON.parse(json)
+        parsed.is_a?(Hash) ? parsed : {}
+      rescue JSON::ParserError
+        {}
+      end
+
+      def comments_from(parsed)
+        # Accept the plural shape, or the old single {"text","span"} a
+        # model may still produce.
+        items = parsed["comments"].is_a?(Array) ? parsed["comments"] : [ parsed ]
+        items = items.first(MAX_COMMENTS).select { |item| item.is_a?(Hash) && item["text"].present? }
+        return [ Comment.new(body: fallback_text, anchor_text: nil) ] if items.empty?
+
+        # The length band is the same trust check as ever, applied to the
+        # rewrite as a whole: however it was split, the comments together
+        # should say roughly what the person said — much shorter is a
+        # summary, much longer is invention. Each extra comment earns
+        # PER_COMMENT_HEADROOM on the high side for its standing-alone
+        # overhead.
+        combined = items.sum { |item| item["text"].to_s.strip.length }
+        min_length = @transcript.length * MIN_LENGTH_RATIO
+        max_length = @transcript.length * MAX_LENGTH_RATIO + (items.length - 1) * PER_COMMENT_HEADROOM
+        unless combined.between?(min_length, max_length)
+          return [ Comment.new(body: fallback_text, anchor_text: nil) ]
+        end
+
+        items.map do |item|
+          Comment.new(body: item["text"].to_s.strip, anchor_text: verbatim_span(item["span"]))
+        end
+      end
+
+      # The floor when the model can't be reached or its rewrite is
+      # rejected: drop the tics that stand alone as words and collapse
+      # stutters. Conservative on purpose — "like" is a real word ("looks
+      # like the API"), so it only goes when it is clearly filler, and
+      # nothing here reorders or rewrites.
+      def fallback_text
+        cleaned = @transcript
+          .gsub(/\b(?:um+|uh+|er+|hmm+)\b,?\s*/i, "")
+          .gsub(/\b(?:you know|i mean|sort of|kind of|basically)\b,?\s*/i, "")
+          .gsub(/\blike\b,?\s+(?=like\b)/i, "")
+          # A comma before "like" marks it as filler — "it looks like the
+          # API" has no comma, "this is, like, vague" does.
+          .gsub(/,\s*like\b,?\s*/i, " ")
+          .gsub(/\b(\w+)(\s+\1\b)+/i, '\1')
+          .gsub(/\s{2,}/, " ")
+          .gsub(/\s+([,.!?])/, '\1')
+          .strip
+
+        return @transcript if cleaned.empty?
+
+        cleaned.sub(/\A./) { |c| c.upcase }
+      end
+
+      def verbatim_span(span)
+        span = span.to_s.strip
+        return nil if span.empty? || span.casecmp("null").zero?
+        return nil if span.length > MAX_ANCHOR_LENGTH
+
+        candidate = span if @excerpt.include?(span)
+        # Models wrap spans in quotes even when told not to; that much we
+        # forgive. Anything else isn't in the document.
+        candidate ||= begin
+          trimmed = span.gsub(/\A[\s"'“”‘’]+|[\s"'“”‘’]+\z/, "").presence
+          trimmed if trimmed && @excerpt.include?(trimmed)
+        end
+
+        candidate && anchorable(candidate)
+      end
+
+      # An anchor has to live in two representations at once: findable in
+      # the rendered page (that's what the highlighter searches) and
+      # resolvable to positions in the markdown source (CommentThread
+      # handles that, including a stripped-markdown fallback for inline
+      # markup like "`main` is always releasable"). The model quotes from
+      # the rendered excerpt, so the second half is the one to check —
+      # with the resolver's own translation, not a cruder one.
+      #
+      # The one thing the highlighter cannot do is cross block boundaries:
+      # a span covering two table cells ("Voice (mic button)\n24%") has no
+      # contiguous home in the DOM. So a multi-line span degrades to its
+      # longest resolvable line, and an unresolvable line to its longest
+      # resolvable run of words. An anchor that fails everything is
+      # dropped — the caller falls back to the section heading, which is
+      # a worse pin but a visible one.
+      def anchorable(span)
+        lines = span.split("\n").map(&:strip).reject(&:empty?)
+        return span if lines.length == 1 && resolvable?(span)
+
+        whole_lines = lines.select { |line| resolvable?(line) }
+        return whole_lines.max_by(&:length) if whole_lines.any?
+
+        lines.flat_map { |line| word_runs(line) }
+          .select { |run| run.length >= MIN_ANCHOR_LENGTH && resolvable?(run) }
+          .max_by(&:length)
+      end
+
+      def resolvable?(text)
+        @document.include?(text) || stripped_document.include?(text)
+      end
+
+      def stripped_document
+        @stripped_document ||= CommentThread.strip_markdown(@document).first
+      end
+
+      # Every contiguous run of words in the line. ~n²/2 candidates for n
+      # words, and MAX_ANCHOR_LENGTH caps n well under coffee-break size.
+      def word_runs(line)
+        words = line.split(/\s+/)
+        (0...words.length).flat_map do |from|
+          (from...words.length).map { |to| words[from..to].join(" ") }
+        end
+      end
+    end
+  end
+end

--- a/engine/app/views/coplan/plans/_voice_control.html.erb
+++ b/engine/app/views/coplan/plans/_voice_control.html.erb
@@ -14,6 +14,7 @@
     position: fixed child and pin the button to the toolbar instead of the
     viewport. %>
 <span data-controller="coplan--voice"
+      data-action="keydown@document->coplan--voice#keyDown keyup@document->coplan--voice#keyUp blur@window->coplan--voice#interrupt"
       data-coplan--voice-url-value="<%= plan_comment_threads_path(plan) %>"
       data-coplan--voice-dictation-url-value="<%= plan_dictations_path(plan) %>"
       data-coplan--voice-transcription-value="<%= CoPlan::Ai.available? %>"

--- a/engine/app/views/coplan/plans/_voice_control.html.erb
+++ b/engine/app/views/coplan/plans/_voice_control.html.erb
@@ -1,0 +1,27 @@
+<%# Push-to-talk commenting — records what you say and posts it as a
+    comment pinned to the passage that was on screen. Hidden by the
+    controller when the browser has no way to capture audio at all.
+
+    Whether the server can transcribe decides how the browser captures:
+    with a provider configured it records audio and sends it (works
+    everywhere, much more accurate), without one it falls back to the
+    browser's own speech recognition (Chrome only, and worse).
+
+    Rendered at page level rather than in the masthead toolbar for two
+    reasons: it follows the scroll (you comment on what you're reading, so
+    the control has to be reachable from there), and `.plan-actions` sets
+    backdrop-filter, which would make it the containing block for a
+    position: fixed child and pin the button to the toolbar instead of the
+    viewport. %>
+<span data-controller="coplan--voice"
+      data-coplan--voice-url-value="<%= plan_comment_threads_path(plan) %>"
+      data-coplan--voice-dictation-url-value="<%= plan_dictations_path(plan) %>"
+      data-coplan--voice-transcription-value="<%= CoPlan::Ai.available? %>"
+      class="voice-control">
+  <button type="button" class="btn btn--ghost btn--sm btn--icon voice-btn"
+          data-coplan--voice-target="button" data-action="coplan--voice#toggle"
+          aria-label="Comment by voice" title="Comment by voice — or hold Shift to talk">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>
+  </button>
+  <span class="voice-status text-sm text-muted" data-coplan--voice-target="status" aria-live="polite"></span>
+</span>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -47,7 +47,7 @@
 
 <div class="plan-document card">
   <% if @plan.current_content.present? %>
-    <div class="plan-layout" data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections" data-coplan--text-selection-focus-thread-value="<%= params[:thread] %>" data-action="keydown.esc@document->coplan--text-selection#dismiss" data-coplan--checkbox-revision-value="<%= @plan.current_revision %>" data-coplan--checkbox-toggle-url-value="<%= toggle_checkbox_plan_path(@plan) %>" data-coplan--changed-sections-keys-value="<%= @changed_section_keys.to_json %>">
+    <div class="plan-layout" data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections" data-coplan--text-selection-focus-thread-value="<%= params[:thread] %>" data-action="keydown.esc@document->coplan--text-selection#dismiss coplan:open-thread@document->coplan--text-selection#openThread" data-coplan--checkbox-revision-value="<%= @plan.current_revision %>" data-coplan--checkbox-toggle-url-value="<%= toggle_checkbox_plan_path(@plan) %>" data-coplan--changed-sections-keys-value="<%= @changed_section_keys.to_json %>">
       <nav class="content-nav" data-coplan--content-nav-target="sidebar" aria-label="Document outline">
         <%# No "Contents" label — the outline speaks for itself, and the plan
             title now lives in the sticky nav. Just the collapse control. %>
@@ -114,6 +114,10 @@
 </div>
 
 <%= render partial: "coplan/shared/folder_picker", locals: { folders: @my_folders } %>
+
+<% if current_user && @plan.current_content.present? %>
+  <%= render partial: "coplan/plans/voice_control", locals: { plan: @plan } %>
+<% end %>
 
 <%# Headless comment navigation — no floating toolbar, just the keyboard:
     j/k step through comments, r focuses reply, a/d accept/discard,

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -121,11 +121,12 @@
 
 <%# Headless comment navigation — no floating toolbar, just the keyboard:
     j/k step through comments, r focuses reply, a/d accept/discard,
-    s toggles resolved-thread visibility. %>
-<% if @threads.any? %>
-  <div data-controller="coplan--comment-nav"
-       data-action="coplan:anchors-updated@document->coplan--comment-nav#handleAnchorsUpdated"
-       hidden></div>
-<% end %>
+    s toggles resolved-thread visibility. Rendered even when the page
+    loads without a single thread: comments arrive live (voice, selection,
+    other viewers' broadcasts), and gating this on @threads.any? left the
+    first comment on a fresh plan with no keyboard at all. %>
+<div data-controller="coplan--comment-nav"
+     data-action="coplan:anchors-updated@document->coplan--comment-nav#handleAnchorsUpdated"
+     hidden></div>
 
 </div>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -15,6 +15,9 @@ CoPlan::Engine.routes.draw do
     end
     resources :references, controller: "references", only: [:create, :destroy]
     resources :attachments, controller: "attachments", only: [:create, :destroy]
+    # Cleans up a spoken remark and works out which passage it was about;
+    # see DictationsController.
+    resources :dictations, only: [:create]
     resources :comment_threads, only: [:create] do
       member do
         patch :resolve

--- a/spec/requests/dictations_spec.rb
+++ b/spec/requests/dictations_spec.rb
@@ -1,0 +1,316 @@
+require "rails_helper"
+
+RSpec.describe "Dictations", type: :request do
+  let(:alice) { create(:coplan_user, :admin) }
+
+  # An anchor is only worth returning if it resolves against the plan's
+  # own markdown, so these specs need a plan that actually says the thing
+  # the model quotes back.
+  let(:plan) do
+    create(:plan, :considering, created_by_user: alice).tap do |p|
+      version = create(:plan_version, plan: p, revision: 2, actor_id: alice.id,
+        content_markdown: "## Ambition\n\nOur goal is world domination by Q3.\n")
+      p.update_columns(current_plan_version_id: version.id, current_revision: 2)
+    end
+  end
+
+  before { sign_in_as(alice) }
+
+  it "returns the cleaned body and the span" do
+    allow(CoPlan::Ai).to receive(:call)
+      .and_return({ "text" => "This is too grand.", "span" => "world domination" }.to_json)
+
+    post plan_dictations_path(plan),
+      params: { transcript: "this is like um too grand", excerpt: "Our goal is world domination by Q3." },
+      as: :json
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["body"]).to eq("This is too grand.")
+    expect(body["anchor_text"]).to eq("world domination")
+    expect(body["comments"]).to eq([ { "body" => "This is too grand.", "anchor_text" => "world domination" } ])
+  end
+
+  it "returns every comment when the remark was about several places" do
+    allow(CoPlan::Ai).to receive(:call).and_return({ "comments" => [
+      { "text" => "Too grand.", "span" => "world domination" },
+      { "text" => "Q3 is optimistic.", "span" => "by Q3" }
+    ] }.to_json)
+
+    post plan_dictations_path(plan),
+      params: { transcript: "too grand and honestly Q3 is optimistic", excerpt: "Our goal is world domination by Q3." },
+      as: :json
+
+    expect(response).to have_http_status(:ok)
+    comments = JSON.parse(response.body)["comments"]
+    expect(comments.map { |c| c["anchor_text"] }).to eq([ "world domination", "by Q3" ])
+  end
+
+  it "returns a locally tidied transcript rather than an error when the AI can't help" do
+    allow(CoPlan::Ai).to receive(:call).and_raise(CoPlan::Ai::Error, "not configured")
+
+    post plan_dictations_path(plan),
+      params: { transcript: "um too formal", excerpt: "Our goal is world domination by Q3." },
+      as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["body"]).to eq("Too formal")
+    expect(JSON.parse(response.body)["anchor_text"]).to be_nil
+  end
+
+  # Only what was on screen goes to the model — narrower is more accurate,
+  # cheaper, and sends less of the document off the box.
+  it "sends the visible excerpt, not the whole document" do
+    expect(CoPlan::Ai).to receive(:call) do |system_prompt:, user_content:|
+      expect(user_content).to include("only this paragraph was visible")
+      expect(user_content).not_to include(plan.current_content)
+      expect(system_prompt).to include("filler words")
+      { "text" => "Tighten this.", "span" => nil }.to_json
+    end
+
+    post plan_dictations_path(plan),
+      params: { transcript: "tighten this", excerpt: "only this paragraph was visible" },
+      as: :json
+
+    expect(JSON.parse(response.body)["body"]).to eq("Tighten this.")
+  end
+
+  # "Oh, I meant both of them" is a follow-up; without the comment it
+  # follows there is no "them". The model gets the conversation so far.
+  it "gives the model the recent comments as conversational context" do
+    thread = CoPlan::CommentThread.create!(
+      plan: plan, plan_version: plan.current_plan_version, created_by_user: alice,
+      anchor_text: "world domination"
+    )
+    CoPlan::Comment.create!(
+      comment_thread: thread, author_type: "human", author_id: alice.id,
+      body_markdown: "🎙️ It should be main."
+    )
+
+    expect(CoPlan::Ai).to receive(:call) do |user_content:, **|
+      expect(user_content).to include("Recent comments")
+      expect(user_content).to include("It should be main.")
+      expect(user_content).to include(%(on "world domination"))
+      { "text" => "I meant both of them.", "span" => nil }.to_json
+    end
+
+    post plan_dictations_path(plan),
+      params: { transcript: "oh I meant both of them", excerpt: "Our goal is world domination by Q3." },
+      as: :json
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "falls back to the plan content when the client sends no excerpt" do
+    expect(CoPlan::Ai).to receive(:call) do |user_content:, **|
+      expect(user_content).to include(plan.current_content.truncate(50, omission: ""))
+      { "text" => "Tighten this.", "span" => nil }.to_json
+    end
+
+    post plan_dictations_path(plan), params: { transcript: "tighten this" }, as: :json
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  describe "with recorded audio instead of a transcript" do
+    def audio_upload(content = "fake audio", type: "audio/webm", extension: ".webm")
+      file = Tempfile.new([ "dictation", extension ], binmode: true)
+      file.write(content)
+      file.rewind
+      Rack::Test::UploadedFile.new(file.path, type)
+    end
+
+    it "transcribes the recording and interprets what it heard" do
+      expect(CoPlan::Ai).to receive(:transcribe) do |file:, context:|
+        # OpenAI reads the format off the filename, so the extension has
+        # to survive the round trip from the browser's blob.
+        expect(File.extname(file.path)).to eq(".webm")
+        expect(File.read(file.path)).to eq("fake audio")
+        expect(context).to include("world domination")
+        "this is like um too grand"
+      end
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "This is too grand.", "span" => "world domination" }.to_json)
+
+      post plan_dictations_path(plan),
+        params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3." }
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["transcript"]).to eq("this is like um too grand")
+      expect(body["body"]).to eq("This is too grand.")
+      expect(body["anchor_text"]).to eq("world domination")
+    end
+
+    it "keeps Safari's MP4 recording as an MP4" do
+      expect(CoPlan::Ai).to receive(:transcribe) do |file:, **|
+        expect(File.extname(file.path)).to eq(".mp4")
+        "too grand"
+      end
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Too grand.", "span" => nil }.to_json)
+
+      post plan_dictations_path(plan),
+        params: { audio: audio_upload(type: "audio/mp4", extension: ".mp4") }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # There is nothing to fall back to — no words were captured anywhere
+    # else — so the client needs to hear that rather than post silence.
+    it "reports failure rather than posting an empty comment" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_raise(CoPlan::Ai::Error, "unavailable")
+      expect(CoPlan::Ai).not_to receive(:call)
+
+      post plan_dictations_path(plan), params: { audio: audio_upload }
+
+      expect(response).to have_http_status(:bad_gateway)
+      expect(JSON.parse(response.body)["error"]).to be_present
+    end
+
+    it "refuses a recording too large to be a spoken remark" do
+      stub_const("CoPlan::DictationsController::MAX_AUDIO_BYTES", 4)
+      expect(CoPlan::Ai).not_to receive(:transcribe)
+
+      post plan_dictations_path(plan), params: { audio: audio_upload("far too many bytes") }
+
+      expect(response).to have_http_status(:bad_gateway)
+    end
+
+    # Whisper-family models answer silence by repeating their prompt, and
+    # we prompt with the text that was on screen. Left alone this posts a
+    # sentence lifted off the page as though the person had said it —
+    # pinned, plausible, and entirely invented.
+    describe "when the transcriber echoes the prompt back" do
+      it "reports hearing nothing rather than posting the page back" do
+        allow(CoPlan::Ai).to receive(:transcribe).and_return("Our goal is world domination")
+        expect(CoPlan::Ai).not_to receive(:call)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3." }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("Didn't hear anything")
+      end
+
+      it "ignores case and line breaks, which the echo doesn't preserve" do
+        allow(CoPlan::Ai).to receive(:transcribe).and_return("our goal is\nWORLD DOMINATION")
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3." }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "treats an empty transcript the same way" do
+        allow(CoPlan::Ai).to receive(:transcribe).and_return("")
+
+        post plan_dictations_path(plan), params: { audio: audio_upload, excerpt: "Anything." }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      # A remark that merely mentions words from the page is the normal
+      # case — it's what commenting on a document sounds like.
+      it "lets through a remark that quotes only part of the page" do
+        allow(CoPlan::Ai).to receive(:transcribe).and_return("is world domination really the goal here")
+        allow(CoPlan::Ai).to receive(:call)
+          .and_return({ "text" => "Is world domination really the goal?", "span" => nil }.to_json)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3." }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    # gpt-4o-transcribe is a chat model with ears. Given an
+    # instruction-shaped remark ("add some content about how editing
+    # works") and a prompt full of context, it sometimes answers instead
+    # of transcribing — a whole essay, with figures lifted from the
+    # prompt, arriving as though the person had said it. Nobody can say
+    # 1,200 characters in four seconds: a transcript that outruns the
+    # clock was generated, not heard.
+    describe "when the transcriber answers the remark instead of writing it down" do
+      let(:essay) do
+        "Sure, here is some additional information about how agent editing works. " * 20
+      end
+
+      it "retries without the prompt, which leaves it nothing to answer from" do
+        contexts = []
+        allow(CoPlan::Ai).to receive(:transcribe) do |file:, context: nil|
+          contexts << context
+          context ? essay : "add some content about how editing works"
+        end
+        allow(CoPlan::Ai).to receive(:call)
+          .and_return({ "text" => "Add some content about how editing works.", "span" => nil }.to_json)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3.", duration_ms: 4000 }
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["transcript"]).to eq("add some content about how editing works")
+        expect(contexts).to eq([ "Our goal is world domination by Q3.", nil ])
+      end
+
+      it "refuses when even the promptless retry outruns the clock" do
+        allow(CoPlan::Ai).to receive(:transcribe).and_return(essay)
+        expect(CoPlan::Ai).not_to receive(:call)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3.", duration_ms: 4000 }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("Didn't catch that — try saying it again")
+      end
+
+      it "does not second-guess a transcript the recording had time for" do
+        expect(CoPlan::Ai).to receive(:transcribe).once.and_return("too grand")
+        allow(CoPlan::Ai).to receive(:call)
+          .and_return({ "text" => "Too grand.", "span" => nil }.to_json)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3.", duration_ms: 2000 }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      # A client that doesn't say how long the take was gets the old
+      # behavior — there is no clock to check against.
+      it "takes the transcript at its word without a duration" do
+        expect(CoPlan::Ai).to receive(:transcribe).once.and_return(essay)
+        allow(CoPlan::Ai).to receive(:call)
+          .and_return({ "text" => "An essay.", "span" => nil }.to_json)
+
+        post plan_dictations_path(plan),
+          params: { audio: audio_upload, excerpt: "Our goal is world domination by Q3." }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    # A browser that transcribed for itself has already done the work.
+    it "prefers a transcript the browser supplies" do
+      expect(CoPlan::Ai).not_to receive(:transcribe)
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Too grand.", "span" => nil }.to_json)
+
+      post plan_dictations_path(plan),
+        params: { transcript: "too grand", audio: audio_upload }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # Plans are readable by link (PlanPolicy#show? is true, same as
+  # commenting), so the boundary that matters here is being signed in at
+  # all — an anonymous visitor must not be able to spend AI calls.
+  it "does not run for a signed-out visitor" do
+    reset! # drops the signed-in session established above
+
+    expect(CoPlan::Ai).not_to receive(:call)
+    post plan_dictations_path(plan), params: { transcript: "hi" }, as: :json
+
+    expect(response).not_to have_http_status(:ok)
+  end
+end

--- a/spec/requests/dictations_spec.rb
+++ b/spec/requests/dictations_spec.rb
@@ -101,6 +101,30 @@ RSpec.describe "Dictations", type: :request do
     expect(response).to have_http_status(:ok)
   end
 
+  # A deleted comment's text was removed on purpose. The context goes to
+  # an external provider — the author's retracted words must not ride
+  # along.
+  it "leaves deleted comments out of the context" do
+    thread = CoPlan::CommentThread.create!(
+      plan: plan, plan_version: plan.current_plan_version, created_by_user: alice
+    )
+    CoPlan::Comment.create!(
+      comment_thread: thread, author_type: "human", author_id: alice.id,
+      body_markdown: "I regret saying this.", deleted_at: Time.current
+    )
+
+    expect(CoPlan::Ai).to receive(:call) do |user_content:, **|
+      expect(user_content).not_to include("I regret saying this.")
+      { "text" => "Too grand.", "span" => nil }.to_json
+    end
+
+    post plan_dictations_path(plan),
+      params: { transcript: "too grand", excerpt: "Our goal is world domination by Q3." },
+      as: :json
+
+    expect(response).to have_http_status(:ok)
+  end
+
   it "falls back to the plan content when the client sends no excerpt" do
     expect(CoPlan::Ai).to receive(:call) do |user_content:, **|
       expect(user_content).to include(plan.current_content.truncate(50, omission: ""))

--- a/spec/services/coplan/comments/interpret_dictation_spec.rb
+++ b/spec/services/coplan/comments/interpret_dictation_spec.rb
@@ -1,0 +1,265 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::Comments::InterpretDictation do
+  let(:excerpt) do
+    <<~TEXT
+      Pilot usage, first four weeks
+      Median latency was 340 milliseconds across the pilot cohort.
+      The higher-fidelity sidecar stays behind a flag until it is proven.
+    TEXT
+  end
+
+  def stub_ai(text:, span: nil)
+    allow(CoPlan::Ai).to receive(:call).and_return({ "text" => text, "span" => span }.to_json)
+  end
+
+  it "returns the cleaned remark and the span it refers to" do
+    stub_ai(
+      text: "Put the median latency in seconds in the header.",
+      span: "Median latency was 340 milliseconds across the pilot cohort."
+    )
+
+    result = described_class.call(
+      excerpt: excerpt,
+      transcript: "put the medium weight latency I put the like the speed at the units of seconds like on the header"
+    )
+
+    expect(result.body).to eq("Put the median latency in seconds in the header.")
+    expect(result.anchor_text).to eq("Median latency was 340 milliseconds across the pilot cohort.")
+  end
+
+  it "reads JSON the model wrapped in a code fence" do
+    allow(CoPlan::Ai).to receive(:call).and_return(<<~RESPONSE)
+      ```json
+      {"text": "This is too cautious.", "span": null}
+      ```
+    RESPONSE
+
+    result = described_class.call(excerpt: excerpt, transcript: "this is like too cautious")
+
+    expect(result.body).to eq("This is too cautious.")
+    expect(result.anchor_text).to be_nil
+  end
+
+  # A "cleanup" that loses or invents half the remark has become a
+  # summary, and the person's own words are better than that.
+  it "keeps their words when the rewrite changes length drastically" do
+    transcript = "the rollout section needs to say which week we ship to everyone and who signs off"
+    stub_ai(text: "Fix rollout.")
+
+    expect(described_class.call(excerpt: excerpt, transcript: transcript).body)
+      .to eq("The rollout section needs to say which week we ship to everyone and who signs off")
+  end
+
+  it "keeps their words when the model pads it out" do
+    transcript = "too formal"
+    stub_ai(text: "I believe this particular passage reads far too formally for our intended audience.")
+
+    expect(described_class.call(excerpt: excerpt, transcript: transcript).body).to eq("Too formal")
+  end
+
+  it "rejects a span that is a paraphrase rather than a quotation" do
+    stub_ai(text: "Too cautious.", span: "the sidecar is gated behind a feature flag")
+
+    expect(described_class.call(excerpt: excerpt, transcript: "too cautious").anchor_text).to be_nil
+  end
+
+  it "forgives quote marks the model wraps around the span" do
+    stub_ai(text: "Too cautious.", span: %(“Median latency was 340 milliseconds across the pilot cohort.”))
+
+    expect(described_class.call(excerpt: excerpt, transcript: "too cautious").anchor_text)
+      .to eq("Median latency was 340 milliseconds across the pilot cohort.")
+  end
+
+  it "rejects a span long enough to be a block quote rather than a pointer" do
+    stub_ai(text: "All of this.", span: excerpt.strip + (" padding to exceed the cap." * 40))
+
+    expect(described_class.call(excerpt: excerpt, transcript: "all of this").anchor_text).to be_nil
+  end
+
+  it "falls back to a local tidy-up when the response isn't JSON" do
+    allow(CoPlan::Ai).to receive(:call).and_return("Sure! Here's the cleaned up comment.")
+
+    result = described_class.call(excerpt: excerpt, transcript: "this is, like, too formal")
+
+    expect(result.body).to eq("This is too formal")
+    expect(result.anchor_text).to be_nil
+  end
+
+  it "falls back to a local tidy-up when the AI is unavailable" do
+    allow(CoPlan::Ai).to receive(:call).and_raise(CoPlan::Ai::Error, "no API key configured")
+
+    result = described_class.call(excerpt: excerpt, transcript: "um this is you know too formal")
+
+    expect(result.body).to eq("This is too formal")
+    expect(result.anchor_text).to be_nil
+  end
+
+  # "like" is a real word far more often than it's a tic, so the local
+  # pass only drops it where the sentence marks it as filler.
+  it "leaves a genuine 'like' alone" do
+    allow(CoPlan::Ai).to receive(:call).and_raise(CoPlan::Ai::Error, "no API key configured")
+
+    result = described_class.call(excerpt: excerpt, transcript: "it looks like the sidecar is gated")
+
+    expect(result.body).to eq("It looks like the sidecar is gated")
+  end
+
+  # The excerpt is what was on screen, one block of rendered text per
+  # line. The anchor has to resolve against the markdown source, and the
+  # two are not the same document.
+  describe "spans that exist on screen but not in the source" do
+    let(:document) do
+      <<~MARKDOWN
+        ### Where the comments came from
+
+        | Surface | Share |
+        |---|---|
+        | Typed in the browser | 68% |
+        | Voice (mic button) | 24% |
+      MARKDOWN
+    end
+
+    let(:rendered) { "Where the comments came from\nSurface\nShare\nTyped in the browser\n68%\nVoice (mic button)\n24%" }
+
+    # Adjacent table cells read as adjacent lines, so the model quite
+    # reasonably quotes across them — and "Voice (mic button)\n24%"
+    # appears nowhere in "| Voice (mic button) | 24% |". Left alone this
+    # produced a thread with anchor text and no position: a comment that
+    # is simply invisible on the page.
+    it "narrows a span that crosses a table cell to one that resolves" do
+      stub_ai(text: "This share looks low.", span: "Voice (mic button)\n24%")
+
+      result = described_class.call(
+        excerpt: rendered, document: document, transcript: "this share looks low"
+      )
+
+      expect(result.anchor_text).to eq("Voice (mic button)")
+      expect(document).to include(result.anchor_text)
+    end
+
+    # Inline markup is different: the model reads "main is always
+    # releasable" off the screen, the markdown says "`main` is always
+    # releasable" — but CommentThread resolves exactly this via stripped
+    # markdown, so the whole span survives. (An earlier version narrowed
+    # it to "is always releasable": stricter than the resolver, and the
+    # highlight missed the very word the remark was about.)
+    it "keeps a span broken only by inline markup — the resolver handles it" do
+      stub_ai(text: "What does releasable mean?", span: "main is always releasable")
+
+      result = described_class.call(
+        excerpt: "main is always releasable",
+        document: "- Branches live < 24h\n- `main` is always releasable\n",
+        transcript: "what does releasable mean"
+      )
+
+      expect(result.anchor_text).to eq("main is always releasable")
+    end
+
+    it "does not salvage a fragment too short to point at anything" do
+      stub_ai(text: "Hm.", span: "the sidecar is proven")
+
+      result = described_class.call(
+        excerpt: "the sidecar is proven",
+        document: "Prove **the** worth first.",
+        transcript: "hm"
+      )
+
+      # "the" is in the document; a pin on it would be noise.
+      expect(result.anchor_text).to be_nil
+    end
+
+    it "keeps a span that appears in the source untouched" do
+      stub_ai(text: "Low.", span: "Typed in the browser")
+
+      expect(described_class.call(excerpt: rendered, document: document, transcript: "low").anchor_text)
+        .to eq("Typed in the browser")
+    end
+
+    # Better no pin than a pin pointing nowhere: the caller falls back to
+    # the section heading, which is always in the source.
+    it "gives up when no part of the span is in the source" do
+      stub_ai(text: "Low.", span: "Surface\nShare")
+
+      expect(described_class.call(excerpt: rendered, document: "# Something else", transcript: "low").anchor_text)
+        .to be_nil
+    end
+  end
+
+  it "does not call the AI without a transcript" do
+    expect(CoPlan::Ai).not_to receive(:call)
+
+    expect(described_class.call(excerpt: excerpt, transcript: "  ").body).to eq("")
+  end
+
+  # "Rename both of these" is one remark but two placements. The model
+  # returns a comments array; each entry gets its own span vetting.
+  describe "a remark about more than one passage" do
+    def stub_ai_comments(comments)
+      allow(CoPlan::Ai).to receive(:call).and_return({ "comments" => comments }.to_json)
+    end
+
+    it "returns one comment per passage, each with its own span" do
+      stub_ai_comments([
+        { "text" => "Quote the latency in seconds.", "span" => "Median latency was 340 milliseconds across the pilot cohort." },
+        { "text" => "Unflag this before launch.", "span" => "The higher-fidelity sidecar stays behind a flag until it is proven." }
+      ])
+
+      result = described_class.call(excerpt: excerpt, transcript: "fix the latency units and unflag the sidecar before launch")
+
+      expect(result.comments.map(&:body)).to eq([ "Quote the latency in seconds.", "Unflag this before launch." ])
+      expect(result.comments.map(&:anchor_text)).to eq([
+        "Median latency was 340 milliseconds across the pilot cohort.",
+        "The higher-fidelity sidecar stays behind a flag until it is proven."
+      ])
+      # The singular readers see the first comment.
+      expect(result.body).to eq("Quote the latency in seconds.")
+    end
+
+    it "keeps a repeated span repeated — that is how two copies are addressed" do
+      stub_ai_comments([
+        { "text" => "Rename this to master.", "span" => "pilot cohort" },
+        { "text" => "Rename this to master.", "span" => "pilot cohort" }
+      ])
+
+      result = described_class.call(excerpt: excerpt, transcript: "rename both of them to master")
+
+      expect(result.comments.map(&:anchor_text)).to eq([ "pilot cohort", "pilot cohort" ])
+    end
+
+    it "vets each span on its own — a bad one falls, the rest stand" do
+      stub_ai_comments([
+        { "text" => "Too cautious.", "span" => "a paraphrase that is not in the excerpt" },
+        { "text" => "Too slow.", "span" => "Median latency was 340 milliseconds across the pilot cohort." }
+      ])
+
+      result = described_class.call(excerpt: excerpt, transcript: "this is too cautious and honestly too slow as well")
+
+      expect(result.comments.first.anchor_text).to be_nil
+      expect(result.comments.last.anchor_text).to eq("Median latency was 340 milliseconds across the pilot cohort.")
+    end
+
+    it "folds anything past the cap away rather than posting a flood" do
+      stub_ai_comments((1..6).map { |i| { "text" => "Point number #{i}.", "span" => nil } })
+
+      result = described_class.call(
+        excerpt: excerpt,
+        transcript: "one two three four five six distinct points about this document somehow"
+      )
+
+      expect(result.comments.length).to eq(described_class::MAX_COMMENTS)
+    end
+
+    it "keeps their words when the split balloons past what was said" do
+      stub_ai_comments([
+        { "text" => "I believe this passage requires a substantially more rigorous treatment of the underlying assumptions.", "span" => nil },
+        { "text" => "Furthermore the rollout timeline deserves a full risk assessment with owners and dates attached.", "span" => nil }
+      ])
+
+      result = described_class.call(excerpt: excerpt, transcript: "tighten this up")
+
+      expect(result.comments.length).to eq(1)
+      expect(result.comments.first.body).to eq("Tighten this up")
+    end
+  end
+end

--- a/spec/system/voice_commenting_spec.rb
+++ b/spec/system/voice_commenting_spec.rb
@@ -280,6 +280,36 @@ RSpec.describe "Voice commenting", type: :system do
       expect(thread).to be_anchored
     end
 
+    # The very first comment on a plan arrives without a page load, and
+    # the keyboard has to work on it. Comment navigation used to render
+    # only when the page loaded with threads already present — so on a
+    # fresh plan the dictated comment appeared, its popover opened, and
+    # d/j/k did nothing at all.
+    it "lets the keyboard discard the first comment without a reload" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_return("too cautious")
+      allow(CoPlan::Ai).to receive(:call).and_return({
+        "text" => "Too cautious.",
+        "span" => "The higher-fidelity sidecar stays behind a flag until it is proven."
+      }.to_json)
+
+      stub_recorder
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      thread = nil
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+      expect { thread = CoPlan::CommentThread.where(plan_id: plan.id).sole }.not_to raise_error
+      # The auto-opened popover is the discard target.
+      expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true, wait: 10)
+
+      find("body").send_keys("d")
+
+      Timeout.timeout(10) { sleep 0.1 until thread.reload.status == "discarded" }
+      expect(page).to have_no_css("mark.anchor-highlight--open", wait: 10)
+    end
+
     # What was on screen is passed as a transcription hint, which is what
     # makes domain words come back as words rather than phonetic guesses.
     it "gives the transcriber the text that was on screen" do

--- a/spec/system/voice_commenting_spec.rb
+++ b/spec/system/voice_commenting_spec.rb
@@ -1,0 +1,469 @@
+require "rails_helper"
+
+# The voice control is the one feature whose whole value is what happens
+# in the browser: transcribe, work out which passage was meant, and pin a
+# comment there. Headless Chrome has no microphone, so SpeechRecognition
+# is replaced with a fake that emits a fixed transcript on demand — every
+# other step is the real thing.
+RSpec.describe "Voice commenting", type: :system do
+  let(:author) { create(:coplan_user, email: "author@example.com") }
+
+  let(:plan_content) do
+    <<~MARKDOWN
+      # Launch Plan
+
+      ## Goals
+
+      We will ship the voice tier to everyone in the first week.
+
+      ## Rollout
+
+      The higher-fidelity sidecar stays behind a flag until it is proven.
+    MARKDOWN
+  end
+
+  let(:plan) do
+    p = CoPlan::Plan.create!(title: "Launch Plan", created_by_user: author)
+    version = CoPlan::PlanVersion.create!(
+      plan: p, revision: 1,
+      content_markdown: plan_content, actor_type: "human", actor_id: author.id
+    )
+    p.update!(current_plan_version: version, current_revision: 1)
+    p
+  end
+
+  def sign_in(user)
+    visit sign_in_path
+    fill_in "Email address", with: user.email
+    click_button "Sign In"
+    expect(page).to have_current_path(root_path)
+  end
+
+  # Installed before any page script runs, so the Stimulus controller sees
+  # a browser that can transcribe and renders the mic button.
+  #
+  # Two real behaviours to model, and which one is in play matters:
+  #   - tap the button: continuous = false, so the browser decides speech
+  #     has ended and fires the result on its own.
+  #   - hold to talk: the result arrives because stop() was called on
+  #     release, and abort() throws away whatever was captured.
+  # A fake that always emits on start() would make "cancel" look like it
+  # posted, because the post would have happened before the cancel.
+  def stub_speech_recognition(transcript, emit_on_stop: false)
+    page.driver.browser.execute_cdp(
+      "Page.addScriptToEvaluateOnNewDocument",
+      source: <<~JS
+        window.SpeechRecognition = class {
+          _emit() {
+            if (this._done) return
+            this._done = true
+            // Shaped like a real SpeechRecognitionResultList: an iterable
+            // of results, each indexable by alternative, and isFinal is
+            // what tells the controller the transcript is settled.
+            const result = [{ transcript: #{transcript.to_json} }]
+            result.isFinal = true
+            this.onresult({ results: [result] })
+            this.onend()
+          }
+          start() {
+            this._done = false
+            if (!#{emit_on_stop}) setTimeout(() => this._emit(), 10)
+          }
+          stop() { this._emit() }
+          abort() { this._done = true }
+        }
+      JS
+    )
+  end
+
+  # Recording + server transcription is the better path and the default
+  # wherever a provider is configured, so the browser's own recognition
+  # has to be asked for explicitly. Its own tests are further down.
+  before do
+    allow(CoPlan::Ai).to receive(:available?).and_return(false)
+    sign_in(author)
+  end
+
+  it "cleans up the remark and pins it to the passage the AI identifies" do
+    allow(CoPlan::Ai).to receive(:call).and_return({
+      "text" => "This bit is too cautious.",
+      "span" => "The higher-fidelity sidecar stays behind a flag until it is proven."
+    }.to_json)
+
+    stub_speech_recognition("this bit is like way too like cautious")
+    visit plan_path(plan)
+
+    find(".voice-btn").click
+
+    expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+
+    thread = CoPlan::CommentThread.where(plan_id: plan.id).last
+    expect(thread.anchor_text).to eq("The higher-fidelity sidecar stays behind a flag until it is proven.")
+    expect(thread.comments.first.body_markdown).to eq("🎙️ This bit is too cautious.")
+    # The anchor has to resolve against the document, or there's no pin.
+    # anchor_start is what actually produces the highlight — a thread with
+    # anchor_text that never resolved is a pin pointing at nothing.
+    expect(thread).to be_anchored
+    expect(thread.anchor_start).to be_present
+    expect(plan.current_content[thread.anchor_start...thread.anchor_end])
+      .to eq("The higher-fidelity sidecar stays behind a flag until it is proven.")
+
+    # The speaker never chose a spot on the page — the model did — so the
+    # thread opens itself to show where it landed. Without this, a pin
+    # below the fold reads as "it said posted but nothing happened".
+    expect(page).to have_css("#comment_thread_#{thread.id}_popover", visible: true, wait: 10)
+    expect(page).to have_content("This bit is too cautious.")
+  end
+
+  # The AI is an enhancement. When it can't answer, the comment still has
+  # to land somewhere visible rather than becoming an invisible thread,
+  # and the client's own tidy-up still takes the worst tics out.
+  it "falls back to the heading and a local cleanup when the AI is down" do
+    allow(CoPlan::Ai).to receive(:call).and_raise(CoPlan::Ai::Error, "not configured")
+
+    stub_speech_recognition("um this section is, you know, like like too vague")
+    visit plan_path(plan)
+
+    find(".voice-btn").click
+
+    expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+
+    thread = CoPlan::CommentThread.where(plan_id: plan.id).last
+    expect(thread.anchor_text).to be_present
+    expect(thread).to be_anchored
+    expect(thread.anchor_start).to be_present
+
+    body = thread.comments.first.body_markdown
+    expect(body).not_to match(/\bum\b/i)
+    expect(body).not_to match(/you know/i)
+    expect(body).not_to match(/like like/i)
+    expect(body).to include("too vague")
+  end
+
+  describe "hold Shift to talk" do
+    HOLD = 0.7 # comfortably past the controller's 350ms hold delay
+
+    before do
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Held to talk.", "span" => nil }.to_json)
+    end
+
+    # Shift left held would make the next test type its email in capitals
+    # and land back on the sign-in page, so releasing is unconditional —
+    # both here and in the ensure below.
+    after { page.driver.browser.action.release_actions }
+
+    # The wait has to happen between two separate `perform` calls. A
+    # `pause` inside one chain blocks the renderer's task queue for its
+    # duration, so the controller's hold timer doesn't fire until after
+    # the release — the hold looks like a tap and nothing is ever
+    # recorded. Only the test harness behaves that way; a real keyboard
+    # doesn't stop the clock.
+    def hold_shift(duration = HOLD)
+      page.driver.browser.action.key_down(:shift).perform
+      sleep duration
+      yield if block_given?
+    ensure
+      page.driver.browser.action.key_up(:shift).perform
+    end
+
+    it "records while Shift is held and posts on release" do
+      stub_speech_recognition("held to talk", emit_on_stop: true)
+      visit plan_path(plan)
+
+      hold_shift
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+
+      thread = CoPlan::CommentThread.where(plan_id: plan.id).sole
+      expect(thread.comments.first.body_markdown).to eq("🎙️ Held to talk.")
+    end
+
+    # Shift is held constantly while typing capitals; a tap must not open
+    # the mic, or the feature is unusable on any page with a text field.
+    it "ignores a quick tap of Shift" do
+      stub_speech_recognition("should never be sent", emit_on_stop: true)
+      visit plan_path(plan)
+
+      page.driver.browser.action.key_down(:shift).key_up(:shift).perform
+
+      expect(page).to have_no_css(".voice-btn--listening", wait: 2)
+      expect(CoPlan::CommentThread.where(plan_id: plan.id).count).to eq(0)
+    end
+
+    # Shift+key is a shortcut or a capital letter, not speech — and
+    # whatever was captured must be discarded rather than posted.
+    it "cancels without posting when another key is pressed" do
+      stub_speech_recognition("should never be sent", emit_on_stop: true)
+      visit plan_path(plan)
+
+      hold_shift do
+        expect(page).to have_css(".voice-btn--listening")
+        page.driver.browser.action.send_keys("a").perform
+      end
+
+      expect(page).to have_no_css(".voice-btn--listening", wait: 5)
+      expect(CoPlan::CommentThread.where(plan_id: plan.id).count).to eq(0)
+    end
+  end
+
+  # The path that works in Safari and Firefox, and the better one in
+  # Chrome too: capture audio, let the server transcribe it. Nothing here
+  # touches SpeechRecognition, which those browsers don't usefully have.
+  describe "recording for the server to transcribe" do
+    before { allow(CoPlan::Ai).to receive(:available?).and_return(true) }
+
+    # `peak` is how far the loudest sample sits from silence, on the
+    # 0–128 scale the controller meters. 30 is ordinary speech; 0 is a
+    # microphone that captured nothing.
+    #
+    # `context_state` models the AudioContext lifecycle. "suspended" is
+    # what push-to-talk actually gets — Chrome doesn't treat a bare Shift
+    # keydown as a user gesture, so the meter never produces a sample and
+    # its all-zero reading must not be mistaken for a silent room.
+    def stub_recorder(peak: 30, context_state: "running")
+      page.driver.browser.execute_cdp("Page.addScriptToEvaluateOnNewDocument", source: <<~JS)
+        delete window.SpeechRecognition
+        delete window.webkitSpeechRecognition
+        Object.defineProperty(navigator, "mediaDevices", {
+          configurable: true,
+          value: { getUserMedia: async () => ({ getTracks: () => [{ stop() {} }] }) }
+        })
+        window.AudioContext = class {
+          constructor() { this.state = #{context_state.to_json} }
+          resume() { return Promise.resolve() } // stays suspended, as without a gesture
+          createAnalyser() {
+            const state = () => this.state
+            return {
+              fftSize: 512,
+              getByteTimeDomainData(samples) {
+                samples.fill(state() === "running" ? 128 + #{peak} : 128)
+              }
+            }
+          }
+          createMediaStreamSource() { return { connect() {} } }
+          close() {}
+        }
+        window.MediaRecorder = class {
+          static isTypeSupported() { return true }
+          constructor(stream, options) {
+            this.mimeType = (options || {}).mimeType || "audio/webm"
+            this.state = "inactive"
+          }
+          start() { this.state = "recording" }
+          stop() {
+            this.state = "inactive"
+            this.ondataavailable({ data: new Blob(["fake audio"], { type: this.mimeType }) })
+            if (this.onstop) this.onstop()
+          }
+        }
+      JS
+    end
+
+    it "sends the recording and posts what comes back" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_return("this bit is like way too like cautious")
+      allow(CoPlan::Ai).to receive(:call).and_return({
+        "text" => "This bit is too cautious.",
+        "span" => "The higher-fidelity sidecar stays behind a flag until it is proven."
+      }.to_json)
+
+      stub_recorder
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      expect(page).to have_css(".voice-btn--listening")
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+
+      thread = CoPlan::CommentThread.where(plan_id: plan.id).sole
+      expect(thread.comments.first.body_markdown).to eq("🎙️ This bit is too cautious.")
+      expect(thread).to be_anchored
+    end
+
+    # What was on screen is passed as a transcription hint, which is what
+    # makes domain words come back as words rather than phonetic guesses.
+    it "gives the transcriber the text that was on screen" do
+      expect(CoPlan::Ai).to receive(:transcribe) do |file:, context:|
+        expect(File.read(file.path)).to eq("fake audio")
+        expect(context).to include("higher-fidelity sidecar")
+        "too cautious"
+      end
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Too cautious.", "span" => nil }.to_json)
+
+      stub_recorder
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+    end
+
+    # "Rename both of them" is one remark, two comments, two pins — and
+    # when the model repeats the same span, each repeat takes the next
+    # copy of that text, so the two threads land on different positions.
+    it "turns a remark about two places into two pinned comments" do
+      dual_plan = CoPlan::Plan.create!(title: "Naming", created_by_user: author)
+      version = CoPlan::PlanVersion.create!(
+        plan: dual_plan, revision: 1,
+        content_markdown: "# Naming\n\nThe first module is called main.\n\nThe second module is also called main.\n",
+        actor_type: "human", actor_id: author.id
+      )
+      dual_plan.update!(current_plan_version: version, current_revision: 1)
+
+      allow(CoPlan::Ai).to receive(:transcribe).and_return("rename both of them to master")
+      allow(CoPlan::Ai).to receive(:call).and_return({ "comments" => [
+        { "text" => "Rename this to master.", "span" => "called main" },
+        { "text" => "Rename this to master.", "span" => "called main" }
+      ] }.to_json)
+
+      stub_recorder
+      visit plan_path(dual_plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status", text: /2 comments added/, wait: 10)
+
+      threads = CoPlan::CommentThread.where(plan_id: dual_plan.id).order(:created_at).to_a
+      expect(threads.length).to eq(2)
+      expect(threads.map(&:anchor_text).uniq).to eq([ "called main" ])
+      # Different copies of the phrase, not two pins on the same one.
+      expect(threads.map(&:anchor_start).uniq.length).to eq(2)
+    end
+
+    # The excerpt is everything that was readably on screen during the
+    # take, not a snapshot of where it began: people start talking about
+    # one paragraph and scroll to another mid-sentence, and the pin has to
+    # be able to land on either. It is also not the whole document — what
+    # was never on screen stays off the wire.
+    it "accumulates the excerpt across a mid-recording scroll" do
+      tall_plan = CoPlan::Plan.create!(title: "Tall Plan", created_by_user: author)
+      filler = (1..100).map { |i| "Filler paragraph number #{i} to push the ending far below the fold." }.join("\n\n")
+      version = CoPlan::PlanVersion.create!(
+        plan: tall_plan, revision: 1,
+        content_markdown: "# Tall Plan\n\nThe alpha waypoint opens the document.\n\n#{filler}\n\nThe omega waypoint closes the document.\n",
+        actor_type: "human", actor_id: author.id
+      )
+      tall_plan.update!(current_plan_version: version, current_revision: 1)
+
+      expect(CoPlan::Ai).to receive(:transcribe) do |context:, **|
+        expect(context).to include("alpha waypoint")
+        expect(context).to include("omega waypoint")
+        expect(context).not_to include("Filler paragraph number 50 ")
+        "rename both of these"
+      end
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Rename both of these.", "span" => nil }.to_json)
+
+      stub_recorder
+      visit plan_path(tall_plan)
+
+      find(".voice-btn").click
+      expect(page).to have_css(".voice-btn--listening")
+      page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+    end
+
+    # The gesture that kept "not hearing" people: hold-to-talk used to
+    # open the microphone only after the 350ms hold was confirmed, so the
+    # first word or two of every short remark predated the recording. The
+    # ear now opens at the keydown itself, and confirming the hold adopts
+    # a capture already in progress.
+    it "captures from the press when talking with Shift held" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_return("oh I meant both of them")
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "Oh — I meant both of them.", "span" => nil }.to_json)
+
+      stub_recorder
+      visit plan_path(plan)
+
+      page.driver.browser.action.key_down(:shift).perform
+      sleep 0.7
+      expect(page).to have_css(".voice-btn--listening")
+      page.driver.browser.action.key_up(:shift).perform
+
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+      thread = CoPlan::CommentThread.where(plan_id: plan.id).sole
+      expect(thread.comments.first.body_markdown).to eq("🎙️ Oh — I meant both of them.")
+    ensure
+      page.driver.browser.action.release_actions
+    end
+
+    # The failure that shipped: a recording with nothing in it still went
+    # to the transcriber, which answered silence by repeating the context
+    # we sent — so a heading off the page arrived as a comment, pinned to
+    # itself, that nobody had said. The microphone knows it heard nothing
+    # long before the server can, so it never gets sent.
+    it "doesn't send a recording it heard nothing in" do
+      expect(CoPlan::Ai).not_to receive(:transcribe)
+
+      stub_recorder(peak: 0)
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status--error", text: /didn't hear anything/i, wait: 5)
+      expect(CoPlan::CommentThread.where(plan_id: plan.id).count).to eq(0)
+    end
+
+    # The first regression this guard caused: a suspended AudioContext
+    # meters exactly like a silent room, and the silence check threw away
+    # recordings people were audibly speaking into. A meter that never
+    # ran gets no vote — the take is sent, and the server's echo check
+    # remains the defence against actual silence.
+    it "sends the recording when the meter never ran, rather than calling speech silence" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_return("it should be main and master")
+      allow(CoPlan::Ai).to receive(:call)
+        .and_return({ "text" => "It should be main and master.", "span" => nil }.to_json)
+
+      stub_recorder(peak: 0, context_state: "suspended")
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+      thread = CoPlan::CommentThread.where(plan_id: plan.id).sole
+      expect(thread.comments.first.body_markdown).to eq("🎙️ It should be main and master.")
+    end
+
+    # Audio has no fallback: unlike a browser transcript there are no
+    # words to post if transcription fails, so say so rather than posting
+    # an empty comment.
+    it "says so when the recording can't be made out" do
+      allow(CoPlan::Ai).to receive(:transcribe).and_raise(CoPlan::Ai::Error, "unavailable")
+
+      stub_recorder
+      visit plan_path(plan)
+
+      find(".voice-btn").click
+      find(".voice-btn").click
+
+      # The server's own wording, not a generic one: "couldn't reach the
+      # transcriber" and "heard nothing" call for different next moves.
+      expect(page).to have_css(".voice-status--error", text: /Couldn't make out the recording/, wait: 10)
+      expect(CoPlan::CommentThread.where(plan_id: plan.id).count).to eq(0)
+    end
+  end
+
+  # Nothing in the flow may claim an agent is coming: with none attached,
+  # a dictated comment is just a comment.
+  it "never promises an agent" do
+    allow(CoPlan::Ai).to receive(:call)
+      .and_return({ "text" => "No agent is attached here.", "span" => nil }.to_json)
+
+    stub_speech_recognition("no agent is attached here")
+    visit plan_path(plan)
+
+    find(".voice-btn").click
+
+    expect(page).to have_css(".voice-status", text: /Comment added/, wait: 10)
+    expect(page).to have_no_css(".voice-status", text: /waiting for the agent/i)
+    expect(page).to have_no_css(".agent-pill")
+  end
+end


### PR DESCRIPTION
## What

Hold **Shift** (or tap the floating mic) and talk — what you said posts as a comment pinned to the passage that was on screen, cleaned up and auto-opened so you see where it landed.

## How it works

**Capture.** Recording starts at the Shift *press*, not after the 350ms hold-confirmation — people start talking immediately, and the first word matters ("oh, I meant both of them"). A tap, a Shift-shortcut, or extending a selection discards the take unheard. A level meter drives a ring on the button (the fill says "mic is open", the ring says "it can hear you") and backstops against posting silence — failing open when the AudioContext never gets a user gesture. Browsers without a configured AI provider fall back to the Web Speech API.

**Transcription.** `gpt-4o-transcribe` (override: `COPLAN_TRANSCRIBE_MODEL`), prompted with the text that was *readably* visible during the take — that hint is the difference between "CoPlan" and "co-plan". Two guards for how that model fails:
- *Prompt echo*: given silence it repeats its prompt, i.e. the page itself. Anything wholly contained in the excerpt is rejected as "didn't hear anything".
- *Fabrication*: it's a chat model with ears — given an instruction-shaped remark it can **answer** instead of transcribing (observed live: "add some content about how editing works" came back as an essay with figures lifted from the prompt). The client sends the take's duration; a transcript longer than the recording had seconds to hold (~30 chars/sec + slack) is retried without the prompt, and refused if still implausible.

**Interpretation.** One `gpt-4o` call cleans the words (fillers, false starts, mis-transcribed jargon) and quotes the exact span the remark was about. Nothing it returns is trusted:
- spans must appear character-for-character in the excerpt *and* resolve against the markdown source (via `CommentThread.strip_markdown`) — a span crossing table cells degrades to its longest resolvable line/run, or is dropped;
- the rewrite must stay within a length band of what was said — shorter is a summary, longer is invention; every failure falls back to a locally tidied transcript.

A remark about several passages ("rename both of these") becomes up to four pinned comments; a repeated span means successive occurrences. Recent comments ride along as context so follow-ups resolve.

**Placement.** The excerpt accumulates across mid-take scrolls (blocks count only when readably visible, not one-pixel slivers). The occurrence picked is the copy nearest the viewport. An unresolvable pin falls back to the current section heading; a server 422 (anchor-must-resolve validation) retries the same way. The posted thread scrolls into view and opens.

## Notes for review

- `_watchAgentPill` / spoken acknowledgments reference an agent-presence pill that doesn't exist yet — they no-op by design and light up when the agent-collaboration PR lands.
- Dictation requires a signed-in user (anonymous visitors must not spend AI calls); comment posting itself is unchanged.
- The mic hides entirely when the browser can neither record nor recognize.

## Tests

76 examples green: request specs for the dictation endpoint (echo, fabrication, formats, auth), unit specs for interpretation (span vetting, length band, multi-comment, fallbacks), and 14 system specs driving a fake MediaRecorder through capture, mid-take scrolls, multi-pin, auto-open, and failure reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)