### PR TITLE
Add containing-folder navigation

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -515,11 +515,11 @@ img, svg {
   display: none;
 }
 
-/* Scroll-aware document title in the top nav. Collapsed to zero width when
-   inactive so it steals no space and causes no reflow at the top of a plan;
-   coplan--nav-title flips --visible once the header scrolls behind the bar.
-   It lives in the left "where am I?" cluster (see .site-nav__inner). */
-.site-nav__doc-title {
+/* Scroll-aware plan context in the top nav: containing folder + document title.
+   Collapsed to zero width while the masthead is visible, so it steals no
+   space and causes no reflow at the top of a plan. coplan--nav-title reveals
+   the whole context once #plan-header scrolls behind the bar. */
+.site-nav__plan-context {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
@@ -529,6 +529,7 @@ img, svg {
      slack — never the other way round. */
   flex: 0 1 auto;
   min-width: 0;
+  width: 0;
   max-width: 0;
   overflow: hidden;
   opacity: 0;
@@ -541,17 +542,28 @@ img, svg {
   pointer-events: none;
   /* Grow a touch slower than the fade, so it reads as sliding in from the
      links rather than shoving the search box aside. */
-  transition: max-width 0.28s ease, opacity 0.18s ease;
+  transition: width 0.28s ease, max-width 0.28s ease, opacity 0.18s ease;
 }
 
-.site-nav__doc-title--visible {
-  max-width: 22rem;
+.site-nav__plan-context--visible {
+  width: 25rem;
+  max-width: 25rem;
   opacity: 1;
   pointer-events: auto;
 }
 
+.site-nav__doc-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
 .site-nav__doc-title:hover {
   color: var(--color-text);
+  text-decoration: none;
 }
 
 .site-nav__doc-title-text {
@@ -569,7 +581,7 @@ img, svg {
    holds nothing else on the left. On a phone it's the ONLY plan context (the
    Contents sidebar is hidden < 1024px), so let it take more of the row. */
 @media (max-width: 640px) {
-  .site-nav__doc-title--visible {
+  .site-nav__plan-context--visible {
     max-width: 58vw;
   }
 }
@@ -620,6 +632,47 @@ img, svg {
   flex-shrink: 0;
   /* Level the toolbar pill's baseline band with the byline text. */
   margin-bottom: -2px;
+}
+
+/* Compact "up to containing folder" control. In the masthead it lives in
+   the byline, where it takes no width away from the title; its accessible
+   name and tooltip carry the full folder path. */
+.plan-location-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s;
+}
+
+.plan-location-link:hover,
+.plan-location-link:focus-visible {
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  text-decoration: none;
+}
+
+.plan-location-link--masthead {
+  width: 24px;
+  height: 24px;
+  margin: -2px 0 -2px 2px;
+}
+
+.plan-location-link--nav {
+  width: 26px;
+  height: 26px;
+  color: var(--color-text);
+  background: var(--color-surface-muted);
+}
+
+.plan-location-link--nav svg {
+  width: 16px;
+  height: 16px;
 }
 
 /* Plan page header: one lockup — the file icon beside a text stack
@@ -5918,14 +5971,29 @@ img.avatar {
 }
 
 /* ---- Touch devices (any width) ----
-   A finger needs a bigger target than a cursor. On coarse pointers the bar's
-   icon controls and the menu rows grow to ~44px regardless of screen width,
-   so a touch tablet with the bell still on the bar is just as tappable. */
+   A finger needs a bigger target than a cursor. On coarse pointers the icon
+   controls and menu rows grow to ~44px regardless of screen width, so a touch
+   tablet with the bell still on the bar is just as tappable. */
 @media (pointer: coarse) {
   .site-nav__menu-btn,
   .site-nav__bell {
     min-width: 44px;
     min-height: 44px;
+  }
+
+  /* Preserve a 44px touch target without giving the compact control 44px
+     of layout footprint in the byline or sticky plan context. */
+  .plan-location-link {
+    width: 44px;
+    height: 44px;
+  }
+
+  .plan-location-link--masthead {
+    margin: -12px -10px -12px -8px;
+  }
+
+  .plan-location-link--nav {
+    margin: -9px;
   }
 
   .menu__item {

--- a/engine/app/controllers/coplan/libraries_controller.rb
+++ b/engine/app/controllers/coplan/libraries_controller.rb
@@ -1,37 +1,65 @@
 module CoPlan
-  # A library is a data-model concept, not a destination: a person's
-  # library is browsed on their profile, so these routes redirect there
-  # (fragments like #folder-x survive the redirect). The standalone page
-  # only renders for a future non-user owner (e.g. a team) that has no
-  # profile to redirect to.
+  # Read-only folder navigation for someone else's library. Owners continue
+  # into their editable workspace; everyone else gets the same level-by-level
+  # folder model without drag, move, or create controls.
   class LibrariesController < ApplicationController
     def mine
-      redirect_to profile_path(current_user.username.presence || current_user.id)
+      redirect_to plans_path
     end
 
     def show
       @library = Library.find(params[:id])
       authorize!(@library, :show?)
 
-      if @library.owner.is_a?(CoPlan::User)
-        owner = @library.owner
-        redirect_to profile_path(owner.username.presence || owner.id)
+      if @library.writable_by?(current_user)
+        redirect_to plans_path(folder: params[:folder].presence)
         return
       end
 
       @owner = @library.owner
       @folders = @library.folders.order(:name).to_a
+      @folders_by_id = @folders.index_by(&:id)
       @folder_children = @folders.group_by(&:parent_id)
-      @root_folders = @folder_children[nil] || []
+      @folder = @folders_by_id[params[:folder]] if params[:folder].present?
+      if params[:folder].present? && @folder.nil?
+        redirect_to library_path(@library), alert: "That folder no longer exists."
+        return
+      end
 
       placements = @library.placements
         .visible_to(current_user)
         .where(plan: Plan.active)
         .joins(:plan).order("coplan_plans.updated_at DESC")
-        .includes(plan: [ :created_by_user, :plan_type, :tags ])
+        .includes(:folder, plan: [ :created_by_user, :plan_type, :current_version_stub ])
         .to_a
       @placements_by_folder = placements.group_by(&:folder_id)
-      @plan_count = placements.size
+
+      @root_plans = if @owner.is_a?(CoPlan::User)
+        Plan.visible_to(current_user).active
+          .where(created_by_user_id: @owner.id)
+          .where.not(id: @library.placements.select(:plan_id))
+          .order(updated_at: :desc)
+          .includes(:created_by_user, :plan_type, :current_version_stub)
+          .to_a
+      else
+        []
+      end
+
+      @breadcrumbs = []
+      node = @folder
+      while node
+        @breadcrumbs.unshift(node)
+        node = @folders_by_id[node.parent_id]
+      end
+      @subfolders = (@folder_children[@folder&.id] || []).sort_by { |folder| folder.name.downcase }
+      @plans = @folder ? (@placements_by_folder[@folder.id] || []).map(&:plan) : @root_plans
+      @plan_count = placements.size + @root_plans.size
+
+      direct_counts = @placements_by_folder.transform_values(&:size)
+      count_folder = lambda do |folder|
+        direct_counts.fetch(folder.id, 0) + (@folder_children[folder.id] || []).sum { |child| count_folder.call(child) }
+      end
+      @folder_counts = @folders.index_with { |folder| count_folder.call(folder) }.transform_keys(&:id)
     end
   end
 end

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -687,6 +687,7 @@ module CoPlan
 
     def broadcast_plan_update(plan)
       Broadcaster.replace_to(plan, target: "plan-header", partial: "coplan/plans/header", locals: { plan: plan })
+      Broadcaster.replace_to(plan, target: "plan-nav-context", partial: "coplan/plans/nav_context", locals: { plan: plan })
     end
 
     # Turbo Streams for a visibility change: re-render the header (the
@@ -708,6 +709,7 @@ module CoPlan
     def archive_streams(message)
       [
         turbo_stream.replace("plan-header", partial: "coplan/plans/header", locals: { plan: @plan }),
+        turbo_stream.replace("plan-nav-context", partial: "coplan/plans/nav_context", locals: { plan: @plan }),
         turbo_stream.replace("plan-banner-slot", partial: "coplan/plans/banner", locals: { plan: @plan }),
         turbo_stream.replace("plan-toolbar", partial: "coplan/plans/toolbar", locals: { plan: @plan }),
         toast_stream(message, "notice")

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -142,11 +142,12 @@ module CoPlan
       # Old ?tab=history links: history is its own page now (the other
       # former tabs are same-page sections).
       return redirect_to history_plan_path(@plan) if params[:tab] == "history"
-      # The viewer's own placement (if any) drives the toolbar's
-      # Save/Saved state and the folder navigator's current-folder mark.
+      # Placements drive both the viewer-relative Save/Saved state and the
+      # compact jump up to the containing folder in the author's library.
       @shelf_placements = @plan.placements
         .includes(:library, folder: { parent: :parent })
         .order(:created_at)
+      @author_placement = @shelf_placements.find { |placement| placement.library_id == @plan.created_by_user.library.id }
       @my_folders = current_user.library.folders.order(:name).to_a
       @threads = @plan.comment_threads.with_kept_comments.includes(:comments, :created_by_user).order(:created_at)
       # The reader view joins auto-extracted resources to their Markdown

--- a/engine/app/javascript/controllers/coplan/nav_title_controller.js
+++ b/engine/app/javascript/controllers/coplan/nav_title_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Fades the plan title into the sticky top nav once the document's own
-// header has scrolled up behind the bar. Persistent wayfinding —
+// Fades the plan context (containing-folder control + title) into the sticky top nav
+// once the document's own header has scrolled up behind the bar. Persistent wayfinding —
 // especially on mobile and on comment deep links, where you land centered
 // on an anchor with the masthead already off-screen — that costs zero
 // space while the header is still visible.
@@ -70,12 +70,14 @@ export default class extends Controller {
   }
 
   _setVisible(visible) {
-    this.element.classList.toggle("site-nav__doc-title--visible", visible)
+    this.element.classList.toggle("site-nav__plan-context--visible", visible)
     // Collapsed, it's decorative and must stay out of the tab order; once
-    // shown it's a real return-to-top control, so expose it to keyboard and
-    // screen-reader users too.
+    // shown, both the containing-folder and return-to-top links are real controls,
+    // so expose them to keyboard and screen-reader users too.
     this.element.setAttribute("aria-hidden", String(!visible))
-    this.element.tabIndex = visible ? 0 : -1
+    this.element.querySelectorAll("a").forEach(link => {
+      link.tabIndex = visible ? 0 : -1
+    })
   }
 
   // --nav-height is authored in rem; resolve it to px for rootMargin.

--- a/engine/app/models/coplan/plan.rb
+++ b/engine/app/models/coplan/plan.rb
@@ -196,6 +196,13 @@ module CoPlan
       archived_at.present?
     end
 
+    # A plan's containing location is the folder chosen by its author in
+    # their own library. Other people may save the same plan elsewhere, but
+    # those placements are personal organization rather than its home.
+    def author_placement
+      placements.find_by(library_id: created_by_user.library.id)
+    end
+
     # Legacy API compatibility (see LEGACY_STATUSES). Emits the closest
     # five-state equivalent of the current visibility/archival state.
     def legacy_status

--- a/engine/app/views/coplan/libraries/show.html.erb
+++ b/engine/app/views/coplan/libraries/show.html.erb
@@ -1,5 +1,4 @@
 <% owner_name = @owner.respond_to?(:name) ? @owner.name : @library.name %>
-<% mine = @library.writable_by?(current_user) %>
 
 <div class="library">
   <header class="library__header">
@@ -8,33 +7,64 @@
         <%= user_avatar(@owner, size: "lg") %>
       <% end %>
       <div>
-        <h1 class="library__title"><%= mine ? "Your library" : "#{owner_name}’s library" %></h1>
+        <h1 class="library__title"><%= owner_name %>’s library</h1>
         <p class="library__subtitle text-muted">
           <%= pluralize(@plan_count, "plan") %> across <%= pluralize(@folders.size, "folder") %>
-          <% if mine %> · the read-only view others see from your profile<% end %>
-          <% if !mine && @owner.is_a?(CoPlan::User) %> · curated by <%= profile_link(@owner) %><% end %>
+          <% if @owner.is_a?(CoPlan::User) %> · curated by <%= profile_link(@owner) %><% end %>
         </p>
       </div>
     </div>
-    <% if mine %>
-      <%= link_to "Organize in workspace", plans_path, class: "btn btn--secondary btn--sm" %>
-    <% end %>
   </header>
 
-  <% if @folders.empty? %>
+  <nav class="workspace-crumbs" aria-label="Folder location">
+    <%= link_to library_path(@library),
+          class: "workspace-crumbs__crumb #{'workspace-crumbs__crumb--current' if @breadcrumbs.empty?}",
+          aria: @breadcrumbs.empty? ? { current: "location" } : {},
+          data: { turbo_prefetch: true } do %>
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+      <%= owner_name %>’s library
+    <% end %>
+    <% @breadcrumbs.each_with_index do |crumb, index| %>
+      <svg class="workspace-crumbs__sep" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+      <% current = index == @breadcrumbs.size - 1 %>
+      <%= link_to crumb.name, library_path(@library, folder: crumb.id),
+            class: "workspace-crumbs__crumb #{'workspace-crumbs__crumb--current' if current}",
+            aria: current ? { current: "location" } : {},
+            data: { turbo_prefetch: true } %>
+    <% end %>
+  </nav>
+
+  <% @subfolders.each do |folder| %>
+    <%= link_to library_path(@library, folder: folder.id), class: "folder-row", data: { turbo_prefetch: true } do %>
+      <span class="folder-row__icon" aria-hidden="true">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+      </span>
+      <span class="folder-row__name"><%= folder.name %></span>
+      <% count = @folder_counts[folder.id] %>
+      <span class="folder-row__count text-muted"><%= count.zero? ? "empty" : pluralize(count, "item") %></span>
+    <% end %>
+  <% end %>
+
+  <% @plans.each do |plan| %>
+    <% summary = plan.try(:summary).presence || plan_content_preview(plan) %>
+    <article class="plan-row">
+      <span class="plan-row__icon"><%= plan_type_icon(plan, size: :lg) %></span>
+      <div class="plan-row__main">
+        <div class="plan-row__line">
+          <%= link_to plan.title, plan_path(plan), class: "plan-row__title", data: { turbo_prefetch: true } %><%= plan_state_badge(plan) %>
+        </div>
+        <% if summary.present? %><p class="plan-row__summary text-muted"><%= summary %></p><% end %>
+      </div>
+      <div class="plan-row__meta">
+        <span class="plan-row__time text-muted"><%= time_ago_in_words(plan.updated_at) %> ago</span>
+        <span class="plan-row__avatar"><%= link_to user_avatar(plan.created_by_user), profile_path_for(plan.created_by_user), title: plan.created_by_user.name %></span>
+      </div>
+    </article>
+  <% end %>
+
+  <% if @subfolders.empty? && @plans.empty? %>
     <div class="library__empty">
-      <p>Nothing on these shelves yet.</p>
-      <% if mine %>
-        <p class="text-muted text-sm">Create folders in your <%= link_to "workspace", plans_path %> sidebar and drag plans onto them — yours or anyone’s published work.</p>
-      <% else %>
-        <p class="text-muted text-sm"><%= owner_name %> hasn’t organized any plans into folders yet.</p>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="library__shelves">
-      <% @root_folders.sort_by { |f| f.name.downcase }.each do |folder| %>
-        <%= render "coplan/libraries/shelf", folder: folder, depth: 1 %>
-      <% end %>
+      <p>Nothing in this folder yet.</p>
     </div>
   <% end %>
 </div>

--- a/engine/app/views/coplan/plans/_header.html.erb
+++ b/engine/app/views/coplan/plans/_header.html.erb
@@ -3,12 +3,14 @@
     (content commits, visibility changes, API edits) with no current_user,
     so viewer-relative chrome (presence, the owner toolbar, Save) lives in
     the masthead's side column next to this, never inside it. %>
+<% author_placement = local_assigns.fetch(:author_placement) { plan.author_placement } %>
 <div class="page-header page-header--plan" id="plan-header">
   <%= plan_type_icon(plan, size: :lg) %>
   <div class="page-header__text">
     <h1 class="page-header__title"><%= plan.title %></h1>
     <div class="page-header__byline text-sm text-muted">
       <%= user_avatar(plan.created_by_user) %> <%= profile_link(plan.created_by_user) %> · v<%= plan.current_revision %><%= plan_state_badge(plan) %>
+      <%= render "coplan/plans/location_link", plan: plan, placement: author_placement, location: :masthead %>
     </div>
   </div>
 </div>

--- a/engine/app/views/coplan/plans/_location_link.html.erb
+++ b/engine/app/views/coplan/plans/_location_link.html.erb
@@ -1,0 +1,19 @@
+<%# Go up from the document to its containing folder in the author's
+    library. An unfiled document goes to that library's root. %>
+<% unless plan.archived? %>
+  <% library = plan.created_by_user.library %>
+  <% folder = placement&.folder %>
+  <% label = folder ? "Up to containing folder — #{folder.path}" : "Up to #{plan.created_by_user.name}’s library" %>
+  <%= link_to library_path(library, folder: folder&.id),
+        class: "plan-location-link plan-location-link--#{location}",
+        title: label,
+        aria: { label: label },
+        tabindex: location == :nav ? -1 : nil,
+        data: { turbo_prefetch: true } do %>
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>
+      <path d="m14 13-2-2-2 2"/>
+      <path d="M12 11v6"/>
+    </svg>
+  <% end %>
+<% end %>

--- a/engine/app/views/coplan/plans/_nav_context.html.erb
+++ b/engine/app/views/coplan/plans/_nav_context.html.erb
@@ -1,0 +1,8 @@
+<% author_placement = local_assigns.fetch(:author_placement) { plan.author_placement } %>
+<span id="plan-nav-context" class="site-nav__plan-context" data-controller="coplan--nav-title" aria-hidden="true">
+  <%= render "coplan/plans/location_link", plan: plan, placement: author_placement, location: :nav %>
+  <a href="#plan-header" class="site-nav__doc-title" data-action="click->coplan--nav-title#scrollToTop" tabindex="-1">
+    <%= plan_type_icon(plan, size: :sm) %>
+    <span class="site-nav__doc-title-text"><%= plan.title %></span>
+  </a>
+</span>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -9,20 +9,23 @@
   <meta name="twitter:description" content="<%= plan_og_description(@plan) %>">
 <% end %>
 
+<% my_placement = current_user && @shelf_placements.find { |p| p.library.writable_by?(current_user) } %>
+<% reference_count = plan_reference_count(@plan, @references) %>
+
 <%# Fills the sticky nav's title slot (see layouts/coplan/application). The
-    icon + title mirror the masthead's #plan-header; coplan--nav-title fades
-    it in once that header scrolls behind the bar. %>
+    containing-folder control, icon, and title mirror the masthead;
+    coplan--nav-title fades them in once #plan-header scrolls behind the bar. %>
 <% content_for :nav_title do %>
-  <a href="#plan-header" class="site-nav__doc-title" data-controller="coplan--nav-title" data-action="click->coplan--nav-title#scrollToTop" aria-hidden="true" tabindex="-1">
-    <%= plan_type_icon(@plan, size: :sm) %>
-    <span class="site-nav__doc-title-text"><%= @plan.title %></span>
-  </a>
+  <span class="site-nav__plan-context" data-controller="coplan--nav-title" aria-hidden="true">
+    <%= render "coplan/plans/location_link", plan: @plan, placement: @author_placement, location: :nav %>
+    <a href="#plan-header" class="site-nav__doc-title" data-action="click->coplan--nav-title#scrollToTop" tabindex="-1">
+      <%= plan_type_icon(@plan, size: :sm) %>
+      <span class="site-nav__doc-title-text"><%= @plan.title %></span>
+    </a>
+  </span>
 <% end %>
 
 <%= turbo_stream_from @plan %>
-
-<% my_placement = current_user && @shelf_placements.find { |p| p.library.writable_by?(current_user) } %>
-<% reference_count = plan_reference_count(@plan, @references) %>
 
 <%# plan-keys: Backspace goes back to wherever you came from; [ / ] jump
     between the document and its footnote sections. Cold opens (direct link,
@@ -37,7 +40,7 @@
     broadcasts own the left, this request (and the visibility/archive
     stream responses) own the right, so neither can clobber the other. %>
 <div class="plan-masthead" data-controller="coplan--presence" data-coplan--presence-plan-id-value="<%= @plan.id %>" data-plan-section="top">
-  <%= render partial: "coplan/plans/header", locals: { plan: @plan } %>
+  <%= render partial: "coplan/plans/header", locals: { plan: @plan, author_placement: @author_placement } %>
   <div class="plan-masthead__side">
     <%= render partial: "coplan/plans/viewers", locals: { viewers: CoPlan::PlanViewer.active_viewers_for(@plan), current_user: current_user } %>
     <%= render partial: "coplan/plans/toolbar", locals: { plan: @plan, my_placement: my_placement } %>

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -16,13 +16,7 @@
     containing-folder control, icon, and title mirror the masthead;
     coplan--nav-title fades them in once #plan-header scrolls behind the bar. %>
 <% content_for :nav_title do %>
-  <span class="site-nav__plan-context" data-controller="coplan--nav-title" aria-hidden="true">
-    <%= render "coplan/plans/location_link", plan: @plan, placement: @author_placement, location: :nav %>
-    <a href="#plan-header" class="site-nav__doc-title" data-action="click->coplan--nav-title#scrollToTop" tabindex="-1">
-      <%= plan_type_icon(@plan, size: :sm) %>
-      <span class="site-nav__doc-title-text"><%= @plan.title %></span>
-    </a>
-  </span>
+  <%= render "coplan/plans/nav_context", plan: @plan, author_placement: @author_placement %>
 <% end %>
 
 <%= turbo_stream_from @plan %>

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe CoPlan::Plan, type: :model do
     expect(plan.current_content).to include("Plan Content")
   end
 
+  it "uses the author's own library placement as its containing location" do
+    author = create(:coplan_user)
+    viewer = create(:coplan_user)
+    plan = create(:plan, :published, created_by_user: author)
+    author_folder = create(:folder, created_by_user: author)
+    viewer_folder = create(:folder, created_by_user: viewer)
+    create(:plan_placement, plan: plan, folder: viewer_folder)
+    author_placement = create(:plan_placement, plan: plan, folder: author_folder)
+
+    expect(plan.author_placement).to eq(author_placement)
+  end
+
   # THE discovery predicate (mirrored by PlanPolicy#listed?). Everything a
   # user can be shown in a list routes through one of these two scopes.
   describe ".visible_to" do

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -1,26 +1,59 @@
 require "rails_helper"
 
-# Libraries are a data concept, not a destination: these routes exist so
-# old links keep working, and both redirect to the owner's profile — the
-# one place a person's library is browsed.
 RSpec.describe "Libraries", type: :request do
   let(:alice) { create(:coplan_user, username: "alice") }
 
   before { sign_in_as(alice) }
 
   describe "GET /library" do
-    it "redirects to the current user's profile by username" do
+    it "redirects to the current user's editable workspace" do
       get my_library_path
-      expect(response).to redirect_to(profile_path("alice"))
+      expect(response).to redirect_to(plans_path)
     end
-
   end
 
   describe "GET /libraries/:id" do
-    it "redirects a user-owned library to its owner's profile" do
+    it "redirects the owner to the matching folder in their workspace" do
+      folder = create(:folder, created_by_user: alice)
+
+      get library_path(alice.library, folder: folder.id)
+
+      expect(response).to redirect_to(plans_path(folder: folder.id))
+    end
+
+    it "browses another user's library one folder level at a time" do
       bob = create(:coplan_user, username: "bob")
-      get library_path(CoPlan::Library.for(bob))
-      expect(response).to redirect_to(profile_path("bob"))
+      projects = create(:folder, name: "Projects", created_by_user: bob)
+      launches = create(:folder, name: "Launches", parent: projects, created_by_user: bob)
+      filed = create(:plan, :published, title: "Filed launch", created_by_user: bob)
+      loose = create(:plan, :published, title: "Loose plan", created_by_user: bob)
+      private_plan = create(:plan, :draft, title: "Private draft", created_by_user: bob)
+      create(:plan_placement, plan: filed, folder: launches)
+      create(:plan_placement, plan: private_plan, folder: launches)
+
+      get library_path(bob.library)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Projects", "Loose plan")
+      expect(response.body).not_to include("Filed launch", "Private draft")
+
+      get library_path(bob.library, folder: projects.id)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Projects", "Launches")
+      expect(response.body).not_to include("Filed launch", "Loose plan")
+
+      get library_path(bob.library, folder: launches.id)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Projects", "Launches", "Filed launch")
+      expect(response.body).not_to include("Loose plan", "Private draft")
+    end
+
+    it "returns to the library root when the requested folder is gone" do
+      bob = create(:coplan_user)
+
+      get library_path(bob.library, folder: "missing")
+
+      expect(response).to redirect_to(library_path(bob.library))
+      expect(flash[:alert]).to eq("That folder no longer exists.")
     end
   end
 end

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe "Plans", type: :request do
     expect(response.body).to include("plan-layout__content")
   end
 
+  it "does not link archived plans to a library that omits them" do
+    archived_plan = create(:plan, :archived, created_by_user: alice)
+
+    get plan_path(archived_plan)
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).not_to include("plan-location-link")
+  end
+
   it "scopes comment footnote ids so they can't collide with the plan body's" do
     thread = create(:comment_thread, :with_anchor, plan: plan, plan_version: plan.current_plan_version, created_by_user: alice)
     comment = create(:comment, comment_thread: thread, author_type: "human", author_id: alice.id,

--- a/spec/system/folders_workspace_spec.rb
+++ b/spec/system/folders_workspace_spec.rb
@@ -73,6 +73,49 @@ RSpec.describe "Folders workspace", type: :system do
       expect(page).to have_current_path(plans_path(folder: q3.id))
     end
 
+    it "goes up to the plan's containing folder from the masthead and sticky nav" do
+      foldered_plan.current_plan_version.update!(
+        content_markdown: (1..30).map { |n| "## Section #{n}\n\nEnough content to scroll past the masthead." }.join("\n\n")
+      )
+      location_path = library_path(author.library, folder: q3.id)
+      workspace_destination = plans_path(folder: q3.id)
+
+      visit plan_path(foldered_plan)
+      masthead_location = find(".plan-location-link--masthead")
+      expect(masthead_location[:href]).to end_with(location_path)
+      expect(masthead_location["aria-label"]).to eq("Up to containing folder — Team EBT/Q3")
+      expect(masthead_location["data-turbo-prefetch"]).to eq("true")
+      masthead_location.click
+      expect(page).to have_current_path(workspace_destination)
+
+      visit plan_path(foldered_plan)
+      page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
+      expect(page).to have_css(".site-nav__plan-context--visible")
+      sticky_location = find(".plan-location-link--nav")
+      expect(sticky_location[:href]).to end_with(location_path)
+      expect(sticky_location["aria-label"]).to eq("Up to containing folder — Team EBT/Q3")
+      expect(sticky_location["data-turbo-prefetch"]).to eq("true")
+      sticky_location.click
+      expect(page).to have_current_path(workspace_destination)
+    end
+
+    it "opens the author's navigable folder when viewing someone else's plan" do
+      saved = create(:folder, name: "Saved by me", created_by_user: other)
+      CoPlan::Plans::Place.call(plan: foldered_plan, folder: saved, actor: other)
+      sign_in(other)
+      destination = library_path(author.library, folder: q3.id)
+
+      visit plan_path(foldered_plan)
+      location = find(".plan-location-link--masthead")
+      expect(location[:href]).to end_with(destination)
+      expect(location["aria-label"]).to eq("Up to containing folder — Team EBT/Q3")
+      location.click
+
+      expect(page).to have_current_path(destination)
+      expect(page).to have_css(".workspace-crumbs__crumb--current", text: "Q3")
+      expect(page).to have_link("Q3 Launch Plan")
+    end
+
     it "quietly flags private plans in the level view" do
       visit plans_path
       row = find(".plan-row[data-plan-id='#{brainstorm_plan.id}']")

--- a/spec/system/human_editing_spec.rb
+++ b/spec/system/human_editing_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "Human plan editing", type: :system do
 
   it "archives and restores the plan in place" do
     visit plan_path(plan)
+    expect(page).to have_css(".plan-location-link--nav", visible: :all)
 
     open_plan_menu
     within("#plan-menu") { click_button "Archive plan" }
@@ -117,6 +118,7 @@ RSpec.describe "Human plan editing", type: :system do
     # undo, no navigation away from the document.
     expect(page).to have_css(".plan-banner--archived", text: "hidden from lists")
     expect(page).to have_content("Editable Plan")
+    expect(page).not_to have_css(".plan-location-link", visible: :all)
     expect(plan.reload.archived?).to be(true)
 
     # Archive leaves the menu while archived.
@@ -126,6 +128,7 @@ RSpec.describe "Human plan editing", type: :system do
 
     within(".plan-banner--archived") { click_button "Restore" }
     expect(page).not_to have_css(".plan-banner--archived")
+    expect(page).to have_css(".plan-location-link--nav", visible: :all)
     expect(plan.reload.archived?).to be(false)
   end
 


### PR DESCRIPTION
## Why
Plans can be saved in multiple personal libraries, so readers need a compact, unambiguous way to go up to the author-chosen containing folder without losing title space or landing on a generic profile.

## What
- Add a compact folder-up control to the plan byline and sticky header with Turbo hover prefetch
- Add breadcrumb-based, read-only folder navigation for other users’ libraries while keeping owners in their editable workspace
- Preserve visibility boundaries and include unfiled authored plans at the library root

## Risk Assessment
Moderate — this changes plan chrome and existing library-route behavior, but the new browser is read-only, uses the existing visibility scope, and owners remain routed to their editable workspace.

Generated with Amp