### PR TITLE
Add rich reference previews and back matter

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1855,7 +1855,25 @@ img.avatar {
 .markdown-rendered .footnote-ref a,
 .markdown-rendered sup a[data-footnote-ref] {
   text-decoration: none;
-  padding: 0 2px;
+  padding: 1px 4px;
+  border-radius: 999px;
+  background: var(--color-primary-light);
+  font-weight: 600;
+}
+
+.markdown-rendered .reference-anchor--section {
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.markdown-rendered .reference-anchor:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.markdown-rendered [id^="section-"] {
+  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
 }
 
 .markdown-rendered section[data-footnotes] {
@@ -1872,6 +1890,119 @@ img.avatar {
 
 .markdown-rendered a[data-footnote-backref] {
   text-decoration: none;
+}
+
+/* Citation and internal-section previews. A single manual popover is filled
+   from the rendered target already on the page, so it opens without a fetch
+   and can coexist with comment popovers. */
+.reference-preview {
+  display: none;
+  position: fixed;
+  inset: auto;
+  width: min(420px, calc(100vw - 32px));
+  max-height: min(55vh, 460px);
+  margin: 0;
+  padding: var(--space-md);
+  overflow-y: auto;
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: 210;
+}
+
+.reference-preview:popover-open {
+  display: block;
+}
+
+/* Fallback for browsers without the Popover API. Kept as its own selector so
+   an older parser rejecting :popover-open does not discard this rule too. */
+.reference-preview--open {
+  display: block;
+}
+
+.reference-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xs);
+}
+
+.reference-preview__label {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.reference-preview__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  font: inherit;
+  font-size: var(--text-lg);
+  cursor: pointer;
+}
+
+.reference-preview__close:hover {
+  color: var(--color-text);
+  background: var(--color-bg-muted);
+}
+
+.reference-preview__title {
+  display: block;
+  margin-bottom: var(--space-sm);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+.reference-preview__body {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+
+.reference-preview__body p {
+  margin: 0;
+}
+
+.reference-preview__body a {
+  color: var(--color-primary);
+  overflow-wrap: anywhere;
+}
+
+.reference-preview__jump {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  color: var(--color-primary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.reference-preview__jump:hover {
+  text-decoration: underline;
+}
+
+.reference-preview--sheet {
+  top: auto !important;
+  left: 0 !important;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  max-height: 55vh;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-bottom: none;
 }
 
 /* Comment popover (appears on text selection) */

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1980,6 +1980,33 @@ img.avatar {
   overflow-wrap: anywhere;
 }
 
+.reference-preview__body .reference-preview__source {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: var(--space-sm);
+  padding: var(--space-sm);
+  color: inherit;
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+}
+
+.reference-preview__body .reference-preview__source:hover {
+  border-color: var(--color-primary);
+}
+
+.reference-preview__source-title {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.reference-preview__source-meta {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
 .reference-preview--sheet {
   top: auto !important;
   left: 0 !important;

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1898,10 +1898,9 @@ img.avatar {
   text-decoration: none;
 }
 
-/* Citation and internal-section previews. A single hover card is filled from
-   the rendered target already on the page, so it opens without a fetch. It
-   deliberately stays out of the browser's top layer so native anchor clicks
-   pass through instead of first dismissing a popover. */
+/* Citation and internal-section previews. A single manual popover is filled
+   from the rendered target already on the page, so it opens without a fetch
+   and can coexist with comment popovers. */
 .reference-preview {
   display: none;
   position: fixed;
@@ -1919,6 +1918,12 @@ img.avatar {
   z-index: 210;
 }
 
+.reference-preview:popover-open {
+  display: block;
+}
+
+/* Fallback for browsers without the Popover API. Kept as its own selector so
+   an older parser rejecting :popover-open does not discard this rule too. */
 .reference-preview--open {
   display: block;
 }

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2007,6 +2007,26 @@ img.avatar {
   font-size: var(--text-xs);
 }
 
+.reference-preview__body .citation-source__icon {
+  display: none;
+}
+
+.reference-preview__body .citation-source__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reference-preview__body .citation-source__title {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.reference-preview__body .citation-source__meta {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
 .reference-preview--sheet {
   top: auto !important;
   left: 0 !important;
@@ -3283,10 +3303,86 @@ img.avatar {
   color: var(--color-text-muted);
 }
 
+#plan-citations:empty {
+  display: none;
+}
+
+.reference-citations {
+  margin-top: var(--space-sm);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.reference-citations > ol {
+  margin: 0;
+  padding-left: calc(24px + var(--space-lg));
+}
+
+.reference-citations > ol > li {
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.reference-citations > ol > li::marker {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.reference-citations p {
+  margin: 0;
+}
+
+.reference-citations a[data-footnote-backref] {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.citation-source {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  max-width: 100%;
+  margin: 2px 1px;
+  padding: 4px var(--space-sm);
+  vertical-align: middle;
+  color: inherit;
+  background: var(--color-bg-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+}
+
+.citation-source:hover {
+  border-color: var(--color-primary);
+}
+
+.citation-source__icon {
+  flex-shrink: 0;
+  font-size: var(--text-base);
+}
+
+.citation-source__content {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.citation-source__title {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.citation-source__meta {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 .references-list {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: var(--space-xs) 0 0;
 }
 
 .references-list__item {
@@ -3320,9 +3416,12 @@ img.avatar {
 
 .references-list__meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-xs);
   margin-top: 2px;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
 }
 
 .references-list__source {

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1928,24 +1928,11 @@ img.avatar {
   display: block;
 }
 
-.reference-preview__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  margin-bottom: var(--space-xs);
-}
-
-.reference-preview__label {
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
 .reference-preview__close {
   display: inline-flex;
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
   align-items: center;
   justify-content: center;
   width: 24px;
@@ -1967,12 +1954,18 @@ img.avatar {
 
 .reference-preview__title {
   display: block;
+  padding-right: calc(24px + var(--space-sm));
   margin-bottom: var(--space-sm);
   font-size: var(--text-sm);
   line-height: 1.4;
 }
 
+.reference-preview__title[hidden] {
+  display: none;
+}
+
 .reference-preview__body {
+  padding-right: calc(24px + var(--space-sm));
   color: var(--color-text-muted);
   font-size: var(--text-sm);
   line-height: 1.55;

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1884,6 +1884,12 @@ img.avatar {
   color: var(--color-text-muted);
 }
 
+.markdown-rendered section[data-footnotes] .footnotes-title {
+  margin: 0 0 var(--space-md);
+  color: var(--color-text);
+  font-size: var(--text-lg);
+}
+
 .markdown-rendered section[data-footnotes] p {
   margin-bottom: var(--space-xs);
 }
@@ -1892,9 +1898,10 @@ img.avatar {
   text-decoration: none;
 }
 
-/* Citation and internal-section previews. A single manual popover is filled
-   from the rendered target already on the page, so it opens without a fetch
-   and can coexist with comment popovers. */
+/* Citation and internal-section previews. A single hover card is filled from
+   the rendered target already on the page, so it opens without a fetch. It
+   deliberately stays out of the browser's top layer so native anchor clicks
+   pass through instead of first dismissing a popover. */
 .reference-preview {
   display: none;
   position: fixed;
@@ -1912,12 +1919,6 @@ img.avatar {
   z-index: 210;
 }
 
-.reference-preview:popover-open {
-  display: block;
-}
-
-/* Fallback for browsers without the Popover API. Kept as its own selector so
-   an older parser rejecting :popover-open does not discard this rule too. */
 .reference-preview--open {
   display: block;
 }
@@ -1979,19 +1980,6 @@ img.avatar {
 .reference-preview__body a {
   color: var(--color-primary);
   overflow-wrap: anywhere;
-}
-
-.reference-preview__jump {
-  display: inline-block;
-  margin-top: var(--space-sm);
-  color: var(--color-primary);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.reference-preview__jump:hover {
-  text-decoration: underline;
 }
 
 .reference-preview--sheet {

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2007,10 +2007,6 @@ img.avatar {
   font-size: var(--text-xs);
 }
 
-.reference-preview__body .citation-source__icon {
-  display: none;
-}
-
 .reference-preview__body .citation-source__content {
   display: flex;
   flex-direction: column;
@@ -3290,9 +3286,7 @@ img.avatar {
 }
 
 /* References section */
-/* Section bodies hang under the header, indented past the round "+" so
-   content lines up with the section title. */
-.references-section,
+/* Empty attachment copy hangs under the header, indented past the round "+". */
 .attachments-section {
   padding: 0 0 0 calc(24px + var(--space-sm));
 }
@@ -3308,24 +3302,40 @@ img.avatar {
 }
 
 .reference-citations {
-  margin-top: var(--space-sm);
+  margin-top: var(--space-md);
   color: var(--color-text-muted);
   font-size: var(--text-sm);
 }
 
+#footnote-references {
+  counter-reset: plan-reference;
+}
+
 .reference-citations > ol {
+  display: grid;
+  gap: var(--space-lg);
+  list-style: none;
   margin: 0;
-  padding-left: calc(24px + var(--space-lg));
+  padding: 0;
 }
 
 .reference-citations > ol > li {
-  padding: var(--space-sm) 0;
-  border-bottom: 1px solid var(--color-border);
+  position: relative;
+  padding: 0 0 0 calc(24px + var(--space-md));
+  line-height: 1.55;
+  counter-increment: plan-reference;
+  scroll-margin-top: calc(var(--nav-height) + var(--space-lg));
 }
 
-.reference-citations > ol > li::marker {
+.reference-citations > ol > li::before,
+.references-list__item::before {
+  content: counter(plan-reference) ".";
+  position: absolute;
+  left: 0;
+  width: 24px;
   color: var(--color-text-muted);
   font-weight: 600;
+  text-align: right;
 }
 
 .reference-citations p {
@@ -3333,74 +3343,72 @@ img.avatar {
 }
 
 .reference-citations a[data-footnote-backref] {
+  position: absolute;
+  top: 0;
+  right: 0;
   color: var(--color-text-muted);
   text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
 }
 
-.citation-source {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-xs);
-  max-width: 100%;
-  margin: 2px 1px;
-  padding: 4px var(--space-sm);
-  vertical-align: middle;
+.reference-citations > ol > li:hover a[data-footnote-backref],
+.reference-citations a[data-footnote-backref]:focus-visible {
+  color: var(--color-primary);
+  opacity: 1;
+}
+
+.citation-source--inline {
+  color: var(--color-primary);
+}
+
+.citation-source--block {
+  display: inline;
   color: inherit;
-  background: var(--color-bg-muted);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
   text-decoration: none;
 }
 
-.citation-source:hover {
-  border-color: var(--color-primary);
-}
-
-.citation-source__icon {
-  flex-shrink: 0;
-  font-size: var(--text-base);
+.citation-source--block:hover .citation-source__title {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .citation-source__content {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
+  display: inline;
 }
 
 .citation-source__title {
-  color: var(--color-text);
-  font-weight: 600;
+  color: var(--color-primary);
+  font-weight: 500;
 }
 
 .citation-source__meta {
   color: var(--color-text-muted);
   font-size: var(--text-xs);
-  white-space: nowrap;
+}
+
+.reference-citations .citation-source__meta::before {
+  content: " · ";
 }
 
 .references-list {
   list-style: none;
   padding: 0;
-  margin: var(--space-xs) 0 0;
+  margin: var(--space-sm) 0 0;
 }
 
 .references-list__item {
   display: flex;
   align-items: flex-start;
-  gap: var(--space-sm);
-  padding: var(--space-sm) 0;
-  border-bottom: 1px solid var(--color-border);
+  position: relative;
+  padding: var(--space-xs) 0 var(--space-xs) calc(24px + var(--space-md));
+  counter-increment: plan-reference;
 }
 
-.references-list__item:last-child {
-  border-bottom: none;
-}
-
-.references-list__icon {
-  flex-shrink: 0;
-  font-size: var(--text-lg);
-  line-height: 1.4;
+.references-list__item::before {
+  top: var(--space-xs);
+  font-size: var(--text-sm);
 }
 
 .references-list__content {
@@ -3409,44 +3417,29 @@ img.avatar {
 }
 
 .references-list__link {
-  display: block;
-  word-break: break-all;
+  display: inline;
+  color: var(--color-primary);
   font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.references-list__link:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .references-list__meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-xs);
-  margin-top: 2px;
+  display: inline;
   color: var(--color-text-muted);
   font-size: var(--text-xs);
 }
 
-.references-list__source {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-  font-style: italic;
-}
-
-.badge--ref-type {
-  font-size: 0.7rem;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-}
-
-.badge--ref-key {
-  font-size: 0.7rem;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--color-surface);
-  color: var(--color-primary);
-  border: 1px solid var(--color-primary);
-  font-family: var(--font-mono, monospace);
+.references-list__meta::before {
+  content: " · ";
 }
 
 .references-list__remove {
@@ -3458,12 +3451,24 @@ img.avatar {
   padding: 2px 6px;
   font-size: var(--text-sm);
   border-radius: var(--radius);
-  transition: color 0.15s, background 0.15s;
+  opacity: 0;
+  transition: color 0.15s, background 0.15s, opacity 0.15s;
+}
+
+.references-list__item:hover .references-list__remove,
+.references-list__remove:focus-visible {
+  opacity: 1;
 }
 
 .references-list__remove:hover {
   color: var(--color-danger);
   background: var(--color-bg);
+}
+
+@media (hover: none) {
+  .references-list__remove {
+    opacity: 1;
+  }
 }
 
 .references-section__header {

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -149,10 +149,10 @@ module CoPlan
         .order(:created_at)
       @my_folders = current_user.library.folders.order(:name).to_a
       @threads = @plan.comment_threads.with_kept_comments.includes(:comments, :created_by_user).order(:created_at)
-      # Links already visible in the document remain auto-extracted for API
-      # discovery, but repeating them in back matter duplicates citations.
-      # Only separately curated resources belong in the reader UI.
-      @references = @plan.references.explicit.order(reference_type: :asc, created_at: :desc)
+      # The reader view joins auto-extracted resources to their Markdown
+      # citations by URL, then lists the remaining resources in the same
+      # References section.
+      @references = @plan.references.order(reference_type: :asc, created_at: :desc)
       @attachments = @plan.attachments_attachments.includes(:blob).order(created_at: :desc)
       # Order matters: compute the one-time "changed since you last looked"
       # highlights against the old last_seen_at, then advance it — so the

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -149,7 +149,10 @@ module CoPlan
         .order(:created_at)
       @my_folders = current_user.library.folders.order(:name).to_a
       @threads = @plan.comment_threads.with_kept_comments.includes(:comments, :created_by_user).order(:created_at)
-      @references = @plan.references.order(reference_type: :asc, created_at: :desc)
+      # Links already visible in the document remain auto-extracted for API
+      # discovery, but repeating them in back matter duplicates citations.
+      # Only separately curated resources belong in the reader UI.
+      @references = @plan.references.explicit.order(reference_type: :asc, created_at: :desc)
       @attachments = @plan.attachments_attachments.includes(:blob).order(created_at: :desc)
       # Order matters: compute the one-time "changed since you last looked"
       # highlights against the old last_seen_at, then advance it — so the

--- a/engine/app/controllers/coplan/references_controller.rb
+++ b/engine/app/controllers/coplan/references_controller.rb
@@ -78,22 +78,34 @@ module CoPlan
     end
 
     def render_references_stream
-      references = @plan.references.reload.explicit.order(reference_type: :asc, created_at: :desc)
+      references = @plan.references.reload.order(reference_type: :asc, created_at: :desc)
+      back_matter = helpers.plan_citation_back_matter(@plan, references)
+      listed_references = helpers.listed_plan_references(references, back_matter[:cited_urls])
+      reference_count = back_matter[:count] + listed_references.size
       render turbo_stream: [
+        turbo_stream.replace(
+          "plan-citations",
+          partial: "coplan/plans/citations",
+          locals: { plan: @plan, back_matter: back_matter }
+        ),
         turbo_stream.replace(
           "plan-references",
           partial: "coplan/plans/references",
-          locals: { references: references, plan: @plan }
+          locals: {
+            references: listed_references,
+            plan: @plan,
+            has_citations: back_matter[:count].positive?
+          }
         ),
         turbo_stream.replace(
           "references-count",
-          html: helpers.content_tag(:span, references.size, class: "section-count", id: "references-count")
+          html: helpers.content_tag(:span, reference_count, class: "section-count", id: "references-count")
         ),
         # The document outline shows the same count; without this it goes
         # stale the moment a reference is added or removed.
         turbo_stream.replace(
           "nav-references-count",
-          html: helpers.content_tag(:span, references.size, class: "section-count", id: "nav-references-count")
+          html: helpers.content_tag(:span, reference_count, class: "section-count", id: "nav-references-count")
         )
       ]
     end

--- a/engine/app/controllers/coplan/references_controller.rb
+++ b/engine/app/controllers/coplan/references_controller.rb
@@ -78,7 +78,7 @@ module CoPlan
     end
 
     def render_references_stream
-      references = @plan.references.reload.order(reference_type: :asc, created_at: :desc)
+      references = @plan.references.reload.explicit.order(reference_type: :asc, created_at: :desc)
       render turbo_stream: [
         turbo_stream.replace(
           "plan-references",

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -16,7 +16,7 @@ module CoPlan
       section
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled open aria-label data-line data-line-text data-action data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
+    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled open aria-label aria-haspopup aria-expanded data-line data-line-text data-action data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
 
     # Commonmarker extensions beyond the gem defaults (tables, tasklist,
     # strikethrough, autolink stay on). Footnotes: `[^1]` in text plus a
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 2
+    RENDER_CACHE_VERSION = 3
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -53,7 +53,8 @@ module CoPlan
       render_options[:sourcepos] = true if interactive
       html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { extension: EXTENSION_OPTIONS, render: render_options }, plugins: { syntax_highlighter: nil })
       with_chips = transform_mention_anchors(html)
-      sanitized = sanitize(with_chips, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+      with_references = transform_reference_anchors(with_chips, numbered_sections: footnote_prefix.nil?)
+      sanitized = sanitize(with_references, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
       result = scope_footnote_ids(result, footnote_prefix) if footnote_prefix
       tag.div(result.html_safe, class: "markdown-rendered", data: { controller: "coplan--mermaid coplan--syntax-highlight" })
@@ -80,12 +81,75 @@ module CoPlan
       doc.to_html
     end
 
+    # Numbered headings get stable fragments so agents can write explicit,
+    # unambiguous same-document references such as
+    # `[§3.1](#section-3-1)`. Plain `§3.1` text is deliberately not linked:
+    # research plans also cite external laws as `RKSV §3.1`, where guessing
+    # that the target is a CoPlan heading would create incorrect links.
+    #
+    # Footnote citations and valid numbered-section links opt into the shared
+    # reference-preview controller. It reads their already-rendered targets,
+    # so previews require no duplicate citation data or network request.
+    def transform_reference_anchors(html, numbered_sections: true)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      used_ids = doc.css("[id]").filter_map { |node| node["id"].presence }.to_set
+      section_ids = Set.new
+
+      if numbered_sections
+        doc.css("h1, h2, h3, h4, h5, h6").each do |heading|
+          section_number = heading.text.squish[/\A(\d+(?:\.\d+)*)\b/, 1]
+          next unless section_number
+
+          heading["id"] ||= unique_dom_id("section-#{section_number.tr('.', '-')}", used_ids)
+          used_ids << heading["id"]
+          section_ids << heading["id"]
+        end
+      end
+
+      doc.css("a[data-footnote-ref]").each do |anchor|
+        enhance_reference_anchor(anchor, type: "footnote")
+      end
+
+      doc.css('a[href^="#"]').each do |anchor|
+        next if anchor["data-footnote-ref"] || anchor["data-footnote-backref"]
+
+        target_id = anchor["href"].delete_prefix("#")
+        enhance_reference_anchor(anchor, type: "section") if section_ids.include?(target_id)
+      end
+
+      doc.to_html
+    end
+
     def markdown_to_plain_text(content)
       html = Commonmarker.to_html(content.to_s.encode("UTF-8"), options: { extension: EXTENSION_OPTIONS }, plugins: { syntax_highlighter: nil })
       Nokogiri::HTML::DocumentFragment.parse(html).text.squish
     end
 
     private
+
+    REFERENCE_PREVIEW_ACTIONS = [
+      "mouseenter->coplan--reference-preview#enter",
+      "mouseleave->coplan--reference-preview#leave",
+      "focus->coplan--reference-preview#enter",
+      "blur->coplan--reference-preview#leave",
+      "click->coplan--reference-preview#pin"
+    ].join(" ").freeze
+
+    def unique_dom_id(base, used_ids)
+      return base unless used_ids.include?(base)
+
+      suffix = 2
+      suffix += 1 while used_ids.include?("#{base}-#{suffix}")
+      "#{base}-#{suffix}"
+    end
+
+    def enhance_reference_anchor(anchor, type:)
+      anchor.add_class("reference-anchor")
+      anchor.add_class("reference-anchor--#{type}")
+      anchor["aria-haspopup"] = "dialog"
+      anchor["aria-expanded"] = "false"
+      anchor["data-action"] = [ anchor["data-action"], REFERENCE_PREVIEW_ACTIONS ].compact.join(" ")
+    end
 
     # Wires rendered task checkboxes to their source lines via Commonmarker's
     # sourcepos metadata, so the parser that decides what renders as a

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -16,7 +16,7 @@ module CoPlan
       section
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title target rel type checked disabled open aria-label aria-haspopup aria-expanded data-line data-line-text data-action data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
+    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title target rel type checked disabled open aria-label aria-haspopup aria-expanded data-line data-line-text data-action data-mention-username data-sourcepos data-reference-type data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
 
     # Commonmarker extensions beyond the gem defaults (tables, tasklist,
     # strikethrough, autolink stay on). Footnotes: `[^1]` in text plus a
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 4
+    RENDER_CACHE_VERSION = 5
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -100,6 +100,7 @@ module CoPlan
 
         anchor["target"] = "_blank"
         anchor["rel"] = "noopener noreferrer"
+        anchor["data-reference-type"] = Reference.classify_url(anchor["href"])
       end
 
       if numbered_sections

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -16,7 +16,7 @@ module CoPlan
       section
     ].freeze
 
-    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title type checked disabled open aria-label aria-haspopup aria-expanded data-line data-line-text data-action data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
+    ALLOWED_ATTRIBUTES = %w[id class lang href src alt title target rel type checked disabled open aria-label aria-haspopup aria-expanded data-line data-line-text data-action data-mention-username data-sourcepos data-footnotes data-footnote-ref data-footnote-backref data-footnote-backref-idx].freeze
 
     # Commonmarker extensions beyond the gem defaults (tables, tasklist,
     # strikethrough, autolink stay on). Footnotes: `[^1]` in text plus a
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 3
+    RENDER_CACHE_VERSION = 4
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -94,6 +94,13 @@ module CoPlan
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
       used_ids = doc.css("[id]").filter_map { |node| node["id"].presence }.to_set
       section_ids = Set.new
+
+      doc.css("a[href]").each do |anchor|
+        next unless anchor["href"].match?(%r{\Ahttps?://}i)
+
+        anchor["target"] = "_blank"
+        anchor["rel"] = "noopener noreferrer"
+      end
 
       if numbered_sections
         doc.css("h1, h2, h3, h4, h5, h6").each do |heading|

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 5
+    RENDER_CACHE_VERSION = 6
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -46,7 +46,7 @@ module CoPlan
     # one markdown fragment (e.g. each comment) — commonmarker numbers
     # footnote ids from #fn-1 per document, so unprefixed fragments collide
     # and reference/backref links jump to the wrong footnote.
-    def render_markdown(content, interactive: true, footnote_prefix: nil)
+    def render_markdown(content, interactive: true, footnote_prefix: nil, footnotes: :inline)
       render_options = { unsafe: true }
       # Sourcepos is only needed to wire checkboxes to their source lines;
       # make_checkboxes_interactive strips it from the final output.
@@ -57,6 +57,9 @@ module CoPlan
       sanitized = sanitize(with_references, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       result = interactive ? make_checkboxes_interactive(sanitized, content) : sanitized
       result = scope_footnote_ids(result, footnote_prefix) if footnote_prefix
+      result = select_footnotes(result, footnotes)
+      return result.html_safe if footnotes == :only
+
       tag.div(result.html_safe, class: "markdown-rendered", data: { controller: "coplan--mermaid coplan--syntax-highlight" })
     end
 
@@ -164,6 +167,21 @@ module CoPlan
       anchor["aria-haspopup"] = "dialog"
       anchor["aria-expanded"] = "false"
       anchor["data-action"] = [ anchor["data-action"], REFERENCE_PREVIEW_ACTIONS ].compact.join(" ")
+    end
+
+    def select_footnotes(html, mode)
+      return html if mode == :inline
+
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      sections = doc.css("section[data-footnotes]")
+      if mode == :only
+        sections.map(&:to_html).join
+      elsif mode == :exclude
+        sections.remove
+        doc.to_html
+      else
+        raise ArgumentError, "unknown footnote mode: #{mode.inspect}"
+      end
     end
 
     # Wires rendered task checkboxes to their source lines via Commonmarker's

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 6
+    RENDER_CACHE_VERSION = 8
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -117,6 +117,13 @@ module CoPlan
         enhance_reference_anchor(anchor, type: "section") if section_ids.include?(target_id)
       end
 
+      doc.css("section[data-footnotes]").each do |section|
+        heading = Nokogiri::XML::Node.new("h2", doc)
+        heading["class"] = "footnotes-title"
+        heading.content = "References"
+        section.prepend_child(heading)
+      end
+
       doc.to_html
     end
 
@@ -132,7 +139,7 @@ module CoPlan
       "mouseleave->coplan--reference-preview#leave",
       "focus->coplan--reference-preview#enter",
       "blur->coplan--reference-preview#leave",
-      "click->coplan--reference-preview#pin"
+      "click->coplan--reference-preview#follow"
     ].join(" ").freeze
 
     def unique_dom_id(base, used_ids)

--- a/engine/app/helpers/coplan/references_helper.rb
+++ b/engine/app/helpers/coplan/references_helper.rb
@@ -2,16 +2,6 @@ module CoPlan
   module ReferencesHelper
     include MarkdownHelper
 
-    def reference_icon(reference_type)
-      case reference_type
-      when "plan" then "📋"
-      when "repository" then "📦"
-      when "pull_request" then "🔀"
-      when "document" then "📄"
-      else "🔗"
-      end
-    end
-
     def reference_domain(url)
       URI.parse(url).host&.delete_prefix("www.")
     rescue URI::InvalidURIError
@@ -51,30 +41,25 @@ module CoPlan
         references.map { |reference| "#{reference.id}:#{reference.updated_at&.to_f}" }.join("|")
       )
       signature = [ plan.current_revision, reference_digest ]
-      @plan_citation_back_matter ||= {}
-      @plan_citation_back_matter[[ plan.id, signature ]] ||= begin
-        cached = Rails.cache.fetch([
-          "coplan/plan-citation-back-matter",
-          MarkdownHelper::RENDER_CACHE_VERSION,
-          plan.id,
-          *signature
-        ]) do
-          result = build_plan_citation_back_matter(plan, references)
-          [ result[:html].to_s, result[:cited_urls].to_a, result[:count] ]
-        end
-
-        {
-          html: cached[0].html_safe,
-          cited_urls: cached[1].to_set.freeze,
-          count: cached[2]
-        }
+      cached = Rails.cache.fetch([
+        "coplan/plan-citation-back-matter",
+        MarkdownHelper::RENDER_CACHE_VERSION,
+        plan.id,
+        *signature
+      ]) do
+        result = build_plan_citation_back_matter(plan, references)
+        [ result[:html].to_s, result[:cited_urls].to_a, result[:count] ]
       end
+
+      {
+        html: cached[0].html_safe,
+        cited_urls: cached[1].to_set.freeze,
+        count: cached[2]
+      }
     end
 
     def listed_plan_references(references, cited_urls)
-      references.reject do |reference|
-        reference.source == "extracted" && cited_urls.include?(reference.url)
-      end
+      references.reject { |reference| cited_urls.include?(reference.url) }
     end
 
     def plan_reference_count(plan, references)
@@ -118,12 +103,14 @@ module CoPlan
 
       anchor.add_class("citation-source")
       anchor["aria-label"] = "Open source: #{title} in a new tab (#{metadata})"
-      anchor.children.remove
+      unless terminal_citation_source?(anchor)
+        anchor.add_class("citation-source--inline")
+        anchor["title"] = metadata
+        return
+      end
 
-      icon = Nokogiri::XML::Node.new("span", anchor.document)
-      icon["class"] = "citation-source__icon"
-      icon["aria-hidden"] = "true"
-      icon.content = reference_icon(type)
+      anchor.add_class("citation-source--block")
+      anchor.children.remove
 
       content = Nokogiri::XML::Node.new("span", anchor.document)
       content["class"] = "citation-source__content"
@@ -138,12 +125,21 @@ module CoPlan
 
       content.add_child(title_node)
       content.add_child(metadata_node)
-      anchor.add_child(icon)
       anchor.add_child(content)
 
       punctuation = anchor.next_sibling
       if punctuation&.text? && punctuation.text.match?(/\A\s*[.,;:]\s*\z/)
         punctuation.remove
+      end
+    end
+
+    def terminal_citation_source?(anchor)
+      anchor.xpath("following-sibling::node()").all? do |sibling|
+        if sibling.text?
+          sibling.text.match?(/\A\s*[.,;:]*\s*\z/)
+        else
+          sibling.attribute("data-footnote-backref").present?
+        end
       end
     end
   end

--- a/engine/app/helpers/coplan/references_helper.rb
+++ b/engine/app/helpers/coplan/references_helper.rb
@@ -1,5 +1,7 @@
 module CoPlan
   module ReferencesHelper
+    include MarkdownHelper
+
     def reference_icon(reference_type)
       case reference_type
       when "plan" then "📋"
@@ -7,6 +9,141 @@ module CoPlan
       when "pull_request" then "🔀"
       when "document" then "📄"
       else "🔗"
+      end
+    end
+
+    def reference_domain(url)
+      URI.parse(url).host&.delete_prefix("www.")
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def reference_type_label(reference_type, url)
+      domain = reference_domain(url)
+
+      case reference_type
+      when "plan" then "CoPlan plan"
+      when "repository" then "GitHub repository"
+      when "pull_request" then "GitHub pull request"
+      when "document"
+        return "Google Sheet" if domain == "docs.google.com" && URI.parse(url).path.start_with?("/spreadsheets/")
+        return "Google Slides" if domain == "docs.google.com" && URI.parse(url).path.start_with?("/presentation/")
+        return "Google Doc" if domain == "docs.google.com"
+        return "Google Drive" if domain == "drive.google.com"
+        return "Notion" if domain&.end_with?("notion.so", "notion.site")
+        return "Confluence" if domain&.include?("confluence")
+
+        "Document"
+      else
+        domain&.match?(/(^|\.)gov(\.|$)/) ? "Government website" : "Website"
+      end
+    rescue URI::InvalidURIError
+      reference_type.humanize
+    end
+
+    # Markdown owns a citation's placement and explanatory text; Reference
+    # owns the linked resource's durable identity. Join those two projections
+    # by URL for one reader-facing References section without duplicating the
+    # versioned plan content in another model.
+    def plan_citation_back_matter(plan, references)
+      references = references.to_a
+      reference_digest = Digest::SHA256.hexdigest(
+        references.map { |reference| "#{reference.id}:#{reference.updated_at&.to_f}" }.join("|")
+      )
+      signature = [ plan.current_revision, reference_digest ]
+      @plan_citation_back_matter ||= {}
+      @plan_citation_back_matter[[ plan.id, signature ]] ||= begin
+        cached = Rails.cache.fetch([
+          "coplan/plan-citation-back-matter",
+          MarkdownHelper::RENDER_CACHE_VERSION,
+          plan.id,
+          *signature
+        ]) do
+          result = build_plan_citation_back_matter(plan, references)
+          [ result[:html].to_s, result[:cited_urls].to_a, result[:count] ]
+        end
+
+        {
+          html: cached[0].html_safe,
+          cited_urls: cached[1].to_set.freeze,
+          count: cached[2]
+        }
+      end
+    end
+
+    def listed_plan_references(references, cited_urls)
+      references.reject do |reference|
+        reference.source == "extracted" && cited_urls.include?(reference.url)
+      end
+    end
+
+    def plan_reference_count(plan, references)
+      back_matter = plan_citation_back_matter(plan, references)
+      back_matter[:count] + listed_plan_references(references, back_matter[:cited_urls]).size
+    end
+
+    private
+
+    def build_plan_citation_back_matter(plan, references)
+      html = render_markdown(plan.current_content, footnotes: :only)
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      sections = doc.css("section[data-footnotes]")
+      return { html: "".html_safe, cited_urls: Set.new.freeze, count: 0 } if sections.empty?
+
+      references_by_url = references.index_by(&:url)
+      cited_urls = Set.new
+
+      sections.each do |section|
+        section["class"] = "reference-citations"
+        section.css(".footnotes-title").remove
+        section.css('a[href^="http://"], a[href^="https://"]').each do |anchor|
+          reference = references_by_url[anchor["href"]]
+          cited_urls << anchor["href"]
+          decorate_citation_source(anchor, reference)
+        end
+      end
+
+      {
+        html: sections.map(&:to_html).join.html_safe,
+        cited_urls: cited_urls.freeze,
+        count: sections.sum { |section| section.xpath("./ol/li").size }
+      }
+    end
+
+    def decorate_citation_source(anchor, reference)
+      type = reference&.reference_type || anchor["data-reference-type"] || Reference.classify_url(anchor["href"])
+      domain = reference_domain(anchor["href"])
+      title = reference&.title.presence || anchor.text.squish.presence || domain || anchor["href"]
+      metadata = [ reference_type_label(type, anchor["href"]), domain ].compact.join(" · ")
+
+      anchor.add_class("citation-source")
+      anchor["aria-label"] = "Open source: #{title} in a new tab (#{metadata})"
+      anchor.children.remove
+
+      icon = Nokogiri::XML::Node.new("span", anchor.document)
+      icon["class"] = "citation-source__icon"
+      icon["aria-hidden"] = "true"
+      icon.content = reference_icon(type)
+
+      content = Nokogiri::XML::Node.new("span", anchor.document)
+      content["class"] = "citation-source__content"
+
+      title_node = Nokogiri::XML::Node.new("span", anchor.document)
+      title_node["class"] = "citation-source__title"
+      title_node.content = title
+
+      metadata_node = Nokogiri::XML::Node.new("span", anchor.document)
+      metadata_node["class"] = "citation-source__meta"
+      metadata_node.content = "#{metadata} ↗"
+
+      content.add_child(title_node)
+      content.add_child(metadata_node)
+      anchor.add_child(icon)
+      anchor.add_child(content)
+
+      punctuation = anchor.next_sibling
+      if punctuation&.text? && punctuation.text.match?(/\A\s*[.,;:]\s*\z/)
+        punctuation.remove
       end
     end
   end

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -146,6 +146,11 @@ export default class extends Controller {
 
     const externalLinks = Array.from(wrapper.querySelectorAll('a[target="_blank"]'))
     externalLinks.forEach(node => {
+      if (node.classList.contains("citation-source")) {
+        node.classList.add("reference-preview__source")
+        return
+      }
+
       const originalText = node.textContent.trim()
       const url = new URL(node.href)
       const domain = url.hostname.replace(/^www\./, "")

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -8,7 +8,7 @@ const SECTION_PREVIEW_LENGTH = 520
 // The target content is already present and sanitized in the plan DOM, so
 // opening a preview is instant and never depends on another request.
 export default class extends Controller {
-  static targets = ["popover", "label", "title", "body", "jump"]
+  static targets = ["popover", "label", "title", "body"]
 
   connect() {
     this.mode = null
@@ -23,7 +23,6 @@ export default class extends Controller {
   enter(event) {
     const anchor = event.currentTarget
     if (!this.targetFor(anchor)) return
-    if (this.mode === "pinned") return
 
     this.cancelOpen()
     this.cancelClose()
@@ -33,17 +32,6 @@ export default class extends Controller {
   leave() {
     this.cancelOpen()
     if (this.mode === "hover") this.scheduleClose()
-  }
-
-  pin(event) {
-    const anchor = event.currentTarget
-    if (!this.targetFor(anchor)) return
-
-    event.preventDefault()
-    this.cancelOpen()
-    this.cancelClose()
-    this.show(anchor, "pinned")
-    if (event.detail === 0) this.jumpTarget.focus({ preventScroll: true })
   }
 
   popoverEnter() {
@@ -71,8 +59,20 @@ export default class extends Controller {
     if (returnFocus && anchor?.isConnected) anchor.focus({ preventScroll: true })
   }
 
-  follow() {
+  // Preserve ordinary hash-link behavior even while dismissing the preview.
+  // Turbo does not consistently navigate same-document fragments after the
+  // hover card changes state during the click, so perform the jump directly.
+  follow(event) {
+    const href = event.currentTarget.getAttribute("href")
+    const target = this.targetFor(event.currentTarget)
+    this.cancelOpen()
+    this.cancelClose()
     this.hide()
+    if (!target || !href?.startsWith("#")) return
+
+    event.preventDefault()
+    window.location.hash = href
+    target.scrollIntoView()
   }
 
   reposition() {
@@ -91,22 +91,13 @@ export default class extends Controller {
 
     const popover = this.popoverTarget
     popover.style.visibility = "hidden"
-    if (!this.isOpen()) {
-      if (typeof popover.showPopover === "function") {
-        try { popover.showPopover() } catch {}
-      } else {
-        popover.classList.add("reference-preview--open")
-      }
-    }
+    popover.classList.add("reference-preview--open")
     this.positionAt(anchor)
     popover.style.visibility = "visible"
   }
 
   hide() {
     if (this.hasPopoverTarget) {
-      if (typeof this.popoverTarget.hidePopover === "function") {
-        try { this.popoverTarget.hidePopover() } catch {}
-      }
       this.popoverTarget.classList.remove("reference-preview--open", "reference-preview--sheet")
       this.popoverTarget.style.visibility = ""
     }
@@ -120,8 +111,6 @@ export default class extends Controller {
     const footnote = anchor.classList.contains("reference-anchor--footnote")
     this.labelTarget.textContent = footnote ? "Citation" : "Internal reference"
     this.titleTarget.textContent = footnote ? `Reference ${anchor.textContent.trim()}` : target.textContent.trim()
-    this.jumpTarget.href = anchor.getAttribute("href")
-    this.jumpTarget.textContent = footnote ? "Go to citation" : "Go to section"
 
     if (footnote) {
       this.renderFootnote(target)
@@ -234,13 +223,6 @@ export default class extends Controller {
   }
 
   isOpen() {
-    if (!this.hasPopoverTarget) return false
-    if (this.popoverTarget.classList.contains("reference-preview--open")) return true
-
-    try {
-      return this.popoverTarget.matches(":popover-open")
-    } catch {
-      return false
-    }
+    return this.hasPopoverTarget && this.popoverTarget.classList.contains("reference-preview--open")
   }
 }

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -91,13 +91,22 @@ export default class extends Controller {
 
     const popover = this.popoverTarget
     popover.style.visibility = "hidden"
-    popover.classList.add("reference-preview--open")
+    if (!this.isOpen()) {
+      if (typeof popover.showPopover === "function") {
+        try { popover.showPopover() } catch {}
+      } else {
+        popover.classList.add("reference-preview--open")
+      }
+    }
     this.positionAt(anchor)
     popover.style.visibility = "visible"
   }
 
   hide() {
     if (this.hasPopoverTarget) {
+      if (typeof this.popoverTarget.hidePopover === "function") {
+        try { this.popoverTarget.hidePopover() } catch {}
+      }
       this.popoverTarget.classList.remove("reference-preview--open", "reference-preview--sheet")
       this.popoverTarget.style.visibility = ""
     }
@@ -223,6 +232,13 @@ export default class extends Controller {
   }
 
   isOpen() {
-    return this.hasPopoverTarget && this.popoverTarget.classList.contains("reference-preview--open")
+    if (!this.hasPopoverTarget) return false
+    if (this.popoverTarget.classList.contains("reference-preview--open")) return true
+
+    try {
+      return this.popoverTarget.matches(":popover-open")
+    } catch {
+      return false
+    }
   }
 }

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -8,7 +8,7 @@ const SECTION_PREVIEW_LENGTH = 520
 // The target content is already present and sanitized in the plan DOM, so
 // opening a preview is instant and never depends on another request.
 export default class extends Controller {
-  static targets = ["popover", "label", "title", "body"]
+  static targets = ["popover", "title", "body"]
 
   connect() {
     this.mode = null
@@ -118,8 +118,10 @@ export default class extends Controller {
 
   renderPreview(anchor, target) {
     const footnote = anchor.classList.contains("reference-anchor--footnote")
-    this.labelTarget.textContent = footnote ? "Citation" : "Internal reference"
-    this.titleTarget.textContent = footnote ? `Reference ${anchor.textContent.trim()}` : target.textContent.trim()
+    const title = target.textContent.trim()
+    this.titleTarget.hidden = footnote
+    this.titleTarget.textContent = footnote ? "" : title
+    this.popoverTarget.setAttribute("aria-label", footnote ? "Citation preview" : `Section preview: ${title}`)
 
     if (footnote) {
       this.renderFootnote(target)
@@ -141,6 +143,13 @@ export default class extends Controller {
     })
     wrapper.querySelectorAll("a[data-footnote-backref]").forEach(node => node.remove())
     wrapper.querySelectorAll('input[type="checkbox"]').forEach(node => node.setAttribute("disabled", ""))
+
+    const externalLinks = Array.from(wrapper.querySelectorAll('a[target="_blank"]'))
+    externalLinks.forEach((node, index) => {
+      const originalText = node.textContent.trim()
+      node.setAttribute("aria-label", `Open external link: ${originalText}`)
+      node.textContent = externalLinks.length > 1 ? `Open external link ${index + 1} ↗` : "Open external link ↗"
+    })
 
     this.bodyTarget.replaceChildren(...Array.from(wrapper.childNodes))
   }

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -153,6 +153,7 @@ export default class extends Controller {
     let node = heading.nextElementSibling
 
     while (node) {
+      if (node.matches("[data-footnotes]")) break
       if (/^H[1-6]$/.test(node.tagName) && Number(node.tagName.slice(1)) <= level) break
 
       const text = node.textContent.replace(/\s+/g, " ").trim()

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -146,7 +146,7 @@ export default class extends Controller {
 
     const externalLinks = Array.from(wrapper.querySelectorAll('a[target="_blank"]'))
     externalLinks.forEach(node => {
-      if (node.classList.contains("citation-source")) {
+      if (node.classList.contains("citation-source--block")) {
         node.classList.add("reference-preview__source")
         return
       }

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -1,0 +1,245 @@
+import { Controller } from "@hotwired/stimulus"
+
+const HOVER_OPEN_DELAY = 180
+const HOVER_CLOSE_DELAY = 220
+const SECTION_PREVIEW_LENGTH = 520
+
+// Previews rendered footnotes and explicitly linked, numbered sections.
+// The target content is already present and sanitized in the plan DOM, so
+// opening a preview is instant and never depends on another request.
+export default class extends Controller {
+  static targets = ["popover", "label", "title", "body", "jump"]
+
+  connect() {
+    this.mode = null
+    this.activeAnchor = null
+  }
+
+  disconnect() {
+    this.cancelOpen()
+    this.cancelClose()
+  }
+
+  enter(event) {
+    const anchor = event.currentTarget
+    if (!this.targetFor(anchor)) return
+    if (this.mode === "pinned") return
+
+    this.cancelOpen()
+    this.cancelClose()
+    this.openTimer = setTimeout(() => this.show(anchor, "hover"), HOVER_OPEN_DELAY)
+  }
+
+  leave() {
+    this.cancelOpen()
+    if (this.mode === "hover") this.scheduleClose()
+  }
+
+  pin(event) {
+    const anchor = event.currentTarget
+    if (!this.targetFor(anchor)) return
+
+    event.preventDefault()
+    this.cancelOpen()
+    this.cancelClose()
+    this.show(anchor, "pinned")
+    if (event.detail === 0) this.jumpTarget.focus({ preventScroll: true })
+  }
+
+  popoverEnter() {
+    this.cancelClose()
+  }
+
+  popoverLeave() {
+    if (this.mode === "hover") this.scheduleClose()
+  }
+
+  dismissFromOutside(event) {
+    if (!this.isOpen()) return
+    if (this.popoverTarget.contains(event.target)) return
+    if (this.activeAnchor?.contains(event.target)) return
+
+    this.dismiss()
+  }
+
+  dismiss(event) {
+    const returnFocus = event?.type === "keydown" || event?.currentTarget?.classList?.contains("reference-preview__close")
+    const anchor = this.activeAnchor
+    this.cancelOpen()
+    this.cancelClose()
+    this.hide()
+    if (returnFocus && anchor?.isConnected) anchor.focus({ preventScroll: true })
+  }
+
+  follow() {
+    this.hide()
+  }
+
+  reposition() {
+    if (this.isOpen() && this.activeAnchor?.isConnected) {
+      this.positionAt(this.activeAnchor)
+    }
+  }
+
+  show(anchor, mode) {
+    const target = this.targetFor(anchor)
+    if (!target) return
+
+    this.renderPreview(anchor, target)
+    this.setActiveAnchor(anchor)
+    this.mode = mode
+
+    const popover = this.popoverTarget
+    popover.style.visibility = "hidden"
+    if (!this.isOpen()) {
+      if (typeof popover.showPopover === "function") {
+        try { popover.showPopover() } catch {}
+      } else {
+        popover.classList.add("reference-preview--open")
+      }
+    }
+    this.positionAt(anchor)
+    popover.style.visibility = "visible"
+  }
+
+  hide() {
+    if (this.hasPopoverTarget) {
+      if (typeof this.popoverTarget.hidePopover === "function") {
+        try { this.popoverTarget.hidePopover() } catch {}
+      }
+      this.popoverTarget.classList.remove("reference-preview--open", "reference-preview--sheet")
+      this.popoverTarget.style.visibility = ""
+    }
+
+    if (this.activeAnchor) this.activeAnchor.setAttribute("aria-expanded", "false")
+    this.activeAnchor = null
+    this.mode = null
+  }
+
+  renderPreview(anchor, target) {
+    const footnote = anchor.classList.contains("reference-anchor--footnote")
+    this.labelTarget.textContent = footnote ? "Citation" : "Internal reference"
+    this.titleTarget.textContent = footnote ? `Reference ${anchor.textContent.trim()}` : target.textContent.trim()
+    this.jumpTarget.href = anchor.getAttribute("href")
+    this.jumpTarget.textContent = footnote ? "Go to citation" : "Go to section"
+
+    if (footnote) {
+      this.renderFootnote(target)
+    } else {
+      this.renderSection(target)
+    }
+  }
+
+  renderFootnote(target) {
+    const fragment = document.createDocumentFragment()
+    Array.from(target.childNodes).forEach(node => fragment.appendChild(node.cloneNode(true)))
+
+    const wrapper = document.createElement("div")
+    wrapper.appendChild(fragment)
+    wrapper.querySelectorAll("[id]").forEach(node => node.removeAttribute("id"))
+    wrapper.querySelectorAll("[data-action], [data-controller]").forEach(node => {
+      node.removeAttribute("data-action")
+      node.removeAttribute("data-controller")
+    })
+    wrapper.querySelectorAll("a[data-footnote-backref]").forEach(node => node.remove())
+    wrapper.querySelectorAll('input[type="checkbox"]').forEach(node => node.setAttribute("disabled", ""))
+
+    this.bodyTarget.replaceChildren(...Array.from(wrapper.childNodes))
+  }
+
+  renderSection(heading) {
+    const level = Number(heading.tagName.slice(1))
+    const parts = []
+    let node = heading.nextElementSibling
+
+    while (node) {
+      if (/^H[1-6]$/.test(node.tagName) && Number(node.tagName.slice(1)) <= level) break
+
+      const text = node.textContent.replace(/\s+/g, " ").trim()
+      if (text) parts.push(text)
+      if (parts.join(" ").length >= SECTION_PREVIEW_LENGTH) break
+      node = node.nextElementSibling
+    }
+
+    let text = parts.join(" ")
+    if (text.length > SECTION_PREVIEW_LENGTH) {
+      text = `${text.slice(0, SECTION_PREVIEW_LENGTH - 1).trimEnd()}…`
+    }
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = text || "This section has no preview text."
+    this.bodyTarget.replaceChildren(paragraph)
+  }
+
+  targetFor(anchor) {
+    const href = anchor?.getAttribute("href")
+    if (!href?.startsWith("#") || href.length === 1) return null
+
+    try {
+      return document.getElementById(decodeURIComponent(href.slice(1)))
+    } catch {
+      return null
+    }
+  }
+
+  setActiveAnchor(anchor) {
+    if (this.activeAnchor && this.activeAnchor !== anchor) {
+      this.activeAnchor.setAttribute("aria-expanded", "false")
+    }
+    this.activeAnchor = anchor
+    anchor.setAttribute("aria-expanded", "true")
+  }
+
+  positionAt(anchor) {
+    const popover = this.popoverTarget
+    if (window.matchMedia("(max-width: 640px)").matches) {
+      popover.classList.add("reference-preview--sheet")
+      popover.style.top = ""
+      popover.style.left = ""
+      return
+    }
+
+    popover.classList.remove("reference-preview--sheet")
+    const anchorRect = anchor.getBoundingClientRect()
+    const popoverRect = popover.getBoundingClientRect()
+    const gap = 8
+
+    let top = anchorRect.bottom + gap
+    let left = anchorRect.left
+    if (top + popoverRect.height > window.innerHeight - 16) {
+      top = anchorRect.top - popoverRect.height - gap
+    }
+    if (left + popoverRect.width > window.innerWidth - 16) {
+      left = window.innerWidth - popoverRect.width - 16
+    }
+
+    popover.style.top = `${Math.max(16, top)}px`
+    popover.style.left = `${Math.max(16, left)}px`
+  }
+
+  scheduleClose() {
+    this.cancelClose()
+    this.closeTimer = setTimeout(() => this.hide(), HOVER_CLOSE_DELAY)
+  }
+
+  cancelOpen() {
+    if (this.openTimer) clearTimeout(this.openTimer)
+    this.openTimer = null
+  }
+
+  cancelClose() {
+    if (this.closeTimer) clearTimeout(this.closeTimer)
+    this.closeTimer = null
+  }
+
+  isOpen() {
+    if (!this.hasPopoverTarget) return false
+    if (this.popoverTarget.classList.contains("reference-preview--open")) return true
+
+    try {
+      return this.popoverTarget.matches(":popover-open")
+    } catch {
+      return false
+    }
+  }
+}

--- a/engine/app/javascript/controllers/coplan/reference_preview_controller.js
+++ b/engine/app/javascript/controllers/coplan/reference_preview_controller.js
@@ -145,13 +145,49 @@ export default class extends Controller {
     wrapper.querySelectorAll('input[type="checkbox"]').forEach(node => node.setAttribute("disabled", ""))
 
     const externalLinks = Array.from(wrapper.querySelectorAll('a[target="_blank"]'))
-    externalLinks.forEach((node, index) => {
+    externalLinks.forEach(node => {
       const originalText = node.textContent.trim()
-      node.setAttribute("aria-label", `Open external link: ${originalText}`)
-      node.textContent = externalLinks.length > 1 ? `Open external link ${index + 1} ↗` : "Open external link ↗"
+      const url = new URL(node.href)
+      const domain = url.hostname.replace(/^www\./, "")
+      const type = this.referenceTypeLabel(node.dataset.referenceType, url)
+
+      const title = document.createElement("span")
+      title.className = "reference-preview__source-title"
+      title.textContent = originalText || domain
+
+      const metadata = document.createElement("span")
+      metadata.className = "reference-preview__source-meta"
+      metadata.textContent = `${type} · ${domain} ↗`
+
+      node.classList.add("reference-preview__source")
+      node.setAttribute("aria-label", `Open source: ${originalText || domain} in a new tab (${type}, ${domain})`)
+      node.replaceChildren(title, metadata)
+
+      const punctuation = node.nextSibling
+      if (punctuation?.nodeType === Node.TEXT_NODE && /^\s*[.,;:]\s*$/.test(punctuation.textContent)) punctuation.remove()
     })
 
     this.bodyTarget.replaceChildren(...Array.from(wrapper.childNodes))
+  }
+
+  referenceTypeLabel(referenceType, url) {
+    if (referenceType === "plan") return "CoPlan plan"
+    if (referenceType === "repository") return "GitHub repository"
+    if (referenceType === "pull_request") return "GitHub pull request"
+
+    if (referenceType === "document") {
+      if (url.hostname === "docs.google.com") {
+        if (url.pathname.startsWith("/spreadsheets/")) return "Google Sheet"
+        if (url.pathname.startsWith("/presentation/")) return "Google Slides"
+        return "Google Doc"
+      }
+      if (url.hostname === "drive.google.com") return "Google Drive"
+      if (url.hostname.endsWith("notion.so") || url.hostname.endsWith("notion.site")) return "Notion"
+      if (url.hostname.includes("confluence")) return "Confluence"
+      return "Document"
+    }
+
+    return /(^|\.)gov(\.|$)/.test(url.hostname) ? "Government website" : "Website"
   }
 
   renderSection(heading) {

--- a/engine/app/models/coplan/plan_version.rb
+++ b/engine/app/models/coplan/plan_version.rb
@@ -31,6 +31,7 @@ module CoPlan
 
     def extract_references
       CoPlan::References::ExtractFromContent.call(plan: plan, content: content_markdown)
+      Broadcaster.replace_plan_references(plan)
     end
 
     def broadcast_history_update

--- a/engine/app/models/coplan/plan_version.rb
+++ b/engine/app/models/coplan/plan_version.rb
@@ -31,7 +31,6 @@ module CoPlan
 
     def extract_references
       CoPlan::References::ExtractFromContent.call(plan: plan, content: content_markdown)
-      broadcast_references_update
     end
 
     def broadcast_history_update
@@ -46,21 +45,6 @@ module CoPlan
         plan,
         target: "history-count",
         html: ApplicationController.helpers.content_tag(:span, ApplicationController.helpers.pluralize(count, "entry"), class: "section-count", id: "history-count")
-      )
-    end
-
-    def broadcast_references_update
-      references = plan.references.reload.order(reference_type: :asc, created_at: :desc)
-      Broadcaster.replace_to(
-        plan,
-        target: "plan-references",
-        partial: "coplan/plans/references",
-        locals: { references: references, plan: plan }
-      )
-      Broadcaster.replace_to(
-        plan,
-        target: "references-count",
-        html: ApplicationController.helpers.content_tag(:span, references.size, class: "section-count", id: "references-count")
       )
     end
 

--- a/engine/app/services/coplan/broadcaster.rb
+++ b/engine/app/services/coplan/broadcaster.rb
@@ -50,6 +50,19 @@ module CoPlan
       # banner (dirty draft in progress).
       def replace_plan_content(plan)
         html = render(partial: "coplan/plans/content_body", locals: { plan: plan })
+        custom_action_to(
+          plan,
+          action: "coplan-replace-if-clean",
+          target: "plan-content-body",
+          html: html,
+          attrs: { "data-revision" => plan.current_revision }
+        )
+      end
+
+      # Reference extraction runs after the version transaction commits. Build
+      # and broadcast this projection only then, so open readers receive the
+      # newly extracted resources rather than the previous revision's list.
+      def replace_plan_references(plan)
         references = plan.references.order(reference_type: :asc, created_at: :desc)
         back_matter = CoPlan::ApplicationController.helpers.plan_citation_back_matter(plan, references)
         listed_references = CoPlan::ApplicationController.helpers.listed_plan_references(references, back_matter[:cited_urls])
@@ -58,13 +71,6 @@ module CoPlan
         extracted_html = render(
           partial: "coplan/plans/reference_list",
           locals: { references: extracted_references, plan: plan, allow_removal: false }
-        )
-        custom_action_to(
-          plan,
-          action: "coplan-replace-if-clean",
-          target: "plan-content-body",
-          html: html,
-          attrs: { "data-revision" => plan.current_revision }
         )
         custom_action_to(
           plan,

--- a/engine/app/services/coplan/broadcaster.rb
+++ b/engine/app/services/coplan/broadcaster.rb
@@ -50,6 +50,15 @@ module CoPlan
       # banner (dirty draft in progress).
       def replace_plan_content(plan)
         html = render(partial: "coplan/plans/content_body", locals: { plan: plan })
+        references = plan.references.order(reference_type: :asc, created_at: :desc)
+        back_matter = CoPlan::ApplicationController.helpers.plan_citation_back_matter(plan, references)
+        listed_references = CoPlan::ApplicationController.helpers.listed_plan_references(references, back_matter[:cited_urls])
+        extracted_references = listed_references.select { |reference| reference.source == "extracted" }
+        reference_count = back_matter[:count] + listed_references.size
+        extracted_html = render(
+          partial: "coplan/plans/reference_list",
+          locals: { references: extracted_references, plan: plan, allow_removal: false }
+        )
         custom_action_to(
           plan,
           action: "coplan-replace-if-clean",
@@ -57,6 +66,29 @@ module CoPlan
           html: html,
           attrs: { "data-revision" => plan.current_revision }
         )
+        custom_action_to(
+          plan,
+          action: "coplan-replace-if-clean",
+          target: "plan-citations",
+          html: back_matter[:html],
+          attrs: { "data-revision" => plan.current_revision }
+        )
+        custom_action_to(
+          plan,
+          action: "coplan-replace-if-clean",
+          target: "plan-extracted-references",
+          html: extracted_html,
+          attrs: { "data-revision" => plan.current_revision }
+        )
+        [ "references-count", "nav-references-count" ].each do |target|
+          custom_action_to(
+            plan,
+            action: "coplan-replace-if-clean",
+            target: target,
+            html: reference_count,
+            attrs: { "data-revision" => plan.current_revision }
+          )
+        end
       end
 
       private

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -91,7 +91,7 @@ Unrecognized tags render as plain text, so never invent one — use `plaintext` 
 
 Beyond standard Markdown (tables, task lists, strikethrough), plans support:
 
-- **Footnotes** — `Some claim.[^queue-depth]` with `[^queue-depth]: Supporting detail and a [durable source](https://example.com/source).` anywhere in the document. Rendered as numbered citation anchors with a footnote section at the bottom. Readers can hover or click the anchor to preview the full note without losing their place.
+- **Footnotes** — `Some claim.[^queue-depth]` with `[^queue-depth]: Supporting detail and a [durable source](https://example.com/source).` anywhere in the document. Rendered as numbered citation anchors with a footnote section at the bottom. Readers can hover or focus the anchor to preview the full note, then click to jump to it.
 - **Collapsible sections** — `<details><summary>Title shown when collapsed</summary>` … `</details>`. Use for long appendices, raw logs, or optional deep-dives so the document stays scannable. Add `open` to the `<details>` tag to render expanded by default. Leave a blank line after `<summary>…</summary>` so Markdown inside the section still renders.
 - **Hover definitions** — `<abbr title="Definition shown on hover">TERM</abbr>`. Use for acronyms and project-specific jargon so readers outside the team can follow along.
 
@@ -101,8 +101,8 @@ Other raw HTML is stripped on render (the Markdown source is preserved), so stic
 
 CoPlan has three related tools with different jobs:
 
-1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/click, and its URL is also auto-extracted into the plan's structured References inventory.
-2. **Reference another section in the same plan with an explicit Markdown link.** Number the target heading, then link its stable fragment: a heading `### 3.1 Rollout` is referenced as `see [§3.1](#section-3-1)`. The link previews that section on hover/click. Never leave a bare `§3.1` when you mean an internal link—section signs are also used for external statutes, so CoPlan deliberately does not guess.
+1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/focus and jumps to the note when clicked; its URL is also auto-extracted into the plan's structured References inventory.
+2. **Reference another section in the same plan with an explicit Markdown link.** Number the target heading, then link its stable fragment: a heading `### 3.1 Rollout` is referenced as `see [§3.1](#section-3-1)`. Hover/focus previews that section and click jumps to it. Never leave a bare `§3.1` when you mean an internal link—section signs are also used for external statutes, so CoPlan deliberately does not guess.
 3. **Mention an external resource directly with a normal descriptive link**, such as `[implementation PR](https://github.com/org/repo/pull/42)`. Prefer a footnote instead when the link supports a specific factual claim.
 
 Use descriptive link text and durable URLs. Avoid bare URLs in prose. Footnote names are author-facing identifiers, so prefer stable semantic names (`[^queue-depth]`) over renumbering a long document by hand.
@@ -227,9 +227,9 @@ No plan types are currently configured.
 
 ### References
 
-References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery and the References back matter; they are not a substitute for placing a citation or link at the claim it supports. **Always add references** when your plan mentions GitHub repos, PRs, design docs, or other plans — they make plans discoverable and show the connective tissue between work.
+References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery; they are not a substitute for placing a citation or link at the claim it supports. Auto-extracted links stay behind the scenes rather than repeating the document's citations. Explicit references that are not linked in the prose appear to readers as **Related resources**.
 
-Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. You can also add explicit references via the API for relevant resources that are not linked in the prose.
+Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. Do not add them again. Add explicit references via the API only for relevant resources that are not linked in the prose.
 
 **Add references on create or update:**
 

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -91,11 +91,21 @@ Unrecognized tags render as plain text, so never invent one — use `plaintext` 
 
 Beyond standard Markdown (tables, task lists, strikethrough), plans support:
 
-- **Footnotes** — `Some claim.[^1]` with `[^1]: Supporting detail or citation.` anywhere in the document. Rendered as numbered superscript links with a footnote section at the bottom. Use these for caveats, citations, and asides that would clutter the main text.
+- **Footnotes** — `Some claim.[^queue-depth]` with `[^queue-depth]: Supporting detail and a [durable source](https://example.com/source).` anywhere in the document. Rendered as numbered citation anchors with a footnote section at the bottom. Readers can hover or click the anchor to preview the full note without losing their place.
 - **Collapsible sections** — `<details><summary>Title shown when collapsed</summary>` … `</details>`. Use for long appendices, raw logs, or optional deep-dives so the document stays scannable. Add `open` to the `<details>` tag to render expanded by default. Leave a blank line after `<summary>…</summary>` so Markdown inside the section still renders.
 - **Hover definitions** — `<abbr title="Definition shown on hover">TERM</abbr>`. Use for acronyms and project-specific jargon so readers outside the team can follow along.
 
 Other raw HTML is stripped on render (the Markdown source is preserved), so stick to these plus standard Markdown.
+
+#### Citations and internal cross-references
+
+CoPlan has three related tools with different jobs:
+
+1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/click, and its URL is also auto-extracted into the plan's structured References inventory.
+2. **Reference another section in the same plan with an explicit Markdown link.** Number the target heading, then link its stable fragment: a heading `### 3.1 Rollout` is referenced as `see [§3.1](#section-3-1)`. The link previews that section on hover/click. Never leave a bare `§3.1` when you mean an internal link—section signs are also used for external statutes, so CoPlan deliberately does not guess.
+3. **Mention an external resource directly with a normal descriptive link**, such as `[implementation PR](https://github.com/org/repo/pull/42)`. Prefer a footnote instead when the link supports a specific factual claim.
+
+Use descriptive link text and durable URLs. Avoid bare URLs in prose. Footnote names are author-facing identifiers, so prefer stable semantic names (`[^queue-depth]`) over renumbering a long document by hand.
 
 ### Update Plan
 
@@ -217,9 +227,9 @@ No plan types are currently configured.
 
 ### References
 
-References connect plans to external resources (repos, PRs, docs) and to other plans. **Always add references** when your plan mentions GitHub repos, PRs, design docs, or other plans — they make plans discoverable and show the connective tissue between work.
+References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery and the References back matter; they are not a substitute for placing a citation or link at the claim it supports. **Always add references** when your plan mentions GitHub repos, PRs, design docs, or other plans — they make plans discoverable and show the connective tissue between work.
 
-Links in plan content are **auto-extracted** as references. You can also add explicit references via the API.
+Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. You can also add explicit references via the API for relevant resources that are not linked in the prose.
 
 **Add references on create or update:**
 

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -101,7 +101,7 @@ Other raw HTML is stripped on render (the Markdown source is preserved), so stic
 
 CoPlan has three related tools with different jobs:
 
-1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/focus; clicking it jumps to the note. Its URL is auto-extracted into the structured References inventory, which supplies the source type, domain, and icon shown with the citation.
+1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/focus; clicking it jumps to the note. Its URL is auto-extracted into the structured References inventory, which supplies the source title, type, and domain shown with the citation.
 2. **Reference another section in the same plan with an explicit Markdown link.** Number the target heading, then link its stable fragment: a heading `### 3.1 Rollout` is referenced as `see [§3.1](#section-3-1)`. Hover/focus previews that section and click jumps to it. Never leave a bare `§3.1` when you mean an internal link—section signs are also used for external statutes, so CoPlan deliberately does not guess.
 3. **Mention an external resource directly with a normal descriptive link**, such as `[implementation PR](https://github.com/org/repo/pull/42)`. Prefer a footnote instead when the link supports a specific factual claim.
 
@@ -227,7 +227,7 @@ No plan types are currently configured.
 
 ### References
 
-References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery and enrich reader-facing citations with the resource's title, type, domain, and icon; they are not a substitute for placing a citation or link at the claim it supports. Readers see citation context and all remaining linked or explicitly curated resources together in one **References** section.
+References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery and enrich reader-facing citations with the resource's title, type, and domain; they are not a substitute for placing a citation or link at the claim it supports. Readers see citation context and all remaining linked or explicitly curated resources together in one **References** section.
 
 Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. Do not add them again. Add explicit references via the API only for relevant resources that are not linked in the prose.
 

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -227,7 +227,7 @@ No plan types are currently configured.
 
 ### References
 
-References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery; they are not a substitute for placing a citation or link at the claim it supports. Auto-extracted links stay behind the scenes rather than repeating the document's citations. Explicit references that are not linked in the prose appear to readers as **Related resources**.
+References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery; they are not a substitute for placing a citation or link at the claim it supports. Auto-extracted links stay behind the scenes rather than repeating the document's citations. Explicit references that are not linked in the prose appear to readers as **Additional resources**.
 
 Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. Do not add them again. Add explicit references via the API only for relevant resources that are not linked in the prose.
 

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -91,7 +91,7 @@ Unrecognized tags render as plain text, so never invent one — use `plaintext` 
 
 Beyond standard Markdown (tables, task lists, strikethrough), plans support:
 
-- **Footnotes** — `Some claim.[^queue-depth]` with `[^queue-depth]: Supporting detail and a [durable source](https://example.com/source).` anywhere in the document. Rendered as numbered citation anchors with a footnote section at the bottom. Readers can hover or focus the anchor to preview the full note, then click to jump to it.
+- **Footnotes** — `Some claim.[^queue-depth]` with `[^queue-depth]: Supporting detail and a [durable source](https://example.com/source).` anywhere in the document. Rendered as numbered citation anchors with the supporting note and source identity in the plan's References section. Readers can hover or focus the anchor to preview the full note, then click to jump to it.
 - **Collapsible sections** — `<details><summary>Title shown when collapsed</summary>` … `</details>`. Use for long appendices, raw logs, or optional deep-dives so the document stays scannable. Add `open` to the `<details>` tag to render expanded by default. Leave a blank line after `<summary>…</summary>` so Markdown inside the section still renders.
 - **Hover definitions** — `<abbr title="Definition shown on hover">TERM</abbr>`. Use for acronyms and project-specific jargon so readers outside the team can follow along.
 
@@ -101,7 +101,7 @@ Other raw HTML is stripped on render (the Markdown source is preserved), so stic
 
 CoPlan has three related tools with different jobs:
 
-1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/focus and jumps to the note when clicked; its URL is also auto-extracted into the plan's structured References inventory.
+1. **Cite an external source for a claim with a footnote.** Put the source link and enough supporting context in the definition. The inline citation previews on hover/focus; clicking it jumps to the note. Its URL is auto-extracted into the structured References inventory, which supplies the source type, domain, and icon shown with the citation.
 2. **Reference another section in the same plan with an explicit Markdown link.** Number the target heading, then link its stable fragment: a heading `### 3.1 Rollout` is referenced as `see [§3.1](#section-3-1)`. Hover/focus previews that section and click jumps to it. Never leave a bare `§3.1` when you mean an internal link—section signs are also used for external statutes, so CoPlan deliberately does not guess.
 3. **Mention an external resource directly with a normal descriptive link**, such as `[implementation PR](https://github.com/org/repo/pull/42)`. Prefer a footnote instead when the link supports a specific factual claim.
 
@@ -227,7 +227,7 @@ No plan types are currently configured.
 
 ### References
 
-References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery; they are not a substitute for placing a citation or link at the claim it supports. Auto-extracted links stay behind the scenes rather than repeating the document's citations. Explicit references that are not linked in the prose appear to readers as **Additional resources**.
+References are the structured, document-level inventory of resources connected to a plan (repos, PRs, docs, links, and other plans). They power discovery and enrich reader-facing citations with the resource's title, type, domain, and icon; they are not a substitute for placing a citation or link at the claim it supports. Readers see citation context and all remaining linked or explicitly curated resources together in one **References** section.
 
 Links anywhere in plan content—including links inside footnote definitions—are **auto-extracted** as references. Do not add them again. Add explicit references via the API only for relevant resources that are not linked in the prose.
 

--- a/engine/app/views/coplan/plans/_citations.html.erb
+++ b/engine/app/views/coplan/plans/_citations.html.erb
@@ -1,0 +1,4 @@
+<div id="plan-citations"
+     data-coplan--live-update-revision-value="<%= plan.current_revision %>">
+  <%= back_matter[:html] %>
+</div>

--- a/engine/app/views/coplan/plans/_content_body.html.erb
+++ b/engine/app/views/coplan/plans/_content_body.html.erb
@@ -8,5 +8,5 @@
     on write paths; the explicit RENDER_CACHE_VERSION key handles renderer
     changes instead. -%>
 <% cache ["coplan/plan-content-body", CoPlan::MarkdownHelper::RENDER_CACHE_VERSION, plan.id, plan.current_plan_version&.content_sha256 || plan.current_revision], skip_digest: true do %>
-  <%= render_markdown(plan.current_content) %>
+  <%= render_markdown(plan.current_content, footnotes: :exclude) %>
 <% end %>

--- a/engine/app/views/coplan/plans/_footnotes.html.erb
+++ b/engine/app/views/coplan/plans/_footnotes.html.erb
@@ -7,11 +7,11 @@
   <section class="plan-footnote" id="footnote-references" data-plan-section="references" aria-labelledby="footnote-references-title">
     <div class="plan-footnote__header">
       <% if current_user && allowed_to?(plan, :contribute?) %>
-        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a related resource" aria-label="Add a related resource">
+        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add an additional resource" aria-label="Add an additional resource">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
         </button>
       <% end %>
-      <h2 class="plan-footnote__title" id="footnote-references-title">Related resources</h2>
+      <h2 class="plan-footnote__title" id="footnote-references-title">Additional resources</h2>
       <span class="section-count" id="references-count"><%= references.size %></span>
     </div>
     <%= render partial: "coplan/plans/references", locals: { references: references, plan: plan } %>

--- a/engine/app/views/coplan/plans/_footnotes.html.erb
+++ b/engine/app/views/coplan/plans/_footnotes.html.erb
@@ -7,11 +7,11 @@
   <section class="plan-footnote" id="footnote-references" data-plan-section="references" aria-labelledby="footnote-references-title">
     <div class="plan-footnote__header">
       <% if current_user && allowed_to?(plan, :contribute?) %>
-        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a reference" aria-label="Add a reference">
+        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a related resource" aria-label="Add a related resource">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
         </button>
       <% end %>
-      <h2 class="plan-footnote__title" id="footnote-references-title">References</h2>
+      <h2 class="plan-footnote__title" id="footnote-references-title">Related resources</h2>
       <span class="section-count" id="references-count"><%= references.size %></span>
     </div>
     <%= render partial: "coplan/plans/references", locals: { references: references, plan: plan } %>

--- a/engine/app/views/coplan/plans/_footnotes.html.erb
+++ b/engine/app/views/coplan/plans/_footnotes.html.erb
@@ -5,16 +5,23 @@
     line tall. %>
 <div class="plan-footnotes">
   <section class="plan-footnote" id="footnote-references" data-plan-section="references" aria-labelledby="footnote-references-title">
+    <% back_matter = plan_citation_back_matter(plan, references) %>
+    <% listed_references = listed_plan_references(references, back_matter[:cited_urls]) %>
     <div class="plan-footnote__header">
       <% if current_user && allowed_to?(plan, :contribute?) %>
-        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add an additional resource" aria-label="Add an additional resource">
+        <button type="button" class="section-add" popovertarget="add-reference-modal" title="Add a reference" aria-label="Add a reference">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
         </button>
       <% end %>
-      <h2 class="plan-footnote__title" id="footnote-references-title">Additional resources</h2>
-      <span class="section-count" id="references-count"><%= references.size %></span>
+      <h2 class="plan-footnote__title" id="footnote-references-title">References</h2>
+      <span class="section-count" id="references-count"><%= back_matter[:count] + listed_references.size %></span>
     </div>
-    <%= render partial: "coplan/plans/references", locals: { references: references, plan: plan } %>
+    <%= render partial: "coplan/plans/citations", locals: { plan: plan, back_matter: back_matter } %>
+    <%= render partial: "coplan/plans/references", locals: {
+          references: listed_references,
+          plan: plan,
+          has_citations: back_matter[:count].positive?
+        } %>
   </section>
 
   <section class="plan-footnote" id="footnote-attachments" data-plan-section="attachments" aria-labelledby="footnote-attachments-title">

--- a/engine/app/views/coplan/plans/_reference_list.html.erb
+++ b/engine/app/views/coplan/plans/_reference_list.html.erb
@@ -2,15 +2,11 @@
   <ul class="references-list">
     <% references.each do |ref| %>
       <li class="references-list__item">
-        <span class="references-list__icon" aria-hidden="true"><%= reference_icon(ref.reference_type) %></span>
         <div class="references-list__content">
           <a href="<%= ref.url %>" target="_blank" rel="noopener noreferrer" class="references-list__link">
             <%= ref.title.presence || truncate(ref.url, length: 80) %>
           </a>
           <span class="references-list__meta">
-            <% if ref.key.present? %>
-              <code class="badge badge--ref-key"><%= ref.key %></code>
-            <% end %>
             <span><%= reference_type_label(ref.reference_type, ref.url) %></span>
             <% if reference_domain(ref.url).present? %>
               <span aria-hidden="true">·</span>

--- a/engine/app/views/coplan/plans/_reference_list.html.erb
+++ b/engine/app/views/coplan/plans/_reference_list.html.erb
@@ -1,0 +1,27 @@
+<% if references.any? %>
+  <ul class="references-list">
+    <% references.each do |ref| %>
+      <li class="references-list__item">
+        <span class="references-list__icon" aria-hidden="true"><%= reference_icon(ref.reference_type) %></span>
+        <div class="references-list__content">
+          <a href="<%= ref.url %>" target="_blank" rel="noopener noreferrer" class="references-list__link">
+            <%= ref.title.presence || truncate(ref.url, length: 80) %>
+          </a>
+          <span class="references-list__meta">
+            <% if ref.key.present? %>
+              <code class="badge badge--ref-key"><%= ref.key %></code>
+            <% end %>
+            <span><%= reference_type_label(ref.reference_type, ref.url) %></span>
+            <% if reference_domain(ref.url).present? %>
+              <span aria-hidden="true">·</span>
+              <span><%= reference_domain(ref.url) %> ↗</span>
+            <% end %>
+          </span>
+        </div>
+        <% if allow_removal && current_user && CoPlan::PlanPolicy.new(current_user, plan).update? %>
+          <%= button_to "✕", plan_reference_path(plan, ref), method: :delete, class: "references-list__remove", title: "Remove reference", data: { turbo_confirm: "Remove this reference?", turbo_stream: true } %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/engine/app/views/coplan/plans/_references.html.erb
+++ b/engine/app/views/coplan/plans/_references.html.erb
@@ -4,7 +4,7 @@
       create action replaces this container via turbo_stream, which closes
       the lightbox the moment the reference lands. %>
   <% if current_user %>
-    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add a reference" } do %>
+    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add a related resource" } do %>
       <%= form_with url: plan_references_path(plan), method: :post, class: "add-modal__form" do |f| %>
         <div class="form-group">
           <%= f.label :url, "URL", for: "reference_url" %>
@@ -21,7 +21,7 @@
           <%= f.text_field :key, id: "reference_key", placeholder: "Optional — e.g. auth-repo", name: "reference[key]" %>
         </div>
         <div class="add-modal__actions">
-          <%= f.submit "Add reference", class: "btn btn--primary btn--sm" %>
+          <%= f.submit "Add resource", class: "btn btn--primary btn--sm" %>
         </div>
       <% end %>
     <% end %>
@@ -42,9 +42,6 @@
                   <code class="badge badge--ref-key"><%= ref.key %></code>
                 <% end %>
                 <span class="badge badge--ref-type"><%= type.humanize %></span>
-                <% if ref.source == "extracted" %>
-                  <span class="references-list__source">auto-extracted</span>
-                <% end %>
               </span>
             </div>
             <% if ref.source == "explicit" && current_user && CoPlan::PlanPolicy.new(current_user, plan).update? %>
@@ -56,6 +53,6 @@
     </ul>
   <% else %>
     <%# One quiet line, not a padded card — empty is the common case. %>
-    <p class="plan-footnote__empty">None yet — links in the document are picked up automatically.</p>
+    <p class="plan-footnote__empty">None added.</p>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/_references.html.erb
+++ b/engine/app/views/coplan/plans/_references.html.erb
@@ -4,7 +4,7 @@
       create action replaces this container via turbo_stream, which closes
       the lightbox the moment the reference lands. %>
   <% if current_user %>
-    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add an additional resource" } do %>
+    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add a reference" } do %>
       <%= form_with url: plan_references_path(plan), method: :post, class: "add-modal__form" do |f| %>
         <div class="form-group">
           <%= f.label :url, "URL", for: "reference_url" %>
@@ -21,38 +21,31 @@
           <%= f.text_field :key, id: "reference_key", placeholder: "Optional — e.g. auth-repo", name: "reference[key]" %>
         </div>
         <div class="add-modal__actions">
-          <%= f.submit "Add resource", class: "btn btn--primary btn--sm" %>
+          <%= f.submit "Add reference", class: "btn btn--primary btn--sm" %>
         </div>
       <% end %>
     <% end %>
   <% end %>
 
-  <% if references.any? %>
-    <ul class="references-list">
-      <% references.group_by(&:reference_type).each do |type, refs| %>
-        <% refs.each do |ref| %>
-          <li class="references-list__item">
-            <span class="references-list__icon"><%= reference_icon(type) %></span>
-            <div class="references-list__content">
-              <a href="<%= ref.url %>" target="_blank" rel="noopener" class="references-list__link">
-                <%= ref.title.presence || truncate(ref.url, length: 80) %>
-              </a>
-              <span class="references-list__meta">
-                <% if ref.key.present? %>
-                  <code class="badge badge--ref-key"><%= ref.key %></code>
-                <% end %>
-                <span class="badge badge--ref-type"><%= type.humanize %></span>
-              </span>
-            </div>
-            <% if ref.source == "explicit" && current_user && CoPlan::PlanPolicy.new(current_user, plan).update? %>
-              <%= button_to "✕", plan_reference_path(plan, ref), method: :delete, class: "references-list__remove", title: "Remove reference", data: { turbo_confirm: "Remove this reference?", turbo_stream: true } %>
-            <% end %>
-          </li>
-        <% end %>
-      <% end %>
-    </ul>
-  <% else %>
+  <% extracted_references, explicit_references = references.partition { |reference| reference.source == "extracted" } %>
+  <div id="plan-extracted-references"
+       data-coplan--live-update-revision-value="<%= plan.current_revision %>">
+    <%= render partial: "coplan/plans/reference_list", locals: {
+          references: extracted_references,
+          plan: plan,
+          allow_removal: false
+        } %>
+  </div>
+  <div id="plan-explicit-references">
+    <%= render partial: "coplan/plans/reference_list", locals: {
+          references: explicit_references,
+          plan: plan,
+          allow_removal: true
+        } %>
+  </div>
+
+  <% if references.empty? && !has_citations %>
     <%# One quiet line, not a padded card — empty is the common case. %>
-    <p class="plan-footnote__empty">No additional resources.</p>
+    <p class="plan-footnote__empty">No references yet.</p>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/_references.html.erb
+++ b/engine/app/views/coplan/plans/_references.html.erb
@@ -4,7 +4,7 @@
       create action replaces this container via turbo_stream, which closes
       the lightbox the moment the reference lands. %>
   <% if current_user %>
-    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add a related resource" } do %>
+    <%= render layout: "coplan/shared/add_modal", locals: { id: "add-reference-modal", title: "Add an additional resource" } do %>
       <%= form_with url: plan_references_path(plan), method: :post, class: "add-modal__form" do |f| %>
         <div class="form-group">
           <%= f.label :url, "URL", for: "reference_url" %>
@@ -53,6 +53,6 @@
     </ul>
   <% else %>
     <%# One quiet line, not a padded card — empty is the common case. %>
-    <p class="plan-footnote__empty">None added.</p>
+    <p class="plan-footnote__empty">No additional resources.</p>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -102,13 +102,9 @@
                class="reference-preview"
                popover="manual"
                role="dialog"
-               aria-labelledby="reference-preview-title"
                data-coplan--reference-preview-target="popover"
                data-action="mouseenter->coplan--reference-preview#popoverEnter mouseleave->coplan--reference-preview#popoverLeave">
-          <div class="reference-preview__header">
-            <span class="reference-preview__label" data-coplan--reference-preview-target="label"></span>
-            <button type="button" class="reference-preview__close" aria-label="Close reference preview" data-action="coplan--reference-preview#dismiss">×</button>
-          </div>
+          <button type="button" class="reference-preview__close" aria-label="Close reference preview" data-action="coplan--reference-preview#dismiss">×</button>
           <strong id="reference-preview-title" class="reference-preview__title" data-coplan--reference-preview-target="title"></strong>
           <div class="reference-preview__body" data-coplan--reference-preview-target="body"></div>
         </aside>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -60,7 +60,7 @@
         <ul class="content-nav__list content-nav__list--footnotes">
           <%# ids: the reference/attachment Turbo Streams keep these counts
               live alongside the footnote headers' own counters. %>
-          <li><a href="#footnote-references" class="content-nav__footnote-link">Resources <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
+          <li><a href="#footnote-references" class="content-nav__footnote-link">Additional <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
           <li><a href="#footnote-attachments" class="content-nav__footnote-link">Attachments <span class="section-count" id="nav-attachments-count"><%= @attachments.size %></span></a></li>
         </ul>
       </nav>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -47,7 +47,7 @@
 
 <div class="plan-document card">
   <% if @plan.current_content.present? %>
-    <div class="plan-layout" data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections" data-coplan--text-selection-focus-thread-value="<%= params[:thread] %>" data-action="keydown.esc@document->coplan--text-selection#dismiss coplan:open-thread@document->coplan--text-selection#openThread" data-coplan--checkbox-revision-value="<%= @plan.current_revision %>" data-coplan--checkbox-toggle-url-value="<%= toggle_checkbox_plan_path(@plan) %>" data-coplan--changed-sections-keys-value="<%= @changed_section_keys.to_json %>">
+    <div class="plan-layout" data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections coplan--reference-preview" data-coplan--text-selection-focus-thread-value="<%= params[:thread] %>" data-action="keydown.esc@document->coplan--text-selection#dismiss keydown.esc@document->coplan--reference-preview#dismiss click@document->coplan--reference-preview#dismissFromOutside scroll@window->coplan--reference-preview#reposition resize@window->coplan--reference-preview#reposition coplan:open-thread@document->coplan--text-selection#openThread" data-coplan--checkbox-revision-value="<%= @plan.current_revision %>" data-coplan--checkbox-toggle-url-value="<%= toggle_checkbox_plan_path(@plan) %>" data-coplan--changed-sections-keys-value="<%= @changed_section_keys.to_json %>">
       <nav class="content-nav" data-coplan--content-nav-target="sidebar" aria-label="Document outline">
         <%# No "Contents" label — the outline speaks for itself, and the plan
             title now lives in the sticky nav. Just the collapse control. %>
@@ -93,6 +93,26 @@
 
         <%= render partial: "coplan/plans/footnotes",
               locals: { plan: @plan, references: @references, attachments: @attachments } %>
+
+        <%# Footnote citations and explicit same-document section links share
+            one native popover. Its body is filled instantly from the rendered
+            target already on the page; the footer preserves normal jump-to-
+            target navigation for readers who want the full context. %>
+        <aside id="reference-preview"
+               class="reference-preview"
+               popover="manual"
+               role="dialog"
+               aria-labelledby="reference-preview-title"
+               data-coplan--reference-preview-target="popover"
+               data-action="mouseenter->coplan--reference-preview#popoverEnter mouseleave->coplan--reference-preview#popoverLeave">
+          <div class="reference-preview__header">
+            <span class="reference-preview__label" data-coplan--reference-preview-target="label"></span>
+            <button type="button" class="reference-preview__close" aria-label="Close reference preview" data-action="coplan--reference-preview#dismiss">×</button>
+          </div>
+          <strong id="reference-preview-title" class="reference-preview__title" data-coplan--reference-preview-target="title"></strong>
+          <div class="reference-preview__body" data-coplan--reference-preview-target="body"></div>
+          <a class="reference-preview__jump" data-coplan--reference-preview-target="jump" data-action="coplan--reference-preview#follow"></a>
+        </aside>
       </div>
 
       <div id="plan-threads" data-coplan--text-selection-target="threads"

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -60,7 +60,7 @@
         <ul class="content-nav__list content-nav__list--footnotes">
           <%# ids: the reference/attachment Turbo Streams keep these counts
               live alongside the footnote headers' own counters. %>
-          <li><a href="#footnote-references" class="content-nav__footnote-link">References <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
+          <li><a href="#footnote-references" class="content-nav__footnote-link">Resources <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
           <li><a href="#footnote-attachments" class="content-nav__footnote-link">Attachments <span class="section-count" id="nav-attachments-count"><%= @attachments.size %></span></a></li>
         </ul>
       </nav>
@@ -96,11 +96,10 @@
 
         <%# Footnote citations and explicit same-document section links share
             one native popover. Its body is filled instantly from the rendered
-            target already on the page; the footer preserves normal jump-to-
-            target navigation for readers who want the full context. %>
+            target already on the page. Hover/focus previews it; clicking the
+            original anchor keeps the link's native jump behavior. %>
         <aside id="reference-preview"
                class="reference-preview"
-               popover="manual"
                role="dialog"
                aria-labelledby="reference-preview-title"
                data-coplan--reference-preview-target="popover"
@@ -111,7 +110,6 @@
           </div>
           <strong id="reference-preview-title" class="reference-preview__title" data-coplan--reference-preview-target="title"></strong>
           <div class="reference-preview__body" data-coplan--reference-preview-target="body"></div>
-          <a class="reference-preview__jump" data-coplan--reference-preview-target="jump" data-action="coplan--reference-preview#follow"></a>
         </aside>
       </div>
 

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -97,9 +97,10 @@
         <%# Footnote citations and explicit same-document section links share
             one native popover. Its body is filled instantly from the rendered
             target already on the page. Hover/focus previews it; clicking the
-            original anchor keeps the link's native jump behavior. %>
+            original anchor jumps directly to the referenced target. %>
         <aside id="reference-preview"
                class="reference-preview"
+               popover="manual"
                role="dialog"
                aria-labelledby="reference-preview-title"
                data-coplan--reference-preview-target="popover"

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -22,6 +22,7 @@
 <%= turbo_stream_from @plan %>
 
 <% my_placement = current_user && @shelf_placements.find { |p| p.library.writable_by?(current_user) } %>
+<% reference_count = plan_reference_count(@plan, @references) %>
 
 <%# plan-keys: Backspace goes back to wherever you came from; [ / ] jump
     between the document and its footnote sections. Cold opens (direct link,
@@ -60,7 +61,7 @@
         <ul class="content-nav__list content-nav__list--footnotes">
           <%# ids: the reference/attachment Turbo Streams keep these counts
               live alongside the footnote headers' own counters. %>
-          <li><a href="#footnote-references" class="content-nav__footnote-link">Additional <span class="section-count" id="nav-references-count"><%= @references.size %></span></a></li>
+          <li><a href="#footnote-references" class="content-nav__footnote-link">References <span class="section-count" id="nav-references-count"><%= reference_count %></span></a></li>
           <li><a href="#footnote-attachments" class="content-nav__footnote-link">Attachments <span class="section-count" id="nav-attachments-count"><%= @attachments.size %></span></a></li>
         </ul>
       </nav>

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
 
       expect(external["target"]).to eq("_blank")
       expect(external["rel"]).to eq("noopener noreferrer")
+      expect(external["data-reference-type"]).to eq("link")
       expect(internal["target"]).to be_nil
       expect(internal["rel"]).to be_nil
     end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -44,12 +44,15 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(html).to include('href="#fn-1"')
       expect(html).to include('data-footnote-ref')
       expect(html).to include('class="reference-anchor reference-anchor--footnote"')
-      expect(html).to include("click-&gt;coplan--reference-preview#pin")
+      expect(html).to include("mouseenter-&gt;coplan--reference-preview#enter")
+      expect(html).to include("click-&gt;coplan--reference-preview#follow")
+      expect(html).not_to include("click-&gt;coplan--reference-preview#pin")
     end
 
     it "renders the footnote section with a backreference" do
       html = helper.render_markdown(markdown)
       expect(html).to match(/<section class="footnotes" data-footnotes(="")?>/)
+      expect(html).to include('<h2 class="footnotes-title">References</h2>')
       expect(html).to include("The supporting detail.")
       expect(html).to include('data-footnote-backref')
       expect(html).to include('href="#fnref-1"')
@@ -114,7 +117,9 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(anchor["class"]).to include("reference-anchor--section")
       expect(anchor["aria-haspopup"]).to eq("dialog")
       expect(anchor["aria-expanded"]).to eq("false")
-      expect(anchor["data-action"]).to include("coplan--reference-preview#pin")
+      expect(anchor["data-action"]).to include("coplan--reference-preview#enter")
+      expect(anchor["data-action"]).to include("click->coplan--reference-preview#follow")
+      expect(anchor["data-action"]).not_to include("click->coplan--reference-preview#pin")
     end
 
     it "leaves bare section signs as text because they can cite external documents" do

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(html).to include('href="#fnref-1"')
     end
 
+    it "can split footnotes from the document body for unified back matter" do
+      body = helper.render_markdown(markdown, footnotes: :exclude)
+      footnotes = helper.render_markdown(markdown, footnotes: :only)
+
+      expect(body).to include("A bold claim.")
+      expect(body).not_to include('data-footnotes')
+      expect(footnotes).to include('data-footnotes')
+      expect(footnotes).to include("The supporting detail.")
+      expect(footnotes).not_to include("A bold claim.")
+    end
+
     it "works in non-interactive mode" do
       html = helper.render_markdown(markdown, interactive: false)
       expect(html).to include('data-footnotes')

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(html).to include('<pre lang="mermaid"><code>')
       expect(html).to include("graph LR")
     end
+
+    it "opens external links in a new tab while keeping fragment links local" do
+      markdown = "[Source](https://example.com/evidence) and [§1](#section-1).\n\n## 1 Decision"
+      doc = Nokogiri::HTML::DocumentFragment.parse(helper.render_markdown(markdown))
+      external = doc.at_css('a[href="https://example.com/evidence"]')
+      internal = doc.at_css('a[href="#section-1"]')
+
+      expect(external["target"]).to eq("_blank")
+      expect(external["rel"]).to eq("noopener noreferrer")
+      expect(internal["target"]).to be_nil
+      expect(internal["rel"]).to be_nil
+    end
   end
 
   describe "footnotes" do

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(html).to include('<sup class="footnote-ref">')
       expect(html).to include('href="#fn-1"')
       expect(html).to include('data-footnote-ref')
+      expect(html).to include('class="reference-anchor reference-anchor--footnote"')
+      expect(html).to include("click-&gt;coplan--reference-preview#pin")
     end
 
     it "renders the footnote section with a backreference" do
@@ -83,6 +85,57 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       html = helper.render_markdown("# Heading\n\n[jump](#fnord) <span id=\"fnord\">x</span>\n\n" + markdown, footnote_prefix: "p")
       expect(html).to include('href="#fnord"')
       expect(html).to include('id="fnord"')
+    end
+  end
+
+  describe "internal section references" do
+    let(:markdown) do
+      <<~MARKDOWN
+        # Plan
+
+        See [§3.1](#section-3-1), but do not reinterpret the external statute RKSV §2.
+
+        ### 3.1 Rollout
+
+        Start with a five-percent cohort.
+      MARKDOWN
+    end
+
+    it "gives numbered headings stable section ids" do
+      doc = Nokogiri::HTML::DocumentFragment.parse(helper.render_markdown(markdown))
+
+      expect(doc.at_css("h3")["id"]).to eq("section-3-1")
+    end
+
+    it "enhances explicit links to numbered sections for previews" do
+      doc = Nokogiri::HTML::DocumentFragment.parse(helper.render_markdown(markdown))
+      anchor = doc.at_css('a[href="#section-3-1"]')
+
+      expect(anchor["class"]).to include("reference-anchor--section")
+      expect(anchor["aria-haspopup"]).to eq("dialog")
+      expect(anchor["aria-expanded"]).to eq("false")
+      expect(anchor["data-action"]).to include("coplan--reference-preview#pin")
+    end
+
+    it "leaves bare section signs as text because they can cite external documents" do
+      html = helper.render_markdown(markdown)
+
+      expect(html).to include("RKSV §2")
+      expect(html).not_to include('href="#section-2"')
+    end
+
+    it "does not enhance a fragment link when its numbered section is missing" do
+      doc = Nokogiri::HTML::DocumentFragment.parse(helper.render_markdown("See [§9](#section-9)."))
+      anchor = doc.at_css('a[href="#section-9"]')
+
+      expect(anchor["class"]).to be_nil
+      expect(anchor["data-action"]).to be_nil
+    end
+
+    it "does not create duplicate section ids in prefixed comment fragments" do
+      html = helper.render_markdown("## 3.1 A heading inside a comment", footnote_prefix: "comment-abc")
+
+      expect(html).not_to include('id="section-3-1"')
     end
   end
 

--- a/spec/helpers/references_helper_spec.rb
+++ b/spec/helpers/references_helper_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::ReferencesHelper, type: :helper do
+  describe "#plan_citation_back_matter" do
+    let(:user) { create(:coplan_user) }
+    let(:plan) do
+      plan = CoPlan::Plan.create!(title: "Sourced plan", created_by_user: user)
+      version = CoPlan::PlanVersion.create!(
+        plan: plan,
+        revision: 1,
+        content_markdown: <<~MARKDOWN,
+          This decision is evidence-based.[^experiment]
+
+          [^experiment]: A 30-day production sample supported it. [Study](https://docs.google.com/spreadsheets/d/sample).
+        MARKDOWN
+        actor_type: "human",
+        actor_id: user.id
+      )
+      plan.update!(current_plan_version: version, current_revision: 1)
+      plan
+    end
+
+    it "joins Markdown citation context to structured source identity" do
+      reference = plan.references.find_by!(url: "https://docs.google.com/spreadsheets/d/sample")
+      reference.update!(title: "Rollout experiment results")
+
+      result = helper.plan_citation_back_matter(plan, plan.references.reload)
+      doc = Nokogiri::HTML::DocumentFragment.parse(result[:html])
+      source = doc.at_css("a.citation-source")
+
+      expect(result[:count]).to eq(1)
+      expect(result[:cited_urls]).to contain_exactly(reference.url)
+      expect(doc.at_css(".reference-citations")).to be_present
+      expect(doc.at_css(".footnotes-title")).to be_nil
+      expect(doc.text).to include("A 30-day production sample supported it.")
+      expect(source["target"]).to eq("_blank")
+      expect(source["rel"]).to eq("noopener noreferrer")
+      expect(source.at_css(".citation-source__icon").text).to eq("📄")
+      expect(source.at_css(".citation-source__title").text).to eq("Rollout experiment results")
+      expect(source.at_css(".citation-source__meta").text).to eq("Google Sheet · docs.google.com ↗")
+    end
+
+    it "lists uncited and explicit resources without repeating extracted citation links" do
+      cited = plan.references.first
+      uncited = create(:reference, plan: plan, url: "https://github.com/block/coplan", source: "extracted")
+      explicit = create(:reference, plan: plan, url: cited.url.sub("sample", "curated"), source: "explicit")
+
+      listed = helper.listed_plan_references(plan.references.reload, Set[cited.url])
+
+      expect(listed).to contain_exactly(uncited, explicit)
+    end
+  end
+
+  describe "#reference_type_label" do
+    it "identifies useful document and publisher types from the URL" do
+      expect(helper.reference_type_label("document", "https://docs.google.com/document/d/1")).to eq("Google Doc")
+      expect(helper.reference_type_label("document", "https://docs.google.com/presentation/d/1")).to eq("Google Slides")
+      expect(helper.reference_type_label("link", "https://www.usda.gov/topics")).to eq("Government website")
+    end
+  end
+end

--- a/spec/helpers/references_helper_spec.rb
+++ b/spec/helpers/references_helper_spec.rb
@@ -35,15 +35,34 @@ RSpec.describe CoPlan::ReferencesHelper, type: :helper do
       expect(doc.text).to include("A 30-day production sample supported it.")
       expect(source["target"]).to eq("_blank")
       expect(source["rel"]).to eq("noopener noreferrer")
-      expect(source.at_css(".citation-source__icon").text).to eq("📄")
+      expect(source["class"]).to include("citation-source--block")
       expect(source.at_css(".citation-source__title").text).to eq("Rollout experiment results")
       expect(source.at_css(".citation-source__meta").text).to eq("Google Sheet · docs.google.com ↗")
     end
 
-    it "lists uncited and explicit resources without repeating extracted citation links" do
+    it "keeps a source link inline when prose follows it" do
+      version = CoPlan::PlanVersion.create!(
+        plan: plan,
+        revision: 2,
+        content_markdown: "Claim.[^inline]\n\n[^inline]: The [study](https://example.com/study) informed this decision.",
+        actor_type: "human",
+        actor_id: user.id
+      )
+      plan.update!(current_plan_version: version, current_revision: 2)
+
+      result = helper.plan_citation_back_matter(plan, plan.references.reload)
+      source = Nokogiri::HTML::DocumentFragment.parse(result[:html]).at_css("a.citation-source")
+
+      expect(source["class"]).to include("citation-source--inline")
+      expect(source.text).to eq("study")
+      expect(source["title"]).to eq("Website · example.com")
+    end
+
+    it "lists uncited resources without repeating cited resources" do
       cited = plan.references.first
       uncited = create(:reference, plan: plan, url: "https://github.com/block/coplan", source: "extracted")
       explicit = create(:reference, plan: plan, url: cited.url.sub("sample", "curated"), source: "explicit")
+      cited.update!(source: "explicit")
 
       listed = helper.listed_plan_references(plan.references.reload, Set[cited.url])
 

--- a/spec/models/coplan/plan_version_references_spec.rb
+++ b/spec/models/coplan/plan_version_references_spec.rb
@@ -16,4 +16,19 @@ RSpec.describe "PlanVersion reference extraction", type: :model do
     expect(plan.references.count).to eq(1)
     expect(plan.references.first.url).to eq("https://rubyonrails.org")
   end
+
+  it "broadcasts references after extraction" do
+    plan
+    expect(CoPlan::Broadcaster).to receive(:replace_plan_references) do |updated_plan|
+      expect(updated_plan.references.exists?(url: "https://rubyonrails.org")).to be(true)
+    end
+
+    CoPlan::PlanVersion.create!(
+      plan: plan,
+      revision: plan.current_revision + 1,
+      content_markdown: "See [Rails](https://rubyonrails.org) for details.",
+      actor_type: "human",
+      actor_id: user.id
+    )
+  end
 end

--- a/spec/requests/agent_instructions_spec.rb
+++ b/spec/requests/agent_instructions_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe "Agent Instructions", type: :request do
       expect(response.body).to include('"plan_type"')
     end
 
+    it "distinguishes citations, internal section links, and structured references" do
+      get agent_instructions_path
+
+      expect(response.body).to include("Citations and internal cross-references")
+      expect(response.body).to include("[§3.1](#section-3-1)")
+      expect(response.body).to include("structured, document-level inventory")
+      expect(response.body).to include("hover or click")
+    end
+
     it "builds example URLs from the request base (root mount)" do
       get agent_instructions_path
       expect(response.body).to include("http://www.example.com/api/v1/plans")

--- a/spec/requests/agent_instructions_spec.rb
+++ b/spec/requests/agent_instructions_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe "Agent Instructions", type: :request do
       expect(response.body).to include("Citations and internal cross-references")
       expect(response.body).to include("[§3.1](#section-3-1)")
       expect(response.body).to include("structured, document-level inventory")
-      expect(response.body).to include("Additional resources")
+      expect(response.body).to include("one **References** section")
+      expect(response.body).to include("source type, domain, and icon")
       expect(response.body).to include("click jumps to it")
     end
 

--- a/spec/requests/agent_instructions_spec.rb
+++ b/spec/requests/agent_instructions_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Agent Instructions", type: :request do
       expect(response.body).to include("[§3.1](#section-3-1)")
       expect(response.body).to include("structured, document-level inventory")
       expect(response.body).to include("one **References** section")
-      expect(response.body).to include("source type, domain, and icon")
+      expect(response.body).to include("source title, type, and domain")
       expect(response.body).to include("click jumps to it")
     end
 

--- a/spec/requests/agent_instructions_spec.rb
+++ b/spec/requests/agent_instructions_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Agent Instructions", type: :request do
       expect(response.body).to include("Citations and internal cross-references")
       expect(response.body).to include("[§3.1](#section-3-1)")
       expect(response.body).to include("structured, document-level inventory")
+      expect(response.body).to include("Additional resources")
       expect(response.body).to include("click jumps to it")
     end
 

--- a/spec/requests/agent_instructions_spec.rb
+++ b/spec/requests/agent_instructions_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Agent Instructions", type: :request do
       expect(response.body).to include("Citations and internal cross-references")
       expect(response.body).to include("[§3.1](#section-3-1)")
       expect(response.body).to include("structured, document-level inventory")
-      expect(response.body).to include("hover or click")
+      expect(response.body).to include("click jumps to it")
     end
 
     it "builds example URLs from the request base (root mount)" do

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe "Plans", type: :request do
   it "show plan wires up both text-selection and content-nav controllers" do
     get plan_path(plan)
     expect(response).to have_http_status(:success)
-    expect(response.body).to include('data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections"')
+    expect(response.body).to include('data-controller="coplan--text-selection coplan--content-nav coplan--checkbox coplan--changed-sections coplan--reference-preview"')
+    expect(response.body).to include('data-coplan--reference-preview-target="popover"')
   end
 
   it "show plan shares content target between controllers" do

--- a/spec/services/broadcaster_spec.rb
+++ b/spec/services/broadcaster_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CoPlan::Broadcaster do
     # the captured payloads.
     before { plan }
 
-    it "broadcasts the document body and its unified citation back matter" do
+    it "broadcasts the document body" do
       payloads = []
       allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to) do |_streamable, content:|
         payloads << content.to_s
@@ -27,21 +27,13 @@ RSpec.describe CoPlan::Broadcaster do
 
       described_class.replace_plan_content(plan)
 
-      expect(payloads.size).to eq(5)
+      expect(payloads.size).to eq(1)
       expect(payloads.first).to include('action="coplan-replace-if-clean"')
       expect(payloads.first).to include('target="plan-content-body"')
       expect(payloads.first).to include('data-revision="1"')
       # The fresh markdown render is wrapped in a <template>
       expect(payloads.first).to include("<template>")
       expect(payloads.first).to include("Hello world")
-      expect(payloads.second).to include('action="coplan-replace-if-clean"')
-      expect(payloads.second).to include('target="plan-citations"')
-      expect(payloads.second).to include('data-revision="1"')
-      expect(payloads.third).to include('target="plan-extracted-references"')
-      expect(payloads.third).to include("Source")
-      expect(payloads.fourth).to include('target="references-count"')
-      expect(payloads.fifth).to include('target="nav-references-count"')
-      expect(payloads.join).not_to include("authenticity_token")
     end
 
     it "reflects the latest revision so stale-tab clients can ignore self-broadcasts" do
@@ -61,6 +53,29 @@ RSpec.describe CoPlan::Broadcaster do
 
       expect(payloads.first).to include('data-revision="2"')
       expect(payloads.first).to include("Updated")
+    end
+  end
+
+  describe ".replace_plan_references" do
+    before { plan }
+
+    it "broadcasts unified back matter after extracted references exist" do
+      payloads = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to) do |_streamable, content:|
+        payloads << content.to_s
+      end
+
+      described_class.replace_plan_references(plan)
+
+      expect(payloads.size).to eq(4)
+      expect(payloads.first).to include('action="coplan-replace-if-clean"')
+      expect(payloads.first).to include('target="plan-citations"')
+      expect(payloads.first).to include('data-revision="1"')
+      expect(payloads.second).to include('target="plan-extracted-references"')
+      expect(payloads.second).to include("Source")
+      expect(payloads.third).to include('target="references-count"')
+      expect(payloads.fourth).to include('target="nav-references-count"')
+      expect(payloads.join).not_to include("authenticity_token")
     end
   end
 end

--- a/spec/services/broadcaster_spec.rb
+++ b/spec/services/broadcaster_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CoPlan::Broadcaster do
     p = CoPlan::Plan.create!(title: "Test Plan", created_by_user: author)
     version = CoPlan::PlanVersion.create!(
       plan: p, revision: 1,
-      content_markdown: "# Hello world\n\nSome content here.",
+      content_markdown: "# Hello world\n\nSome content here. [Source](https://example.com/evidence)",
       actor_type: "human", actor_id: author.id
     )
     p.update!(current_plan_version: version, current_revision: 1)
@@ -19,7 +19,7 @@ RSpec.describe CoPlan::Broadcaster do
     # the captured payloads.
     before { plan }
 
-    it "broadcasts a custom turbo-stream action targeting #plan-content-body" do
+    it "broadcasts the document body and its unified citation back matter" do
       payloads = []
       allow(Turbo::StreamsChannel).to receive(:broadcast_stream_to) do |_streamable, content:|
         payloads << content.to_s
@@ -27,13 +27,21 @@ RSpec.describe CoPlan::Broadcaster do
 
       described_class.replace_plan_content(plan)
 
-      expect(payloads.size).to eq(1)
+      expect(payloads.size).to eq(5)
       expect(payloads.first).to include('action="coplan-replace-if-clean"')
       expect(payloads.first).to include('target="plan-content-body"')
       expect(payloads.first).to include('data-revision="1"')
       # The fresh markdown render is wrapped in a <template>
       expect(payloads.first).to include("<template>")
       expect(payloads.first).to include("Hello world")
+      expect(payloads.second).to include('action="coplan-replace-if-clean"')
+      expect(payloads.second).to include('target="plan-citations"')
+      expect(payloads.second).to include('data-revision="1"')
+      expect(payloads.third).to include('target="plan-extracted-references"')
+      expect(payloads.third).to include("Source")
+      expect(payloads.fourth).to include('target="references-count"')
+      expect(payloads.fifth).to include('target="nav-references-count"')
+      expect(payloads.join).not_to include("authenticity_token")
     end
 
     it "reflects the latest revision so stale-tab clients can ignore self-broadcasts" do

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -33,8 +33,30 @@ RSpec.describe "Plan references", type: :system do
       expect(page).to have_content("Some content here")
       # Empty state is one quiet line, scoped to the section (attachments
       # has its own "None yet").
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No additional resources")
-      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /additional resources/i)
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No references yet")
+      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /references/i)
+    end
+
+    it "includes auto-extracted links as rich resources when they are not citations" do
+      version = CoPlan::PlanVersion.create!(
+        plan: plan,
+        revision: 2,
+        content_markdown: "Read the [CoPlan repository](https://github.com/block/coplan) for implementation details.",
+        actor_type: "human",
+        actor_id: user.id
+      )
+      plan.update!(current_plan_version: version, current_revision: 2)
+
+      visit plan_path(plan)
+
+      within("#plan-extracted-references") do
+        link = find_link("CoPlan repository", href: "https://github.com/block/coplan")
+        expect(link["target"]).to eq("_blank")
+        expect(link["rel"]).to eq("noopener noreferrer")
+        expect(page).to have_css(".references-list__meta", text: /GitHub repository\s+·\s+github\.com ↗/)
+        expect(page).to have_css(".references-list__icon", text: "📦")
+      end
+      expect(page).to have_css("#references-count", text: "1")
     end
   end
 
@@ -74,13 +96,20 @@ RSpec.describe "Plan references", type: :system do
         source_link = find_link("Open the source", href: "https://docs.google.com/document/d/evidence")
         expect(source_link["target"]).to eq("_blank")
         expect(source_link["rel"]).to eq("noopener noreferrer")
-        expect(source_link["aria-label"]).to eq("Open source: Open the source in a new tab (Google Doc, docs.google.com)")
-        expect(source_link).to have_css(".reference-preview__source-meta", text: "Google Doc · docs.google.com ↗")
+        expect(source_link["aria-label"]).to eq("Open source: Open the source in a new tab (Google Doc · docs.google.com)")
+        expect(source_link).to have_css(".citation-source__meta", text: "Google Doc · docs.google.com ↗")
       end
-      expect(page).to have_css("#references-count", text: "0")
+      expect(page).to have_css("#references-count", text: "1")
+      expect(page).to have_no_css("#plan-content-body section[data-footnotes]")
+      within("#plan-citations") do
+        source_link = find_link("Open the source", href: "https://docs.google.com/document/d/evidence")
+        expect(source_link["target"]).to eq("_blank")
+        expect(source_link).to have_css(".citation-source__icon", text: "📄")
+        expect(source_link).to have_css(".citation-source__meta", text: "Google Doc · docs.google.com ↗")
+      end
       within("#plan-references") do
         expect(page).to have_no_link("Open the source", href: "https://docs.google.com/document/d/evidence")
-        expect(page).to have_text("No additional resources.")
+        expect(page).to have_no_text("No references yet.")
       end
 
       citation.click
@@ -126,7 +155,7 @@ RSpec.describe "Plan references", type: :system do
         fill_in "reference[url]", with: "https://github.com/org/repo"
         fill_in "reference[title]", with: "My Repo"
         fill_in "reference[key]", with: "my-repo"
-        click_button "Add resource"
+        click_button "Add reference"
       end
 
       # Turbo Stream replaces the list — reference appears without navigation
@@ -149,7 +178,7 @@ RSpec.describe "Plan references", type: :system do
       within(".add-modal:popover-open") do
         fill_in "reference[url]", with: "https://github.com/org/repo"
         fill_in "reference[title]", with: "Repo One"
-        click_button "Add resource"
+        click_button "Add reference"
       end
       expect(page).to have_content("Repo One")
       expect(page).to have_css("#references-count", text: "1")
@@ -160,7 +189,7 @@ RSpec.describe "Plan references", type: :system do
       within(".add-modal:popover-open") do
         fill_in "reference[url]", with: "https://github.com/org/other"
         fill_in "reference[title]", with: "Repo Two"
-        click_button "Add resource"
+        click_button "Add reference"
       end
 
       expect(page).to have_content("Repo One")
@@ -186,7 +215,7 @@ RSpec.describe "Plan references", type: :system do
       # Turbo Stream removes the reference and updates count
       expect(page).not_to have_content("Doomed")
       expect(page).to have_css("#references-count", text: "0")
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No additional resources")
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No references yet")
     end
   end
 

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe "Plan references", type: :system do
         expect(link["target"]).to eq("_blank")
         expect(link["rel"]).to eq("noopener noreferrer")
         expect(page).to have_css(".references-list__meta", text: /GitHub repository\s+·\s+github\.com ↗/)
-        expect(page).to have_css(".references-list__icon", text: "📦")
       end
       expect(page).to have_css("#references-count", text: "1")
     end
@@ -104,7 +103,7 @@ RSpec.describe "Plan references", type: :system do
       within("#plan-citations") do
         source_link = find_link("Open the source", href: "https://docs.google.com/document/d/evidence")
         expect(source_link["target"]).to eq("_blank")
-        expect(source_link).to have_css(".citation-source__icon", text: "📄")
+        expect(source_link[:class]).to include("citation-source--block")
         expect(source_link).to have_css(".citation-source__meta", text: "Google Doc · docs.google.com ↗")
       end
       within("#plan-references") do
@@ -114,6 +113,10 @@ RSpec.describe "Plan references", type: :system do
 
       citation.click
       expect(page.evaluate_script("window.location.hash")).to eq("#fn-launch-data")
+      expect(page.evaluate_script(<<~JS)).to be(true)
+        document.querySelector("#fn-launch-data").getBoundingClientRect().top >=
+          document.querySelector(".site-nav").getBoundingClientRect().bottom
+      JS
 
       visit plan_path(referenced_plan)
       section_link = find('a.reference-anchor--section[href="#section-2-1"]')
@@ -161,6 +164,7 @@ RSpec.describe "Plan references", type: :system do
       # Turbo Stream replaces the list — reference appears without navigation
       expect(page).to have_link("My Repo", href: "https://github.com/org/repo")
       expect(page).not_to have_css("#footnote-references .plan-footnote__empty")
+      expect(page).to have_no_text("my-repo")
 
       # Count spans updated in-place via Turbo Stream (separate stream
       # targets) — the footnote header and the document outline.
@@ -206,8 +210,11 @@ RSpec.describe "Plan references", type: :system do
       expect(page).to have_content("Doomed")
       expect(page).to have_css("#references-count", text: "1")
 
-      # data-turbo-confirm triggers a browser confirm dialog. Scoped: the
-      # TOC's hide button is also a "✕" now that everything shares a page.
+      # The quiet remove control appears when the reference row is active.
+      within("#plan-references") { find(".references-list__item").hover }
+
+      # data-turbo-confirm triggers a browser confirm dialog. Scoped because
+      # the TOC also has a "✕" control.
       accept_confirm("Remove this reference?") do
         within("#plan-references") { click_button "✕" }
       end

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Plan references", type: :system do
       expect(page).to have_content("Some content here")
       # Empty state is one quiet line, scoped to the section (attachments
       # has its own "None yet").
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None added")
-      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /related resources/i)
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No additional resources")
+      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /additional resources/i)
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe "Plan references", type: :system do
 
           Start with a five-percent cohort and monitor errors for one week.
 
-          [^launch-data]: The production sample covered 30 days. [Open the source](https://example.com/evidence).
+          [^launch-data]: The production sample covered 30 days. [Open the source](https://docs.google.com/document/d/evidence).
         MARKDOWN
         actor_type: "human",
         actor_id: user.id
@@ -71,15 +71,16 @@ RSpec.describe "Plan references", type: :system do
       within(".reference-preview") do
         expect(page).to have_no_text("CITATION")
         expect(page).to have_no_text("Reference 1")
-        source_link = find_link("Open external link ↗", href: "https://example.com/evidence")
+        source_link = find_link("Open the source", href: "https://docs.google.com/document/d/evidence")
         expect(source_link["target"]).to eq("_blank")
         expect(source_link["rel"]).to eq("noopener noreferrer")
-        expect(source_link["aria-label"]).to eq("Open external link: Open the source")
+        expect(source_link["aria-label"]).to eq("Open source: Open the source in a new tab (Google Doc, docs.google.com)")
+        expect(source_link).to have_css(".reference-preview__source-meta", text: "Google Doc · docs.google.com ↗")
       end
       expect(page).to have_css("#references-count", text: "0")
       within("#plan-references") do
-        expect(page).to have_no_link("Open the source", href: "https://example.com/evidence")
-        expect(page).to have_text("None added.")
+        expect(page).to have_no_link("Open the source", href: "https://docs.google.com/document/d/evidence")
+        expect(page).to have_text("No additional resources.")
       end
 
       citation.click
@@ -185,7 +186,7 @@ RSpec.describe "Plan references", type: :system do
       # Turbo Stream removes the reference and updates count
       expect(page).not_to have_content("Doomed")
       expect(page).to have_css("#references-count", text: "0")
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None added")
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "No additional resources")
     end
   end
 

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe "Plan references", type: :system do
       expect(section_link["aria-expanded"]).to eq("true")
       expect(page).to have_css(".reference-preview__title", text: "2.1 Rollout", visible: :visible)
       expect(page).to have_css(".reference-preview__body", text: "five-percent cohort", visible: :visible)
+      expect(page).to have_no_css(".reference-preview__body", text: "production sample covered 30 days", visible: :visible)
       expect(page).to have_link("Go to section", href: "#section-2-1")
     end
   end

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -38,6 +38,55 @@ RSpec.describe "Plan references", type: :system do
     end
   end
 
+  describe "inline reference previews" do
+    let(:referenced_plan) do
+      p = CoPlan::Plan.create!(title: "Referenced Plan", created_by_user: user)
+      version = CoPlan::PlanVersion.create!(
+        plan: p,
+        revision: 1,
+        content_markdown: <<~MARKDOWN,
+          # Referenced Plan
+
+          This claim has evidence.[^launch-data] See [§2.1](#section-2-1) for the rollout.
+
+          ## 2.1 Rollout
+
+          Start with a five-percent cohort and monitor errors for one week.
+
+          [^launch-data]: The production sample covered 30 days. [Open the source](https://example.com/evidence).
+        MARKDOWN
+        actor_type: "human",
+        actor_id: user.id
+      )
+      p.update!(current_plan_version: version, current_revision: 1)
+      p
+    end
+
+    it "previews citation content on hover and section content on click" do
+      visit plan_path(referenced_plan)
+
+      citation = find("a.reference-anchor--footnote")
+      citation.hover
+      expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
+      expect(page).to have_link("Open the source", href: "https://example.com/evidence")
+
+      find(".reference-preview__close").click
+      expect(page).not_to have_css(".reference-preview", visible: :visible)
+
+      citation.click
+      expect(citation["aria-expanded"]).to eq("true")
+      expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
+      find(".reference-preview__close").click
+
+      section_link = find('a.reference-anchor--section[href="#section-2-1"]')
+      section_link.click
+      expect(section_link["aria-expanded"]).to eq("true")
+      expect(page).to have_css(".reference-preview__title", text: "2.1 Rollout", visible: :visible)
+      expect(page).to have_css(".reference-preview__body", text: "five-percent cohort", visible: :visible)
+      expect(page).to have_link("Go to section", href: "#section-2-1")
+    end
+  end
+
   describe "adding references via Turbo Stream" do
     it "closes the add-modal via the X button and via Escape" do
       visit plan_path(plan)

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -68,7 +68,11 @@ RSpec.describe "Plan references", type: :system do
       citation = find("a.reference-anchor--footnote")
       citation.hover
       expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
-      expect(page).to have_link("Open the source", href: "https://example.com/evidence")
+      within(".reference-preview") do
+        source_link = find_link("Open the source", href: "https://example.com/evidence")
+        expect(source_link["target"]).to eq("_blank")
+        expect(source_link["rel"]).to eq("noopener noreferrer")
+      end
       expect(page).to have_css("#references-count", text: "0")
       within("#plan-references") do
         expect(page).to have_no_link("Open the source", href: "https://example.com/evidence")

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Plan references", type: :system do
       expect(page).to have_content("Some content here")
       # Empty state is one quiet line, scoped to the section (attachments
       # has its own "None yet").
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None yet")
-      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /references/i)
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None added")
+      expect(page).to have_css("#footnote-references .plan-footnote__title", text: /related resources/i)
     end
   end
 
@@ -62,29 +62,33 @@ RSpec.describe "Plan references", type: :system do
       p
     end
 
-    it "previews citation content on hover and section content on click" do
+    it "previews references on hover and follows their links on click" do
       visit plan_path(referenced_plan)
 
       citation = find("a.reference-anchor--footnote")
       citation.hover
       expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
       expect(page).to have_link("Open the source", href: "https://example.com/evidence")
-
-      find(".reference-preview__close").click
-      expect(page).not_to have_css(".reference-preview", visible: :visible)
+      expect(page).to have_css("#references-count", text: "0")
+      within("#plan-references") do
+        expect(page).to have_no_link("Open the source", href: "https://example.com/evidence")
+        expect(page).to have_text("None added.")
+      end
 
       citation.click
-      expect(citation["aria-expanded"]).to eq("true")
-      expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
-      find(".reference-preview__close").click
+      expect(page.evaluate_script("window.location.hash")).to eq("#fn-launch-data")
 
+      visit plan_path(referenced_plan)
       section_link = find('a.reference-anchor--section[href="#section-2-1"]')
-      section_link.click
+      section_link.hover
       expect(section_link["aria-expanded"]).to eq("true")
       expect(page).to have_css(".reference-preview__title", text: "2.1 Rollout", visible: :visible)
       expect(page).to have_css(".reference-preview__body", text: "five-percent cohort", visible: :visible)
       expect(page).to have_no_css(".reference-preview__body", text: "production sample covered 30 days", visible: :visible)
-      expect(page).to have_link("Go to section", href: "#section-2-1")
+
+      section_link.click
+      expect(page.evaluate_script("window.location.hash")).to eq("#section-2-1")
+      expect(page).to have_no_css(".reference-preview__jump")
     end
   end
 
@@ -113,7 +117,7 @@ RSpec.describe "Plan references", type: :system do
         fill_in "reference[url]", with: "https://github.com/org/repo"
         fill_in "reference[title]", with: "My Repo"
         fill_in "reference[key]", with: "my-repo"
-        click_button "Add reference"
+        click_button "Add resource"
       end
 
       # Turbo Stream replaces the list — reference appears without navigation
@@ -136,7 +140,7 @@ RSpec.describe "Plan references", type: :system do
       within(".add-modal:popover-open") do
         fill_in "reference[url]", with: "https://github.com/org/repo"
         fill_in "reference[title]", with: "Repo One"
-        click_button "Add reference"
+        click_button "Add resource"
       end
       expect(page).to have_content("Repo One")
       expect(page).to have_css("#references-count", text: "1")
@@ -147,7 +151,7 @@ RSpec.describe "Plan references", type: :system do
       within(".add-modal:popover-open") do
         fill_in "reference[url]", with: "https://github.com/org/other"
         fill_in "reference[title]", with: "Repo Two"
-        click_button "Add reference"
+        click_button "Add resource"
       end
 
       expect(page).to have_content("Repo One")
@@ -173,7 +177,7 @@ RSpec.describe "Plan references", type: :system do
       # Turbo Stream removes the reference and updates count
       expect(page).not_to have_content("Doomed")
       expect(page).to have_css("#references-count", text: "0")
-      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None yet")
+      expect(page).to have_css("#footnote-references .plan-footnote__empty", text: "None added")
     end
   end
 

--- a/spec/system/references_spec.rb
+++ b/spec/system/references_spec.rb
@@ -69,9 +69,12 @@ RSpec.describe "Plan references", type: :system do
       citation.hover
       expect(page).to have_css(".reference-preview", text: "production sample covered 30 days", visible: :visible)
       within(".reference-preview") do
-        source_link = find_link("Open the source", href: "https://example.com/evidence")
+        expect(page).to have_no_text("CITATION")
+        expect(page).to have_no_text("Reference 1")
+        source_link = find_link("Open external link ↗", href: "https://example.com/evidence")
         expect(source_link["target"]).to eq("_blank")
         expect(source_link["rel"]).to eq("noopener noreferrer")
+        expect(source_link["aria-label"]).to eq("Open external link: Open the source")
       end
       expect(page).to have_css("#references-count", text: "0")
       within("#plan-references") do
@@ -86,6 +89,7 @@ RSpec.describe "Plan references", type: :system do
       section_link = find('a.reference-anchor--section[href="#section-2-1"]')
       section_link.hover
       expect(section_link["aria-expanded"]).to eq("true")
+      expect(page).to have_no_css(".reference-preview", text: "INTERNAL REFERENCE", visible: :visible)
       expect(page).to have_css(".reference-preview__title", text: "2.1 Rollout", visible: :visible)
       expect(page).to have_css(".reference-preview__body", text: "five-percent cohort", visible: :visible)
       expect(page).to have_no_css(".reference-preview__body", text: "production sample covered 30 days", visible: :visible)


### PR DESCRIPTION
## Why
Agents currently write footnote citations and `§` section references that look meaningful but either require readers to jump away from their place or have no link semantics at all. Readers also need enough source identity to judge whether cited evidence is trustworthy.

## What
- Preview footnote citations and explicitly linked numbered sections on hover or keyboard focus
- Join Markdown citation context to the structured `CoPlan::Reference` inventory by URL
- Render one compact, numbered References section with evidence context, source title/type/domain, and remaining linked or curated resources
- Follow internal references immediately on click and open external HTTP(S) sources in new tabs
- Keep citation back matter, extracted resources, and counts current after live agent edits without broadcasting user-specific form tokens
- Teach agents when to use citations, internal links, and structured reference metadata
- Cover rendering, structured joins, post-extraction live updates, and interactions with helper, request, model, service, and system specs

## Risk Assessment
Low to medium — this changes Markdown rendering and plan-page interactions, but only footnotes and valid explicit section links opt into previews. Bare section symbols remain unchanged, structured reference records remain available through the API, and the full Rails suite passes.

## Screenshots

### Citation preview with source identity
![Citation preview with source title, type, and domain](https://d24qwcpro867f5.cloudfront.net/repos/coplan/prs/177/citation-hover-redesign.png)

### Compact unified References section
![Numbered citation evidence and a structured resource in one References section](https://d24qwcpro867f5.cloudfront.net/repos/coplan/prs/177/references-redesign.png)

Generated with Amp