### PR TITLE
Require a plan type on every plan, defaulting to General

### DIFF
--- a/db/migrate/20260817135827_require_plan_type_on_coplan_plans.co_plan.rb
+++ b/db/migrate/20260817135827_require_plan_type_on_coplan_plans.co_plan.rb
@@ -1,0 +1,40 @@
+# This migration comes from co_plan (originally 20260817000000)
+class RequirePlanTypeOnCoplanPlans < ActiveRecord::Migration[8.1]
+  # Untyped plans are no longer representable: backfill any strays onto the
+  # General catch-all (created by SeedGeneralPlanType, but recreated here in
+  # case a host deleted it while deletion still nullified plans), then
+  # enforce NOT NULL. Raw portable SQL, same reasoning as SeedGeneralPlanType:
+  # this must run identically on MySQL and PostgreSQL hosts.
+  def up
+    # select_value, not execute: raw execute result rows are arrays on
+    # mysql2 but hashes on pg, so indexing into them isn't portable.
+    general_id = connection.select_value("SELECT id FROM coplan_plan_types WHERE LOWER(name) = 'general' LIMIT 1")
+
+    unless general_id
+      general_id = SecureRandom.uuid_v7
+      execute <<~SQL
+        INSERT INTO coplan_plan_types (id, name, description, default_tags, template_content, metadata, created_at, updated_at)
+        VALUES (#{quote(general_id)}, 'General', 'General-purpose plan', '[]', NULL, '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      SQL
+    end
+
+    execute <<~SQL
+      UPDATE coplan_plans SET plan_type_id = #{quote(general_id)} WHERE plan_type_id IS NULL
+    SQL
+
+    # MySQL can't MODIFY a column that participates in a foreign key —
+    # drop the FK around the null change and put it back (a no-op dance on
+    # PostgreSQL, but portable).
+    had_fk = foreign_key_exists?(:coplan_plans, column: :plan_type_id)
+    remove_foreign_key :coplan_plans, column: :plan_type_id if had_fk
+    change_column_null :coplan_plans, :plan_type_id, false
+    add_foreign_key :coplan_plans, :coplan_plan_types, column: :plan_type_id if had_fk
+  end
+
+  def down
+    had_fk = foreign_key_exists?(:coplan_plans, column: :plan_type_id)
+    remove_foreign_key :coplan_plans, column: :plan_type_id if had_fk
+    change_column_null :coplan_plans, :plan_type_id, true
+    add_foreign_key :coplan_plans, :coplan_plan_types, column: :plan_type_id if had_fk
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_180709) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_135827) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -326,7 +326,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_180709) do
     t.string "current_plan_version_id", limit: 36
     t.integer "current_revision", default: 0, null: false
     t.json "metadata"
-    t.string "plan_type_id", limit: 36
+    t.string "plan_type_id", limit: 36, null: false
     t.text "search_text", size: :medium
     t.text "summary"
     t.string "summary_content_sha256", limit: 64

--- a/engine/app/helpers/coplan/plans_helper.rb
+++ b/engine/app/helpers/coplan/plans_helper.rb
@@ -62,23 +62,21 @@ module CoPlan
     # The document's file icon — a colored rounded square with the type's
     # glyph, like a Drive/Finder file icon. Leads the title in rows, the
     # plan header, feed items, and search results; the type's name lives in
-    # the tooltip so it never reads as a tag. Untyped plans get the neutral
-    # document glyph. Safe in broadcast partials (derives from the plan
-    # alone, no current_user).
+    # the tooltip so it never reads as a tag. Every plan has a type (the
+    # untyped fallback defaults to General at create). Safe in broadcast
+    # partials (derives from the plan alone, no current_user).
     def plan_type_icon(plan, size: :md)
       plan_type = plan.plan_type
-      paths = PLAN_TYPE_ICONS[plan_type&.icon] || PLAN_TYPE_ICONS["file-text"]
+      paths = PLAN_TYPE_ICONS[plan_type.icon] || PLAN_TYPE_ICONS["file-text"]
       # Stable per-name tint (Zlib.crc32, not #hash — that differs across
       # processes) so a type keeps its color everywhere, every request.
-      tint = plan_type ? Zlib.crc32(plan_type.name) % PLAN_TYPE_COLOR_COUNT : nil
+      tint = Zlib.crc32(plan_type.name) % PLAN_TYPE_COLOR_COUNT
       glyph = %(<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">#{paths}</svg>).html_safe
 
-      classes = [ "plan-type-icon", "plan-type-icon--#{size}" ]
-      classes << "plan-type-icon--#{tint}" if tint
       content_tag(:span, glyph,
-        class: classes.join(" "),
-        title: plan_type&.name,
-        aria: { label: plan_type ? "#{plan_type.name} document" : "Document" })
+        class: "plan-type-icon plan-type-icon--#{size} plan-type-icon--#{tint}",
+        title: plan_type.name,
+        aria: { label: "#{plan_type.name} document" })
     end
 
     def plan_content_preview(plan, limit: 200)

--- a/engine/app/models/coplan/plan.rb
+++ b/engine/app/models/coplan/plan.rb
@@ -26,7 +26,7 @@ module CoPlan
     # MEDIUMTEXT content, diffs, and operation logs out of MySQL per row.
     belongs_to :current_version_stub, -> { select(:id, :content_sha256) },
       class_name: "PlanVersion", foreign_key: :current_plan_version_id, optional: true
-    belongs_to :plan_type, optional: true
+    belongs_to :plan_type
     has_many :placements, class_name: "CoPlan::PlanPlacement", inverse_of: :plan, dependent: :destroy
     has_many :libraries, through: :placements
     has_many :plan_versions, -> { order(revision: :asc) }, dependent: :destroy
@@ -45,6 +45,12 @@ module CoPlan
     has_many_attached :attachments
 
     after_initialize { self.metadata ||= {} }
+
+    # Every plan has a type (belongs_to above + NOT NULL in the schema).
+    # Callers that don't pick one get the General catch-all, so creation
+    # paths — API, services, direct creates — stay type-optional while
+    # untyped rows stay unrepresentable.
+    before_validation :assign_default_plan_type, on: :create
 
     validates :title, presence: true
     validates :visibility, presence: true, inclusion: { in: VISIBILITIES }
@@ -249,6 +255,10 @@ module CoPlan
     end
 
     private
+
+    def assign_default_plan_type
+      self.plan_type ||= PlanType.general
+    end
 
     # Backstop validation for attachment size/type. The primary check lives in
     # Plans::AddAttachment (which can reject before a blob is even created),

--- a/engine/app/models/coplan/plan_type.rb
+++ b/engine/app/models/coplan/plan_type.rb
@@ -1,6 +1,11 @@
 module CoPlan
   class PlanType < ApplicationRecord
-    has_many :plans, dependent: :nullify
+    GENERAL_NAME = "General"
+
+    # Every plan must have a type, so a type with plans can't be deleted —
+    # nullify would mint invalid (and, at the DB level, unstorable) plans.
+    # Reassign the plans first, then delete.
+    has_many :plans, dependent: :restrict_with_error
 
     after_initialize { self.default_tags ||= [] }
     after_initialize { self.metadata ||= {} }
@@ -16,6 +21,17 @@ module CoPlan
     # database. All name-based plan-type resolution must go through here.
     def self.find_by_name(name)
       where("LOWER(name) = ?", name.to_s.downcase).first
+    end
+
+    # The catch-all type every untyped create falls back to (see
+    # Plan#assign_default_plan_type). The RequirePlanTypeOnCoplanPlans
+    # migration guarantees it exists in any migrated database, so the
+    # create! branch only runs in fresh test databases.
+    def self.general
+      find_by_name(GENERAL_NAME) || create!(name: GENERAL_NAME, description: "General-purpose plan")
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      # Lost a race with a concurrent create — the row exists now.
+      find_by_name(GENERAL_NAME)
     end
 
     def self.ransackable_attributes(auth_object = nil)

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -57,7 +57,7 @@ Returns: plan metadata, `current_content`, `current_revision`, `comment_threads`
   "<%= @base %>/api/v1/plans" | jq .
 ```
 
-Optional fields: `plan_type` (string) — the name of a plan type to use (see [Plan Types](#plan-types) below); `visibility` (string) — plans are **shared with the whole org by default**; `"draft"` (shown as "private" in the UI) exists as a rare escape hatch, not a normal step (see [Visibility &amp; Archiving](#visibility--archiving)).
+Optional fields: `plan_type` (string) — the name of a plan type to use; every plan has a type, so omitting this files the plan under the **General** catch-all (see [Plan Types](#plan-types) below); `visibility` (string) — plans are **shared with the whole org by default**; `"draft"` (shown as "private" in the UI) exists as a rare escape hatch, not a normal step (see [Visibility &amp; Archiving](#visibility--archiving)).
 
 #### Diagrams
 
@@ -200,7 +200,7 @@ The API also accepts the legacy `status` field (`brainstorm`/`considering`/`deve
 
 ### Plan Types
 
-Plan types categorize plans and provide default tags. When creating a plan, pass `plan_type` to associate it with a type.
+Plan types categorize plans and provide default tags. Every plan has exactly one type. When creating a plan, pass `plan_type` to pick one — plans created without an explicit type get **General**.
 <% if @plan_types.any? %>
 
 **Available plan types:**

--- a/engine/db/migrate/20260817000000_require_plan_type_on_coplan_plans.rb
+++ b/engine/db/migrate/20260817000000_require_plan_type_on_coplan_plans.rb
@@ -1,0 +1,39 @@
+class RequirePlanTypeOnCoplanPlans < ActiveRecord::Migration[8.1]
+  # Untyped plans are no longer representable: backfill any strays onto the
+  # General catch-all (created by SeedGeneralPlanType, but recreated here in
+  # case a host deleted it while deletion still nullified plans), then
+  # enforce NOT NULL. Raw portable SQL, same reasoning as SeedGeneralPlanType:
+  # this must run identically on MySQL and PostgreSQL hosts.
+  def up
+    # select_value, not execute: raw execute result rows are arrays on
+    # mysql2 but hashes on pg, so indexing into them isn't portable.
+    general_id = connection.select_value("SELECT id FROM coplan_plan_types WHERE LOWER(name) = 'general' LIMIT 1")
+
+    unless general_id
+      general_id = SecureRandom.uuid_v7
+      execute <<~SQL
+        INSERT INTO coplan_plan_types (id, name, description, default_tags, template_content, metadata, created_at, updated_at)
+        VALUES (#{quote(general_id)}, 'General', 'General-purpose plan', '[]', NULL, '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      SQL
+    end
+
+    execute <<~SQL
+      UPDATE coplan_plans SET plan_type_id = #{quote(general_id)} WHERE plan_type_id IS NULL
+    SQL
+
+    # MySQL can't MODIFY a column that participates in a foreign key —
+    # drop the FK around the null change and put it back (a no-op dance on
+    # PostgreSQL, but portable).
+    had_fk = foreign_key_exists?(:coplan_plans, column: :plan_type_id)
+    remove_foreign_key :coplan_plans, column: :plan_type_id if had_fk
+    change_column_null :coplan_plans, :plan_type_id, false
+    add_foreign_key :coplan_plans, :coplan_plan_types, column: :plan_type_id if had_fk
+  end
+
+  def down
+    had_fk = foreign_key_exists?(:coplan_plans, column: :plan_type_id)
+    remove_foreign_key :coplan_plans, column: :plan_type_id if had_fk
+    change_column_null :coplan_plans, :plan_type_id, true
+    add_foreign_key :coplan_plans, :coplan_plan_types, column: :plan_type_id if had_fk
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe CoPlan::ApplicationHelper, type: :helper do
       plan.update_columns(current_plan_version_id: nil)
       plan.reload
       result = helper.plan_og_description(plan)
-      # Published is the unmarked state, so with no type and no content the
-      # context is just the author.
-      expect(result).to eq("by #{plan.created_by_user.name}")
+      # Published is the unmarked state, and every plan carries a type
+      # (General by default), so with no content the context is type + author.
+      expect(result).to eq("General · by #{plan.created_by_user.name}")
     end
 
     it "truncates long content" do

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -23,6 +23,29 @@ RSpec.describe CoPlan::Plan, type: :model do
     expect(plan.visibility).to eq("published")
   end
 
+  # Untyped plans are unrepresentable: belongs_to presence + NOT NULL in
+  # the schema. Creation stays type-optional — the General catch-all fills
+  # in — so no caller is forced to pick a type.
+  describe "plan type requirement" do
+    it "defaults to the General type when created without one" do
+      plan = create(:plan)
+      expect(plan.plan_type.name).to eq("General")
+    end
+
+    it "keeps an explicitly chosen type" do
+      rfc = create(:plan_type, name: "RFC")
+      plan = create(:plan, plan_type: rfc)
+      expect(plan.plan_type).to eq(rfc)
+    end
+
+    it "cannot have its type cleared after creation" do
+      plan = create(:plan)
+      plan.plan_type = nil
+      expect(plan).not_to be_valid
+      expect(plan.errors[:plan_type]).to be_present
+    end
+  end
+
   it "returns current content from version" do
     plan = create(:plan)
     expect(plan.current_content).to include("Plan Content")
@@ -134,7 +157,7 @@ RSpec.describe CoPlan::Plan, type: :model do
 
     after do
       truncate_tables(*%w[coplan_plan_tags coplan_tags coplan_plan_versions coplan_plans
-                          coplan_search_queries coplan_users])
+                          coplan_plan_types coplan_search_queries coplan_users])
     end
 
     let!(:author) { create(:coplan_user, name: "Tessa Engineer") }

--- a/spec/models/plan_type_spec.rb
+++ b/spec/models/plan_type_spec.rb
@@ -56,10 +56,33 @@ RSpec.describe CoPlan::PlanType, type: :model do
     expect(plan_type.plans).to include(plan)
   end
 
-  it "nullifies plans when destroyed" do
+  it "cannot be destroyed while plans use it — nullify would mint untyped plans" do
     plan_type = create(:plan_type)
     plan = create(:plan, plan_type: plan_type)
-    plan_type.destroy!
-    expect(plan.reload.plan_type_id).to be_nil
+
+    expect(plan_type.destroy).to be(false)
+    expect(plan_type.errors[:base]).to be_present
+    expect(plan.reload.plan_type_id).to eq(plan_type.id)
+  end
+
+  it "can be destroyed once no plans use it" do
+    plan_type = create(:plan_type)
+    expect { plan_type.destroy! }.to change(CoPlan::PlanType, :count).by(-1)
+  end
+
+  describe ".general" do
+    it "returns the existing General type, matched case-insensitively" do
+      existing = create(:plan_type, name: "general")
+      expect(CoPlan::PlanType.general).to eq(existing)
+    end
+
+    it "recreates the General type when missing" do
+      # A migrated database always has General (RequirePlanTypeOnCoplanPlans
+      # seeds it) — remove it to exercise the self-healing branch.
+      CoPlan::PlanType.find_by_name("General")&.destroy!
+      general = CoPlan::PlanType.general
+      expect(general.name).to eq("General")
+      expect(general).to be_persisted
+    end
   end
 end

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe "Api::V1::Plans", type: :request do
     expect(body["current_revision"]).to eq(1)
   end
 
+  it "create without plan_type files the plan under the General catch-all" do
+    post api_v1_plans_path, params: { title: "Untyped Plan", content: "# Untyped" }, headers: headers, as: :json
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    expect(body["plan_type_name"]).to eq("General")
+  end
+
   it "create with plan_type by name" do
     plan_type = create(:plan_type, name: "design-doc")
     post api_v1_plans_path, params: { title: "Typed Plan", content: "# Typed", plan_type: "design-doc" }, headers: headers, as: :json

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -393,11 +393,12 @@ RSpec.describe "Plans", type: :request do
       expect(response.body).to include('title="Mystery Type"')
     end
 
-    it "renders a neutral, untinted document icon for untyped plans" do
+    it "renders the General type icon for plans created without an explicit type" do
       create(:plan, :published, created_by_user: alice, plan_type: nil)
       get plans_path
-      expect(response.body).to include('aria-label="Document"')
-      expect(response.body).not_to match(/plan-type-icon--\d/)
+      expect(response.body).to include('aria-label="General document"')
+      tint = Zlib.crc32("General") % CoPlan::PlansHelper::PLAN_TYPE_COLOR_COUNT
+      expect(response.body).to include("plan-type-icon--#{tint}")
     end
   end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Search (COPLAN-21)", type: :request do
 
   after do
     truncate_tables(*%w[coplan_plan_tags coplan_tags coplan_plan_versions coplan_plans
-                        coplan_search_queries coplan_users])
+                        coplan_plan_types coplan_search_queries coplan_users])
   end
 
   let!(:alice) { create(:coplan_user, name: "Alice Searcher") }

--- a/spec/services/plans/create_spec.rb
+++ b/spec/services/plans/create_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CoPlan::Plans::Create do
     expect(plan.plan_type).to eq(plan_type)
   end
 
-  it "creates plan without plan_type" do
+  it "creates plan without plan_type, falling back to the General catch-all" do
     user = create(:coplan_user)
     plan = CoPlan::Plans::Create.call(
       title: "Untyped Plan",
@@ -47,7 +47,7 @@ RSpec.describe CoPlan::Plans::Create do
     )
 
     expect(plan).to be_persisted
-    expect(plan.plan_type_id).to be_nil
+    expect(plan.plan_type.name).to eq("General")
   end
 
   it "tracks a plan_created analytics event" do


### PR DESCRIPTION
## Why
Untyped plans render inconsistently and complicate every consumer that has to handle a nil type. Every plan should carry exactly one type.

## What
- `Plan` requires `plan_type`; creation without one defaults to the **General** catch-all via `before_validation`, so the API, services, and direct creates stay compatible
- Migration backfills stray null `plan_type_id` rows onto General and enforces `NOT NULL` (drops/re-adds the FK around the change for MySQL, portable to PostgreSQL)
- `PlanType` deletion now restricts when plans reference it (nullify would mint unstorable rows); `PlanType.general` is a race-safe find-or-create
- Simplified `plan_type_icon` by removing the now-unreachable untyped branch; API agent instructions document the General default
- Non-transactional FULLTEXT search specs now truncate `coplan_plan_types` — plan creation there commits a real General row that transactional rollback can't clean up

## Risk Assessment
Medium — a schema constraint change on the core `coplan_plans` table, but the migration backfills before enforcing and the default keeps all creation paths working unchanged. Full suite green (1433 examples) and migration up/down/up roundtrip verified.

Generated with [Amp](https://ampcode.com)