### PR TITLE
Complete agent attribution coverage

### DIFF
--- a/db/migrate/20260815174516_add_agent_provenance_to_library_events.co_plan.rb
+++ b/db/migrate/20260815174516_add_agent_provenance_to_library_events.co_plan.rb
@@ -1,0 +1,8 @@
+class AddAgentProvenanceToLibraryEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :coplan_library_events, :agent_name, :string
+    add_column :coplan_library_events, :api_token_id, :string, limit: 36
+    add_index :coplan_library_events, :api_token_id
+    add_foreign_key :coplan_library_events, :coplan_api_tokens, column: :api_token_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -196,6 +196,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_135827) do
     t.string "actor_id", limit: 36
     t.string "actor_type", null: false
     t.text "after_value"
+    t.string "agent_name"
+    t.string "api_token_id", limit: 36
     t.text "before_value"
     t.datetime "created_at", null: false
     t.string "event_type", null: false
@@ -204,6 +206,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_135827) do
     t.json "metadata"
     t.string "plan_id", limit: 36
     t.string "run_id", limit: 36
+    t.index ["api_token_id"], name: "index_coplan_library_events_on_api_token_id"
     t.index ["event_type"], name: "index_coplan_library_events_on_event_type"
     t.index ["library_id", "created_at"], name: "index_coplan_library_events_on_library_id_and_created_at"
     t.index ["plan_id"], name: "index_coplan_library_events_on_plan_id"
@@ -441,6 +444,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_135827) do
   add_foreign_key "coplan_folders", "coplan_folders", column: "parent_id"
   add_foreign_key "coplan_folders", "coplan_libraries", column: "library_id"
   add_foreign_key "coplan_folders", "coplan_users", column: "created_by_user_id"
+  add_foreign_key "coplan_library_events", "coplan_api_tokens", column: "api_token_id"
   add_foreign_key "coplan_library_events", "coplan_libraries", column: "library_id"
   add_foreign_key "coplan_notifications", "coplan_comment_threads", column: "comment_thread_id"
   add_foreign_key "coplan_notifications", "coplan_comments", column: "comment_id"

--- a/engine/app/controllers/coplan/api/v1/comments_controller.rb
+++ b/engine/app/controllers/coplan/api/v1/comments_controller.rb
@@ -104,7 +104,14 @@ module CoPlan
             return
           end
 
-          Comments::SoftDelete.call(comment: comment, actor: current_user)
+          Comments::SoftDelete.call(
+            comment: comment,
+            actor: current_user,
+            actor_type: api_author_type,
+            actor_id: api_user_id,
+            agent_name: api_agent_name,
+            api_token_id: api_token_id
+          )
 
           thread = comment.comment_thread
           if thread.reload.empty?

--- a/engine/app/controllers/coplan/api/v1/folders_controller.rb
+++ b/engine/app/controllers/coplan/api/v1/folders_controller.rb
@@ -48,7 +48,7 @@ module CoPlan
             created_by_user: current_user
           )
           Libraries::LogEvent.call(
-            library: library, actor: current_user, actor_type: api_author_type,
+            library: library, actor: current_user, **library_event_identity,
             event_type: "folder_created", folder: folder, after: folder.path
           )
           render json: folder_json(folder), status: :created
@@ -93,7 +93,7 @@ module CoPlan
           path = @folder.path
           if @folder.destroy
             Libraries::LogEvent.call(
-              library: @folder.library, actor: current_user, actor_type: api_author_type,
+              library: @folder.library, actor: current_user, **library_event_identity,
               event_type: "folder_deleted", before: path,
               metadata: { folder_name: @folder.name }
             )
@@ -117,24 +117,32 @@ module CoPlan
           new_path = @folder.path
           if @folder.saved_change_to_name?
             Libraries::LogEvent.call(
-              library: @folder.library, actor: current_user, actor_type: api_author_type,
+              library: @folder.library, actor: current_user, **library_event_identity,
               event_type: "folder_renamed", folder: @folder, before: old_path, after: new_path
             )
           end
           if @folder.saved_change_to_parent_id?
             Libraries::LogEvent.call(
-              library: @folder.library, actor: current_user, actor_type: api_author_type,
+              library: @folder.library, actor: current_user, **library_event_identity,
               event_type: "folder_moved", folder: @folder, before: old_path, after: new_path
             )
           end
           if @folder.saved_change_to_description?
             Libraries::LogEvent.call(
-              library: @folder.library, actor: current_user, actor_type: api_author_type,
+              library: @folder.library, actor: current_user, **library_event_identity,
               event_type: "folder_described", folder: @folder,
               before: old_description, after: @folder.description,
               metadata: { path: new_path }
             )
           end
+        end
+
+        def library_event_identity
+          {
+            actor_type: api_author_type,
+            agent_name: api_agent_name,
+            api_token_id: api_token_id
+          }
         end
 
         # `paths` and `counts` let index serialize the whole tree without

--- a/engine/app/controllers/coplan/api/v1/libraries_controller.rb
+++ b/engine/app/controllers/coplan/api/v1/libraries_controller.rb
@@ -243,6 +243,8 @@ module CoPlan
             actor_type: event.actor_type,
             agent: event.actor_type != "human",
             actor: event.actor_user && { id: event.actor_user.id, name: event.actor_user.name },
+            agent_name: event.agent_name,
+            api_token_id: event.api_token_id,
             actor_label: event.metadata["actor_label"],
             run_id: event.run_id,
             plan_id: event.plan_id,

--- a/engine/app/controllers/coplan/api/v1/plans_controller.rb
+++ b/engine/app/controllers/coplan/api/v1/plans_controller.rb
@@ -327,6 +327,7 @@ module CoPlan
             created.each do |f|
               Libraries::LogEvent.call(
                 library: current_user.library, actor: current_user, actor_type: api_author_type,
+                agent_name: api_agent_name, api_token_id: api_token_id,
                 event_type: "folder_created", folder: f, after: f.path
               )
             end

--- a/engine/app/models/coplan/comment.rb
+++ b/engine/app/models/coplan/comment.rb
@@ -3,6 +3,7 @@ module CoPlan
     AUTHOR_TYPES = %w[human local_agent cloud_persona system].freeze
 
     belongs_to :comment_thread
+    belongs_to :api_token, class_name: "CoPlan::ApiToken", optional: true
 
     validates :body_markdown, presence: true
     validates :author_type, presence: true, inclusion: { in: AUTHOR_TYPES }

--- a/engine/app/models/coplan/library_event.rb
+++ b/engine/app/models/coplan/library_event.rb
@@ -28,20 +28,22 @@ module CoPlan
 
     belongs_to :library, class_name: "CoPlan::Library", inverse_of: :library_events
     belongs_to :actor_user, class_name: "CoPlan::User", foreign_key: "actor_id", optional: true
+    belongs_to :api_token, class_name: "CoPlan::ApiToken", optional: true
 
     after_initialize { self.metadata ||= {} }
 
     validates :actor_type, presence: true, inclusion: { in: ACTOR_TYPES }
     validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
+    validates :agent_name, length: { maximum: ApiToken::AGENT_NAME_LIMIT }, allow_nil: true
 
     scope :recent_first, -> { order(created_at: :desc, id: :desc) }
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[id library_id actor_id actor_type event_type plan_id folder_id run_id before_value after_value created_at]
+      %w[id library_id actor_id actor_type agent_name api_token_id event_type plan_id folder_id run_id before_value after_value created_at]
     end
 
     def self.ransackable_associations(_auth_object = nil)
-      %w[library actor_user]
+      %w[library actor_user api_token]
     end
   end
 end

--- a/engine/app/models/coplan/plan_event.rb
+++ b/engine/app/models/coplan/plan_event.rb
@@ -37,6 +37,7 @@ module CoPlan
 
     belongs_to :plan
     belongs_to :actor_user, class_name: "CoPlan::User", foreign_key: "actor_id", optional: true
+    belongs_to :api_token, class_name: "CoPlan::ApiToken", optional: true
 
     after_initialize { self.metadata ||= {} }
 
@@ -49,11 +50,11 @@ module CoPlan
     scope :for_history, -> { order(created_at: :desc) }
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w[id plan_id actor_id actor_type event_type field before_value after_value created_at]
+      %w[id plan_id actor_id actor_type agent_name api_token_id event_type field before_value after_value created_at]
     end
 
     def self.ransackable_associations(_auth_object = nil)
-      %w[plan actor_user]
+      %w[plan actor_user api_token]
     end
 
     # Marker so history rendering can branch on the kind of item without

--- a/engine/app/models/coplan/plan_version.rb
+++ b/engine/app/models/coplan/plan_version.rb
@@ -4,6 +4,7 @@ module CoPlan
 
     belongs_to :plan
     belongs_to :actor_user, class_name: "CoPlan::User", foreign_key: "actor_id", optional: true
+    belongs_to :api_token, class_name: "CoPlan::ApiToken", optional: true
     has_many :comment_threads, dependent: :nullify
 
     # has_attribute? guard: list pages load lean stubs (id + sha only) via

--- a/engine/app/services/coplan/comments/soft_delete.rb
+++ b/engine/app/services/coplan/comments/soft_delete.rb
@@ -11,9 +11,13 @@ module CoPlan
         new(**kwargs).call
       end
 
-      def initialize(comment:, actor:)
+      def initialize(comment:, actor:, actor_type: nil, actor_id: nil, agent_name: nil, api_token_id: nil)
         @comment = comment
         @actor = actor
+        @actor_type = actor_type
+        @actor_id = actor_id
+        @agent_name = agent_name
+        @api_token_id = api_token_id
       end
 
       def call
@@ -24,6 +28,10 @@ module CoPlan
           Plans::LogEvent.call(
             plan: @comment.comment_thread.plan,
             actor: @actor,
+            actor_type: @actor_type,
+            actor_id: @actor_id,
+            agent_name: @agent_name,
+            api_token_id: @api_token_id,
             event_type: "comment_deleted",
             metadata: {
               comment_id: @comment.id,

--- a/engine/app/services/coplan/libraries/log_event.rb
+++ b/engine/app/services/coplan/libraries/log_event.rb
@@ -15,7 +15,8 @@ module CoPlan
       end
 
       def initialize(library:, actor:, event_type:, plan: nil, folder: nil,
-        before: nil, after: nil, metadata: {}, actor_type: nil, run_id: nil)
+        before: nil, after: nil, metadata: {}, actor_type: nil, agent_name: nil,
+        api_token_id: nil, run_id: nil)
         @library = library
         @actor = actor
         @event_type = event_type.to_s
@@ -25,6 +26,8 @@ module CoPlan
         @after = after&.to_s
         @metadata = metadata || {}
         @actor_type_override = actor_type&.to_s
+        @agent_name = agent_name
+        @api_token_id = api_token_id
         @run_id = run_id
       end
 
@@ -33,6 +36,8 @@ module CoPlan
           library: @library,
           actor_id: @actor&.id,
           actor_type: actor_type,
+          agent_name: @agent_name,
+          api_token_id: @api_token_id,
           event_type: @event_type,
           plan_id: @plan&.id,
           folder_id: @folder&.id,

--- a/engine/app/services/coplan/libraries/organize.rb
+++ b/engine/app/services/coplan/libraries/organize.rb
@@ -302,6 +302,7 @@ module CoPlan
         metadata = kwargs.delete(:metadata) || {}
         Libraries::LogEvent.call(
           library: @library, actor: @actor, actor_type: @actor_type,
+          agent_name: @agent_name, api_token_id: @api_token_id,
           run_id: @run_id, metadata: event_metadata.merge(metadata), **kwargs
         )
       end

--- a/engine/app/services/coplan/plans/place.rb
+++ b/engine/app/services/coplan/plans/place.rb
@@ -98,6 +98,8 @@ module CoPlan
           library: @library,
           actor: @actor,
           actor_type: @actor_type,
+          agent_name: @agent_name,
+          api_token_id: @api_token_id,
           event_type: library_event_type(old_path, new_path),
           plan: @plan,
           folder: @folder,

--- a/engine/db/migrate/20260815000003_add_agent_provenance_to_library_events.rb
+++ b/engine/db/migrate/20260815000003_add_agent_provenance_to_library_events.rb
@@ -1,0 +1,8 @@
+class AddAgentProvenanceToLibraryEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :coplan_library_events, :agent_name, :string
+    add_column :coplan_library_events, :api_token_id, :string, limit: 36
+    add_index :coplan_library_events, :api_token_id
+    add_foreign_key :coplan_library_events, :coplan_api_tokens, column: :api_token_id
+  end
+end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -155,6 +155,14 @@ RSpec.describe "Api::V1::Comments", type: :request do
       delete api_v1_plan_destroy_comment_path(plan, id: comment.id), headers: headers, as: :json
       expect(response).to have_http_status(:ok)
       expect(comment.reload.deleted_at).to be_present
+
+      event = plan.plan_events.find_by!(event_type: "comment_deleted")
+      expect(event).to have_attributes(
+        actor_type: "local_agent",
+        actor_id: alice.id,
+        agent_name: alice_token.name,
+        api_token_id: alice_token.id
+      )
     end
 
     it "forbids agent (token auth) callers from deleting their own agent comment" do

--- a/spec/requests/api/v1/folders_spec.rb
+++ b/spec/requests/api/v1/folders_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe "Api::V1::Folders", type: :request do
       expect(json["name"]).to eq("Infra")
       expect(json["parent_id"]).to be_nil
       expect(CoPlan::Folder.find(json["id"]).created_by_user).to eq(alice)
+
+      event = alice.library.library_events.find_by!(event_type: "folder_created")
+      expect(event).to have_attributes(
+        actor_type: "local_agent",
+        actor_id: alice.id,
+        agent_name: alice_token.name,
+        api_token_id: alice_token.id
+      )
     end
 
     it "creates a nested folder" do

--- a/spec/requests/api/v1/libraries_spec.rb
+++ b/spec/requests/api/v1/libraries_spec.rb
@@ -178,6 +178,8 @@ RSpec.describe "Api::V1::Libraries", type: :request do
       expect(events.map(&:event_type)).to include("folder_created", "folder_described", "plan_filed")
       # Token auth means the agent gets attributed, not a human.
       expect(events.map(&:actor_type).uniq).to eq([ "local_agent" ])
+      expect(events.map(&:agent_name).uniq).to eq([ alice_token.name ])
+      expect(events.map(&:api_token_id).uniq).to eq([ alice_token.id ])
       filed = events.find_by(event_type: "plan_filed")
       expect(filed.after_value).to eq("Archive/2025")
       expect(filed.metadata["plan_title"]).to eq("Pricing plan")


### PR DESCRIPTION
## Why

PR #178 attributed agent-created content, plan events, and comments, but two API audit paths still lost full agent identity: comment deletion events and library/folder events.

## What

- Persist agent name and API-token provenance on library events
- Carry agent attribution through folder CRUD, bulk organization, plan placement, and comment deletion
- Add direct provenance associations and expose library-event identity through the API
- Add request coverage for each previously missing path

## Risk Assessment

Low — this extends nullable audit metadata and leaves human/web attribution behavior unchanged.

## Testing

- Full suite: 1,485 examples, 0 failures
- Focused attribution suite: 59 examples, 0 failures
- RuboCop: 15 files, no offenses

Generated with Amp