### PR TITLE
Resolved threads stop nagging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,16 @@ reader to an apparently empty page.
 - `agent_response` and `status_change` don't notify at all on an
   already-closed thread (`Notifications::Create::SILENT_ON_CLOSED_THREAD`);
   human replies and mentions still do
+- Opening a plan clears that plan's unread rows for the viewer
+  (`Notifications::MarkPlanRead`) — you looked, so the nudge is done. The
+  "you looked" signal is `PlanPresenceChannel#subscribed`, not the GET:
+  workspace rows prefetch on hover, and Turbo serves the click from its
+  prefetch cache without asking the server again. `PlansController#show`
+  does it too, but skips `X-Sec-Purpose: prefetch` requests — which is also
+  what keeps a hover from burning the changed-section highlights
 - The workspace "Needs attention" strip is `Notifications::NeedsAttention`,
-  and each row can be dismissed without reading via
-  `NotificationsController#mark_plan_read`
+  and each row has a ✕ that clears the same plan without opening it
+  (`NotificationsController#mark_plan_read`, same service)
 
 ### Inline review UI
 - **Highlights**: anchored text is wrapped in `<mark>` elements — amber for `pending`, blue for `todo`, unstyled for `resolved`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,19 @@ The comment system is central to the collaboration workflow. Domain experts leav
 - Author marks completed work: **Resolve** (`todo → resolved`)
 - Resolved/discarded threads can be **Reopened** back to `pending`
 
+### Notifications follow the thread
+A closed thread (`resolved`/`discarded`) carries no unread inbox rows — its
+highlight is hidden in the doc view, so a row pointing at it would send the
+reader to an apparently empty page.
+- Closing a thread sweeps its unread notifications read (`CommentThread`
+  `after_commit` → `Notifications::MarkThreadRead`)
+- `agent_response` and `status_change` don't notify at all on an
+  already-closed thread (`Notifications::Create::SILENT_ON_CLOSED_THREAD`);
+  human replies and mentions still do
+- The workspace "Needs attention" strip is `Notifications::NeedsAttention`,
+  and each row can be dismissed without reading via
+  `NotificationsController#mark_plan_read`
+
 ### Inline review UI
 - **Highlights**: anchored text is wrapped in `<mark>` elements — amber for `pending`, blue for `todo`, unstyled for `resolved`
 - **Margin dots**: colored indicators in the left margin aligned to each highlight's vertical position

--- a/db/migrate/20260819144056_mark_closed_thread_notifications_read.co_plan.rb
+++ b/db/migrate/20260819144056_mark_closed_thread_notifications_read.co_plan.rb
@@ -1,0 +1,29 @@
+# This migration comes from co_plan (originally 20260819000000)
+class MarkClosedThreadNotificationsRead < ActiveRecord::Migration[8.1]
+  # Clears the accumulated inbox rows that point at resolved or discarded
+  # threads. These are the pile behind "20 unread comments" on a plan whose
+  # comments are all settled — the doc view hides a closed thread's
+  # highlight, so the rows sent readers to an apparently empty page.
+  #
+  # Pairs with the behaviour change: closing a thread now sweeps its rows
+  # read (CommentThread#mark_notifications_read_if_closed), and agent
+  # replies / status changes on an already-closed thread don't notify at
+  # all (Notifications::Create::SILENT_ON_CLOSED_THREAD).
+  #
+  # Idempotent: already-read rows don't match the unread scope. Rows stay
+  # in the inbox history — only their unread flag changes.
+  def up
+    closed_thread_ids = CoPlan::CommentThread
+      .where(status: CoPlan::CommentThread::CLOSED_STATUSES)
+      .select(:id)
+
+    CoPlan::Notification.unread
+      .where(comment_thread_id: closed_thread_ids)
+      .update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    # no-op (not reversible — the original read_at values were nil, but
+    # re-marking them unread would resurrect exactly the noise this cleared)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_135827) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_144056) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -5624,19 +5624,26 @@ img.avatar {
   margin-left: auto;
 }
 
+/* A quiet ✕, matching the filter chips: the row already says what it is,
+   so the dismiss doesn't need a word. Padding buys a real hit area
+   without taking visual weight. */
 .attention__clear {
-  padding: 0;
+  flex-shrink: 0;
+  padding: 2px 6px;
   border: 0;
+  border-radius: var(--radius);
   background: none;
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--text-sm);
+  line-height: 1;
   font-family: inherit;
   cursor: pointer;
+  transition: color 0.15s, background 0.15s;
 }
 
 .attention__clear:hover {
   color: var(--color-text);
-  text-decoration: underline;
+  background: var(--color-bg);
 }
 
 /* Clear is instant, not a task with a progress state: Turbo marks the

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -5639,19 +5639,19 @@ img.avatar {
   text-decoration: underline;
 }
 
-/* Clear in flight — the row pulses until the strip re-renders so the
-   click never feels like it did nothing. Turbo sets aria-busy on submit
-   and clears it on completion or failure. */
+/* Clear is instant, not a task with a progress state: Turbo marks the
+   form aria-busy the moment it's pressed, and the row hides on that —
+   gone before the request finishes, with the response replacing the
+   strip a moment later. Turbo clears aria-busy on failure, so a rejected
+   request puts the row back without any JS of ours. */
 .attention__item:has(.attention__clear-form[aria-busy="true"]) {
-  animation: attention-clear-pulse 0.8s ease-in-out infinite;
+  display: none;
 }
 
-@keyframes attention-clear-pulse {
-  50% { opacity: 0.45; }
-}
-
-.attention__clear-form[aria-busy="true"] .attention__clear {
-  cursor: progress;
+/* Clearing the last row empties the strip, so take the whole thing with
+   it rather than flash an empty bordered box with a stale count. */
+.attention:has(.attention__item:only-child .attention__clear-form[aria-busy="true"]) {
+  display: none;
 }
 
 /* "Since you last looked" strip — recency against your own reading

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -5617,6 +5617,28 @@ img.avatar {
   white-space: nowrap;
 }
 
+/* Dismissal sits at the far right of the row, quiet until hovered — the
+   strip is a nudge, and getting rid of a nudge shouldn't be loud. */
+.attention__clear-form {
+  margin: 0;
+  margin-left: auto;
+}
+
+.attention__clear {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.attention__clear:hover {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+
 /* "Since you last looked" strip — recency against your own reading
    history, quieter than the warning-toned attention strip. */
 .recent-updates {

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -5639,6 +5639,21 @@ img.avatar {
   text-decoration: underline;
 }
 
+/* Clear in flight — the row pulses until the strip re-renders so the
+   click never feels like it did nothing. Turbo sets aria-busy on submit
+   and clears it on completion or failure. */
+.attention__item:has(.attention__clear-form[aria-busy="true"]) {
+  animation: attention-clear-pulse 0.8s ease-in-out infinite;
+}
+
+@keyframes attention-clear-pulse {
+  50% { opacity: 0.45; }
+}
+
+.attention__clear-form[aria-busy="true"] .attention__clear {
+  cursor: progress;
+}
+
 /* "Since you last looked" strip — recency against your own reading
    history, quieter than the warning-toned attention strip. */
 .recent-updates {

--- a/engine/app/channels/coplan/plan_presence_channel.rb
+++ b/engine/app/channels/coplan/plan_presence_channel.rb
@@ -14,6 +14,12 @@ module CoPlan
       end
 
       PlanViewer.track(plan: @plan, user: current_user)
+      # Subscribing means the page is really open in front of somebody —
+      # unlike the GET that fetched it, which Turbo also fires on hover and
+      # may skip entirely when it serves the click from its prefetch cache.
+      # So this is where the plan's unread notifications get cleared. The
+      # bell updates over the notifications stream the layout subscribes to.
+      Notifications::MarkPlanRead.call(user: current_user, plan_id: @plan.id)
       broadcast_viewers
     end
 

--- a/engine/app/controllers/coplan/notifications_controller.rb
+++ b/engine/app/controllers/coplan/notifications_controller.rb
@@ -66,15 +66,36 @@ module CoPlan
       end
     end
 
+    # "Clear" on a workspace attention row: one plan's unread rows marked
+    # read without reading them. The strip re-renders rather than dropping
+    # the row, because clearing one plan can promote the next one into view.
+    def mark_plan_read
+      plan_id = params[:plan_id].to_s
+      if plan_id.present?
+        current_user.notifications.unread.where(plan_id: plan_id).update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      broadcast_badge_update
+
+      respond_to do |format|
+        format.turbo_stream do
+          attention = Notifications::NeedsAttention.call(user: current_user)
+          render turbo_stream: [
+            turbo_stream.update("inbox-badge", current_user.notifications.unread.count.to_s),
+            turbo_stream.replace("needs-attention", partial: "coplan/plans/needs_attention", locals: { attention: attention }),
+            # The plan's own row badge, if that row is on screen — a row
+            # still reading "3" after the strip cleared looks stale.
+            turbo_stream.remove(helpers.plan_unread_badge_id(plan_id))
+          ]
+        end
+        format.html { redirect_back fallback_location: plans_path, notice: "Notifications cleared." }
+      end
+    end
+
     private
 
     def broadcast_badge_update
-      count = current_user.notifications.unread.count
-      Broadcaster.update_to(
-        "coplan_notifications:#{current_user.id}",
-        target: "inbox-badge",
-        html: count.to_s
-      )
+      Notifications::BroadcastBadges.call(user_ids: [ current_user.id ])
     end
   end
 end

--- a/engine/app/controllers/coplan/notifications_controller.rb
+++ b/engine/app/controllers/coplan/notifications_controller.rb
@@ -66,16 +66,13 @@ module CoPlan
       end
     end
 
-    # "Clear" on a workspace attention row: one plan's unread rows marked
-    # read without reading them. The strip re-renders rather than dropping
-    # the row, because clearing one plan can promote the next one into view.
+    # The dismiss "✕" on a workspace attention row: one plan's unread rows
+    # marked read without opening it (opening it does the same thing). The
+    # strip re-renders rather than dropping the row, because clearing one
+    # plan can promote the next one into view.
     def mark_plan_read
       plan_id = params[:plan_id].to_s
-      if plan_id.present?
-        current_user.notifications.unread.where(plan_id: plan_id).update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-      end
-
-      broadcast_badge_update
+      Notifications::MarkPlanRead.call(user: current_user, plan_id: plan_id)
 
       respond_to do |format|
         format.turbo_stream do

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -159,7 +159,7 @@ module CoPlan
       # highlights against the old last_seen_at, then advance it — so the
       # next visit renders clean.
       @changed_section_keys = changed_sections_since_last_visit
-      PlanViewer.track(plan: @plan, user: current_user)
+      record_visit unless prefetch_request?
     end
 
     # A full page (reached from the header's clock icon), not a tab —
@@ -672,6 +672,25 @@ module CoPlan
         old_content: base.content_markdown,
         new_content: current.content_markdown
       )
+    end
+
+    # Looking at a plan advances your last-seen mark (so the "changed since
+    # you last looked" highlights are once-only) and clears the plan's
+    # unread notifications — you looked, the nudge is done.
+    def record_visit
+      PlanViewer.track(plan: @plan, user: current_user)
+      Notifications::MarkPlanRead.call(user: current_user, plan_id: @plan.id)
+    end
+
+    # Workspace rows prefetch on hover (Turbo 8), so this GET can happen
+    # with nobody looking at anything — a cursor resting on a row would
+    # burn its highlights and clear its notifications. The page still
+    # renders normally; the writes wait for a real visit, which
+    # PlanPresenceChannel reports when the page opens. That subscribe is
+    # also the only signal for a click Turbo serves from its prefetch
+    # cache, where the server never sees the navigation at all.
+    def prefetch_request?
+      request.headers["X-Sec-Purpose"] == "prefetch"
     end
 
     def set_plan

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -528,13 +528,19 @@ module CoPlan
     end
 
     # One grouped query per request, shared between the per-row unread
-    # badges and the "needs attention" strip.
+    # badges and the "needs attention" strip. Kept separate from
+    # needs_attention because pagination frames want only this count —
+    # they return before the strip renders, and building its full result
+    # there would buy per-plan lookups nothing.
     def unread_by_plan
-      needs_attention.unread_counts
+      @unread_by_plan ||= current_user.notifications.unread.group(:plan_id).count
     end
 
     def needs_attention
-      @needs_attention ||= Notifications::NeedsAttention.call(user: current_user)
+      @needs_attention ||= Notifications::NeedsAttention.call(
+        user: current_user,
+        unread_counts: unread_by_plan
+      )
     end
 
     def unread_counts_for(plans)

--- a/engine/app/controllers/coplan/plans_controller.rb
+++ b/engine/app/controllers/coplan/plans_controller.rb
@@ -530,7 +530,11 @@ module CoPlan
     # One grouped query per request, shared between the per-row unread
     # badges and the "needs attention" strip.
     def unread_by_plan
-      @unread_by_plan ||= current_user.notifications.unread.group(:plan_id).count
+      needs_attention.unread_counts
+    end
+
+    def needs_attention
+      @needs_attention ||= Notifications::NeedsAttention.call(user: current_user)
     end
 
     def unread_counts_for(plans)
@@ -638,28 +642,11 @@ module CoPlan
       end
     end
 
-    ATTENTION_LIMIT = 5
-
-    # "Needs attention" strip: plans with unread comment notifications for
-    # the current user, most-unread first. Independent of the active
-    # sidebar filters — it's an inbox, not a search result. Bounded: only
-    # the top ATTENTION_LIMIT plans are loaded.
+    # "Needs attention" strip — see Notifications::NeedsAttention. Loading
+    # it here also warms the grouped unread count behind the per-row
+    # badges, so the whole page costs one extra query.
     def load_needs_attention
-      @attention_unread_counts = unread_by_plan
-      top_ids = unread_by_plan.sort_by { |_id, count| -count }
-        .first(ATTENTION_LIMIT).map(&:first)
-      # The plan view hides resolved threads by default. Route each inbox row
-      # through an unread notification so the destination marks it read and
-      # deep-links to the exact thread, even when that thread is resolved.
-      # This is deliberately bounded to ATTENTION_LIMIT indexed lookups.
-      @attention_notification_ids = top_ids.index_with do |plan_id|
-        current_user.notifications.unread.where(plan_id: plan_id).newest_first.pick(:id)
-      end
-      # Even an inbox routes through the discovery predicate — a stale
-      # notification must not resurface an archived plan or another user's
-      # unlisted draft.
-      @attention_plans = Plan.visible_to(current_user).active.where(id: top_ids)
-        .sort_by { |plan| -unread_by_plan.fetch(plan.id, 0) }
+      needs_attention
     end
 
     # Section keys (see Plans::ChangedSections) for content that changed

--- a/engine/app/helpers/coplan/plans_helper.rb
+++ b/engine/app/helpers/coplan/plans_helper.rb
@@ -18,6 +18,14 @@ module CoPlan
       )
     end
 
+    # DOM id of a plan row's unread-comment badge. Shared by the row that
+    # renders it and the Turbo Stream that removes it when that plan's
+    # notifications are cleared (NotificationsController#mark_plan_read) —
+    # takes a plan or a plan id.
+    def plan_unread_badge_id(plan)
+      "plan-unread-#{plan.respond_to?(:id) ? plan.id : plan}"
+    end
+
     # Published is the unmarked normal state. The hidden states (draft,
     # archived) get a quiet crossed-out eye — "this one isn't listed" —
     # rather than a loud colored badge. Safe in broadcast partials

--- a/engine/app/models/coplan/comment_thread.rb
+++ b/engine/app/models/coplan/comment_thread.rb
@@ -26,6 +26,11 @@ module CoPlan
     before_validation :resolve_anchor_position, on: :create
     validate :anchor_must_resolve, on: :create
 
+    # Closing a thread settles its inbox rows. Every path that resolves or
+    # discards goes through an ordinary status write, so the sweep lives
+    # here rather than in the two controllers that trigger it.
+    after_commit :mark_notifications_read_if_closed, on: :update
+
     scope :open_threads, -> { where(status: OPEN_STATUSES) }
     scope :current, -> { where(out_of_date: false) }
     scope :active, -> { where(status: OPEN_STATUSES, out_of_date: false) }
@@ -135,6 +140,10 @@ module CoPlan
       OPEN_STATUSES.include?(status)
     end
 
+    def closed?
+      CLOSED_STATUSES.include?(status)
+    end
+
     def anchor_valid?
       return true unless anchored?
       !out_of_date
@@ -188,6 +197,12 @@ module CoPlan
     end
 
     private
+
+    def mark_notifications_read_if_closed
+      return unless saved_change_to_status? && closed?
+
+      Notifications::MarkThreadRead.call(comment_thread: self)
+    end
 
     def anchor_must_resolve
       return if anchor_text.blank? || anchor_start.present?

--- a/engine/app/services/coplan/comments/process_mentions.rb
+++ b/engine/app/services/coplan/comments/process_mentions.rb
@@ -43,26 +43,13 @@ module CoPlan
           notified_user_ids << user.id if notification.previously_new_record?
         end
 
-        broadcast_badge_updates(notified_user_ids)
+        Notifications::BroadcastBadges.call(user_ids: notified_user_ids)
       end
 
       private
 
       def extract_usernames
         @comment.body_markdown.to_s.scan(MENTION_PATTERN).flatten.uniq
-      end
-
-      def broadcast_badge_updates(user_ids)
-        return if user_ids.empty?
-
-        counts = Notification.where(user_id: user_ids).unread.group(:user_id).count
-        user_ids.each do |user_id|
-          Broadcaster.update_to(
-            "coplan_notifications:#{user_id}",
-            target: "inbox-badge",
-            html: (counts[user_id] || 0).to_s
-          )
-        end
       end
     end
   end

--- a/engine/app/services/coplan/notifications/broadcast_badges.rb
+++ b/engine/app/services/coplan/notifications/broadcast_badges.rb
@@ -1,0 +1,30 @@
+module CoPlan
+  module Notifications
+    # Pushes each person's current unread count to their bell badge. One
+    # grouped count for the whole set, then one stream per recipient —
+    # every path that creates or clears notifications ends here so the
+    # badge can never drift from the inbox.
+    class BroadcastBadges
+      def self.call(user_ids:)
+        new(user_ids: user_ids).call
+      end
+
+      def initialize(user_ids:)
+        @user_ids = Array(user_ids).compact.uniq
+      end
+
+      def call
+        return if @user_ids.empty?
+
+        counts = Notification.where(user_id: @user_ids).unread.group(:user_id).count
+        @user_ids.each do |user_id|
+          Broadcaster.update_to(
+            "coplan_notifications:#{user_id}",
+            target: "inbox-badge",
+            html: (counts[user_id] || 0).to_s
+          )
+        end
+      end
+    end
+  end
+end

--- a/engine/app/services/coplan/notifications/create.rb
+++ b/engine/app/services/coplan/notifications/create.rb
@@ -1,6 +1,13 @@
 module CoPlan
   module Notifications
     class Create
+      # Reasons that stay silent once a thread is closed. An agent working
+      # a thread it then resolves used to leave a pile of unread rows
+      # pointing at a hidden highlight — the reader clicked through to an
+      # apparently empty plan. Human replies and mentions still notify:
+      # somebody deliberately reopening a settled conversation is news.
+      SILENT_ON_CLOSED_THREAD = %w[agent_response status_change].freeze
+
       def self.call(comment_thread:, actor_id:, comment: nil, reason:)
         new(comment_thread:, actor_id:, comment:, reason:).call
       end
@@ -13,6 +20,8 @@ module CoPlan
       end
 
       def call
+        return if silenced?
+
         subscriber_ids = compute_subscribers
         subscriber_ids.delete(@actor_id)
         return if subscriber_ids.empty?
@@ -27,10 +36,14 @@ module CoPlan
           )
         end
 
-        broadcast_badge_updates(subscriber_ids)
+        BroadcastBadges.call(user_ids: subscriber_ids)
       end
 
       private
+
+      def silenced?
+        SILENT_ON_CLOSED_THREAD.include?(@reason) && @comment_thread.closed?
+      end
 
       def compute_subscribers
         case @reason
@@ -72,17 +85,6 @@ module CoPlan
             .compact
         )
         ids
-      end
-
-      def broadcast_badge_updates(subscriber_ids)
-        counts = Notification.where(user_id: subscriber_ids).unread.group(:user_id).count
-        subscriber_ids.each do |user_id|
-          Broadcaster.update_to(
-            "coplan_notifications:#{user_id}",
-            target: "inbox-badge",
-            html: (counts[user_id] || 0).to_s
-          )
-        end
       end
     end
   end

--- a/engine/app/services/coplan/notifications/create.rb
+++ b/engine/app/services/coplan/notifications/create.rb
@@ -20,11 +20,26 @@ module CoPlan
       end
 
       def call
-        return if silenced?
+        # Reading the status and inserting have to be one step. An agent
+        # that replies and then resolves races its own reply job: check
+        # open, resolve commits and sweeps, insert — and the row is unread
+        # forever on a closed thread, with a push already on its way
+        # (WebPushDeliveryJob doesn't re-check read state). The lock
+        # reloads the thread, so either we see the close and stay silent,
+        # or the close waits for us and its sweep catches these rows.
+        notified_ids = @comment_thread.with_lock do
+          silenced? ? [] : insert_notifications
+        end
 
+        BroadcastBadges.call(user_ids: notified_ids)
+      end
+
+      private
+
+      def insert_notifications
         subscriber_ids = compute_subscribers
         subscriber_ids.delete(@actor_id)
-        return if subscriber_ids.empty?
+        return [] if subscriber_ids.empty?
 
         subscriber_ids.each do |user_id|
           Notification.create!(
@@ -36,11 +51,11 @@ module CoPlan
           )
         end
 
-        BroadcastBadges.call(user_ids: subscriber_ids)
+        subscriber_ids
       end
 
-      private
-
+      # with_lock has reloaded the thread, so this reads committed state
+      # rather than whatever the job loaded moments ago.
       def silenced?
         SILENT_ON_CLOSED_THREAD.include?(@reason) && @comment_thread.closed?
       end

--- a/engine/app/services/coplan/notifications/mark_plan_read.rb
+++ b/engine/app/services/coplan/notifications/mark_plan_read.rb
@@ -1,0 +1,35 @@
+module CoPlan
+  module Notifications
+    # Marks every unread row one person carries for one plan read, and
+    # refreshes their badge.
+    #
+    # Two callers, same meaning — "you've dealt with this plan":
+    # opening the plan (you looked; the nudge did its job) and the
+    # workspace strip's dismiss (you don't need to look).
+    #
+    # Rows stay in the inbox history; only their unread flag changes.
+    class MarkPlanRead
+      def self.call(user:, plan_id:)
+        new(user: user, plan_id: plan_id).call
+      end
+
+      def initialize(user:, plan_id:)
+        @user = user
+        @plan_id = plan_id
+      end
+
+      # Returns the number of rows cleared. Zero is the common case on a
+      # plan visit, and costs one indexed count — no badge broadcast.
+      def call
+        return 0 if @plan_id.blank?
+
+        unread = @user.notifications.unread.where(plan_id: @plan_id)
+        cleared = unread.update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        return 0 if cleared.zero?
+
+        BroadcastBadges.call(user_ids: [ @user.id ])
+        cleared
+      end
+    end
+  end
+end

--- a/engine/app/services/coplan/notifications/mark_thread_read.rb
+++ b/engine/app/services/coplan/notifications/mark_thread_read.rb
@@ -1,0 +1,31 @@
+module CoPlan
+  module Notifications
+    # Marks every unread inbox row for one thread read and refreshes the
+    # badge for whoever was carrying them.
+    #
+    # Called when a thread closes (resolved/discarded). A closed thread is
+    # finished work: its highlight is hidden in the doc view, so a row
+    # pointing at it sends the reader to a page with nothing on it. The
+    # rows stay in the inbox history — they just stop counting as unread.
+    class MarkThreadRead
+      def self.call(comment_thread:)
+        new(comment_thread: comment_thread).call
+      end
+
+      def initialize(comment_thread:)
+        @comment_thread = comment_thread
+      end
+
+      # Returns the number of rows cleared.
+      def call
+        unread = Notification.unread.where(comment_thread_id: @comment_thread.id)
+        user_ids = unread.distinct.pluck(:user_id)
+        return 0 if user_ids.empty?
+
+        cleared = unread.update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+        BroadcastBadges.call(user_ids: user_ids)
+        cleared
+      end
+    end
+  end
+end

--- a/engine/app/services/coplan/notifications/needs_attention.rb
+++ b/engine/app/services/coplan/notifications/needs_attention.rb
@@ -31,16 +31,20 @@ module CoPlan
         end
       end
 
-      def self.call(user:)
-        new(user: user).call
+      def self.call(user:, unread_counts: nil)
+        new(user: user, unread_counts: unread_counts).call
       end
 
-      def initialize(user:)
+      # unread_counts: a caller that already grouped this person's unread
+      # rows by plan (the workspace does, for its per-row badges) can pass
+      # the hash in rather than pay for the same query twice.
+      def initialize(user:, unread_counts: nil)
         @user = user
+        @unread_counts = unread_counts
       end
 
       def call
-        unread_counts = @user.notifications.unread.group(:plan_id).count
+        unread_counts = @unread_counts || @user.notifications.unread.group(:plan_id).count
         top_ids = unread_counts.sort_by { |_id, count| -count }.first(LIMIT).map(&:first)
 
         # The plan view hides resolved threads by default. Route each row

--- a/engine/app/services/coplan/notifications/needs_attention.rb
+++ b/engine/app/services/coplan/notifications/needs_attention.rb
@@ -1,0 +1,67 @@
+module CoPlan
+  module Notifications
+    # The workspace "Needs attention" strip: plans carrying unread inbox
+    # rows for one person, most-unread first. Independent of the active
+    # sidebar filters — it's an inbox, not a search result — and bounded to
+    # the top LIMIT plans.
+    #
+    # A query object rather than a controller method because two surfaces
+    # render the same strip: the workspace on load, and the "Clear" button
+    # on each row, which re-renders it (clearing one plan can promote the
+    # next one into view).
+    class NeedsAttention
+      LIMIT = 5
+
+      Result = Struct.new(:unread_counts, :plans, :notification_ids, keyword_init: true) do
+        def any?
+          plans.present?
+        end
+
+        # Plans with unread rows that didn't fit in the strip.
+        def remaining
+          unread_counts.size - plans.size
+        end
+
+        def unread_count_for(plan)
+          unread_counts[plan.id].to_i
+        end
+
+        def notification_id_for(plan)
+          notification_ids.fetch(plan.id)
+        end
+      end
+
+      def self.call(user:)
+        new(user: user).call
+      end
+
+      def initialize(user:)
+        @user = user
+      end
+
+      def call
+        unread_counts = @user.notifications.unread.group(:plan_id).count
+        top_ids = unread_counts.sort_by { |_id, count| -count }.first(LIMIT).map(&:first)
+
+        # The plan view hides resolved threads by default. Route each row
+        # through an unread notification so the destination marks it read
+        # and deep-links to the exact thread. Bounded to LIMIT indexed
+        # lookups.
+        # compact: another tab (or the Clear button) can empty a plan
+        # between the count and this lookup — drop the row rather than
+        # render a link to a notification that no longer exists.
+        notification_ids = top_ids.index_with do |plan_id|
+          @user.notifications.unread.where(plan_id: plan_id).newest_first.pick(:id)
+        end.compact
+
+        # Even an inbox routes through the discovery predicate — a stale
+        # notification must not resurface an archived plan or another
+        # user's unlisted draft.
+        plans = Plan.visible_to(@user).active.where(id: notification_ids.keys)
+          .sort_by { |plan| -unread_counts.fetch(plan.id, 0) }
+
+        Result.new(unread_counts: unread_counts, plans: plans, notification_ids: notification_ids)
+      end
+    end
+  end
+end

--- a/engine/app/views/coplan/plans/_needs_attention.html.erb
+++ b/engine/app/views/coplan/plans/_needs_attention.html.erb
@@ -15,17 +15,14 @@
             <span class="attention__unread"><%= pluralize(attention.unread_count_for(plan), "unread comment") %></span>
             <%# Dismissal without reading: marks this plan's rows read and
                 re-renders the strip in place, which may promote the next
-                plan into view. %>
-            <%# turbo_submits_with swaps the label and Turbo marks the form
-                aria-busy the moment it's clicked (restoring both on
-                failure), so the row pulses instead of sitting there
-                looking unclicked while the request is in flight. %>
+                plan into view. Clicking it hides the row instantly (see
+                the aria-busy rules in the stylesheet) — dismissing a
+                nudge shouldn't have a progress state. %>
             <%= button_to "Clear",
                   mark_plan_read_notifications_path(plan_id: plan.id),
                   method: :post,
                   class: "attention__clear",
                   form: { data: { turbo_stream: true }, class: "attention__clear-form" },
-                  data: { turbo_submits_with: "Clearing…" },
                   aria: { label: "Clear unread comments for #{plan.title}" } %>
           </li>
         <% end %>

--- a/engine/app/views/coplan/plans/_needs_attention.html.erb
+++ b/engine/app/views/coplan/plans/_needs_attention.html.erb
@@ -16,11 +16,16 @@
             <%# Dismissal without reading: marks this plan's rows read and
                 re-renders the strip in place, which may promote the next
                 plan into view. %>
+            <%# turbo_submits_with swaps the label and Turbo marks the form
+                aria-busy the moment it's clicked (restoring both on
+                failure), so the row pulses instead of sitting there
+                looking unclicked while the request is in flight. %>
             <%= button_to "Clear",
                   mark_plan_read_notifications_path(plan_id: plan.id),
                   method: :post,
                   class: "attention__clear",
                   form: { data: { turbo_stream: true }, class: "attention__clear-form" },
+                  data: { turbo_submits_with: "Clearing…" },
                   aria: { label: "Clear unread comments for #{plan.title}" } %>
           </li>
         <% end %>

--- a/engine/app/views/coplan/plans/_needs_attention.html.erb
+++ b/engine/app/views/coplan/plans/_needs_attention.html.erb
@@ -13,15 +13,17 @@
           <li class="attention__item">
             <%= link_to plan.title, notification_path(attention.notification_id_for(plan)), class: "attention__link", data: { turbo: false } %>
             <span class="attention__unread"><%= pluralize(attention.unread_count_for(plan), "unread comment") %></span>
-            <%# Dismissal without reading: marks this plan's rows read and
-                re-renders the strip in place, which may promote the next
-                plan into view. Clicking it hides the row instantly (see
-                the aria-busy rules in the stylesheet) — dismissing a
-                nudge shouldn't have a progress state. %>
-            <%= button_to "Clear",
+            <%# Dismissal without reading (opening the plan clears it too):
+                marks this plan's rows read and re-renders the strip in
+                place, which may promote the next plan into view. Clicking
+                it hides the row instantly (see the aria-busy rules in the
+                stylesheet) — dismissing a nudge shouldn't have a progress
+                state. %>
+            <%= button_to "✕",
                   mark_plan_read_notifications_path(plan_id: plan.id),
                   method: :post,
                   class: "attention__clear",
+                  title: "Clear",
                   form: { data: { turbo_stream: true }, class: "attention__clear-form" },
                   aria: { label: "Clear unread comments for #{plan.title}" } %>
           </li>

--- a/engine/app/views/coplan/plans/_needs_attention.html.erb
+++ b/engine/app/views/coplan/plans/_needs_attention.html.erb
@@ -1,0 +1,36 @@
+<%# The strip replaces itself when a row is cleared, so the wrapper is
+    always rendered — an empty container still gives the Turbo Stream
+    something to target. %>
+<div id="needs-attention">
+  <% if attention.any? %>
+    <section class="attention" aria-label="Plans that need your attention">
+      <h2 class="attention__heading">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+        Needs attention (<%= attention.unread_counts.size %>)
+      </h2>
+      <ul class="attention__list">
+        <% attention.plans.each do |plan| %>
+          <li class="attention__item">
+            <%= link_to plan.title, notification_path(attention.notification_id_for(plan)), class: "attention__link", data: { turbo: false } %>
+            <span class="attention__unread"><%= pluralize(attention.unread_count_for(plan), "unread comment") %></span>
+            <%# Dismissal without reading: marks this plan's rows read and
+                re-renders the strip in place, which may promote the next
+                plan into view. %>
+            <%= button_to "Clear",
+                  mark_plan_read_notifications_path(plan_id: plan.id),
+                  method: :post,
+                  class: "attention__clear",
+                  form: { data: { turbo_stream: true }, class: "attention__clear-form" },
+                  aria: { label: "Clear unread comments for #{plan.title}" } %>
+          </li>
+        <% end %>
+      </ul>
+      <% if attention.remaining > 0 %>
+        <p class="attention__more text-muted text-sm">
+          + <%= pluralize(attention.remaining, "more plan") %> with unread comments —
+          <%= link_to "see notifications", notifications_path, class: "attention__link" %>
+        </p>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/engine/app/views/coplan/plans/_plan_row.html.erb
+++ b/engine/app/views/coplan/plans/_plan_row.html.erb
@@ -38,7 +38,10 @@
         <% end %>
       <% end %>
       <% if unread > 0 %>
-        <span class="inbox-badge" title="<%= pluralize(unread, "unread comment") %>"><%= unread %></span>
+        <%# Ided so clearing a plan's notifications can drop the badge in
+            place — a row still claiming "3" after the strip cleared reads
+            as a stale page. %>
+        <span id="<%= plan_unread_badge_id(plan) %>" class="inbox-badge" title="<%= pluralize(unread, "unread comment") %>"><%= unread %></span>
       <% end %>
     </div>
     <% if summary.present? %>

--- a/engine/app/views/coplan/plans/index.html.erb
+++ b/engine/app/views/coplan/plans/index.html.erb
@@ -103,29 +103,7 @@
       </div>
     <% end %>
 
-    <% if @attention_plans.present? %>
-      <section class="attention" aria-label="Plans that need your attention">
-        <h2 class="attention__heading">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-          Needs attention (<%= @attention_unread_counts.size %>)
-        </h2>
-        <ul class="attention__list">
-          <% @attention_plans.each do |plan| %>
-            <li class="attention__item">
-              <%= link_to plan.title, notification_path(@attention_notification_ids.fetch(plan.id)), class: "attention__link", data: { turbo: false } %>
-              <span class="attention__unread"><%= pluralize(@attention_unread_counts[plan.id].to_i, "unread comment") %></span>
-            </li>
-          <% end %>
-        </ul>
-        <% remaining = @attention_unread_counts.size - @attention_plans.size %>
-        <% if remaining > 0 %>
-          <p class="attention__more text-muted text-sm">
-            + <%= pluralize(remaining, "more plan") %> with unread comments —
-            <%= link_to "see notifications", notifications_path, class: "attention__link" %>
-          </p>
-        <% end %>
-      </section>
-    <% end %>
+    <%= render partial: "coplan/plans/needs_attention", locals: { attention: @needs_attention } %>
 
     <% if @subfolders %>
       <% if @recent_updates.present? %>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -115,6 +115,7 @@ CoPlan::Engine.routes.draw do
     end
     collection do
       post :mark_all_read
+      post :mark_plan_read
     end
   end
 

--- a/engine/db/migrate/20260819000000_mark_closed_thread_notifications_read.rb
+++ b/engine/db/migrate/20260819000000_mark_closed_thread_notifications_read.rb
@@ -1,0 +1,28 @@
+class MarkClosedThreadNotificationsRead < ActiveRecord::Migration[8.1]
+  # Clears the accumulated inbox rows that point at resolved or discarded
+  # threads. These are the pile behind "20 unread comments" on a plan whose
+  # comments are all settled — the doc view hides a closed thread's
+  # highlight, so the rows sent readers to an apparently empty page.
+  #
+  # Pairs with the behaviour change: closing a thread now sweeps its rows
+  # read (CommentThread#mark_notifications_read_if_closed), and agent
+  # replies / status changes on an already-closed thread don't notify at
+  # all (Notifications::Create::SILENT_ON_CLOSED_THREAD).
+  #
+  # Idempotent: already-read rows don't match the unread scope. Rows stay
+  # in the inbox history — only their unread flag changes.
+  def up
+    closed_thread_ids = CoPlan::CommentThread
+      .where(status: CoPlan::CommentThread::CLOSED_STATUSES)
+      .select(:id)
+
+    CoPlan::Notification.unread
+      .where(comment_thread_id: closed_thread_ids)
+      .update_all(read_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    # no-op (not reversible — the original read_at values were nil, but
+    # re-marking them unread would resurrect exactly the noise this cleared)
+  end
+end

--- a/spec/channels/coplan/plan_presence_channel_spec.rb
+++ b/spec/channels/coplan/plan_presence_channel_spec.rb
@@ -16,6 +16,31 @@ RSpec.describe CoPlan::PlanPresenceChannel, type: :channel do
       expect(CoPlan::PlanViewer.where(plan: plan, user: user)).to exist
     end
 
+    # The page being open is the real "you looked at it" signal: the GET can
+    # be a hover prefetch, and a prefetched click never reaches the server.
+    it "clears the plan's unread notifications for the viewer" do
+      thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: create(:coplan_user))
+      mine = create(:notification, user: user, plan: plan, comment_thread: thread)
+      other_plan = create(:plan, created_by_user: user)
+      other_thread = create(:comment_thread, plan: other_plan, plan_version: other_plan.current_plan_version, created_by_user: user)
+      elsewhere = create(:notification, user: user, plan: other_plan, comment_thread: other_thread)
+
+      subscribe(plan_id: plan.id)
+
+      expect(mine.reload.read_at).to be_present
+      expect(elsewhere.reload.read_at).to be_nil
+    end
+
+    it "clears nothing when the subscription is rejected" do
+      thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: user)
+      stale = create(:notification, user: user, plan: plan, comment_thread: thread)
+
+      subscribe(plan_id: "does-not-exist")
+
+      expect(subscription).to be_rejected
+      expect(stale.reload.read_at).to be_nil
+    end
+
     it "authenticates through the engine callback when the connection has no current_user" do
       stub_connection(request: ActionDispatch::Request.empty)
       allow(CoPlan.configuration).to receive(:authenticate).and_return(

--- a/spec/migrations/mark_closed_thread_notifications_read_spec.rb
+++ b/spec/migrations/mark_closed_thread_notifications_read_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require CoPlan::Engine.root.join("db/migrate/20260819000000_mark_closed_thread_notifications_read.rb")
+
+RSpec.describe MarkClosedThreadNotificationsRead do
+  subject(:migration) { described_class.new }
+
+  let(:user) { create(:coplan_user) }
+  let(:plan) { create(:plan, created_by_user: user) }
+
+  def notification_on(status)
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: user, status: status)
+    create(:notification, user: user, plan: plan, comment_thread: thread)
+  end
+
+  before { migration.verbose = false }
+
+  it "marks unread rows on resolved and discarded threads read" do
+    resolved = notification_on("resolved")
+    discarded = notification_on("discarded")
+
+    migration.up
+
+    expect(resolved.reload.read_at).to be_present
+    expect(discarded.reload.read_at).to be_present
+  end
+
+  it "leaves rows on open threads unread" do
+    pending_row = notification_on("pending")
+    todo_row = notification_on("todo")
+
+    migration.up
+
+    expect(pending_row.reload.read_at).to be_nil
+    expect(todo_row.reload.read_at).to be_nil
+  end
+
+  it "does not rewrite an already-read row" do
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: user, status: "resolved")
+    read_at = 3.days.ago
+    already_read = create(:notification, user: user, plan: plan, comment_thread: thread, read_at: read_at)
+
+    migration.up
+
+    expect(already_read.reload.read_at).to be_within(1.second).of(read_at)
+  end
+
+  it "is idempotent across repeated runs" do
+    row = notification_on("resolved")
+
+    migration.up
+    first_pass = row.reload.read_at
+    migration.up
+
+    expect(row.reload.read_at).to be_within(1.second).of(first_pass)
+  end
+end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -81,11 +81,61 @@ RSpec.describe CoPlan::CommentThread, type: :model do
     expect(thread_record.resolved_by_user).to eq(user)
   end
 
+  describe "clearing notifications when a thread closes" do
+    let(:recipient) { create(:coplan_user) }
+
+    before { allow(CoPlan::Broadcaster).to receive(:update_to) }
+
+    it "marks the thread's unread rows read on resolve" do
+      notification = create(:notification, user: recipient, plan: plan, comment_thread: thread_record)
+
+      thread_record.resolve!(user)
+
+      expect(notification.reload.read_at).to be_present
+    end
+
+    it "marks the thread's unread rows read on discard" do
+      notification = create(:notification, user: recipient, plan: plan, comment_thread: thread_record)
+
+      thread_record.discard!(user)
+
+      expect(notification.reload.read_at).to be_present
+    end
+
+    it "leaves rows alone when the thread stays open" do
+      notification = create(:notification, user: recipient, plan: plan, comment_thread: thread_record)
+
+      thread_record.accept!(user)
+
+      expect(notification.reload.read_at).to be_nil
+    end
+
+    it "does not clear rows on an unrelated update to a closed thread" do
+      thread_record.resolve!(user)
+      notification = create(:notification, user: recipient, plan: plan, comment_thread: thread_record, reason: "reply")
+
+      thread_record.update!(anchor_context: "later edit")
+
+      expect(notification.reload.read_at).to be_nil
+    end
+  end
+
   it "open? returns true for pending and todo" do
     thread_record.status = "pending"
     expect(thread_record).to be_open
     thread_record.status = "todo"
     expect(thread_record).to be_open
+  end
+
+  it "closed? returns true for resolved and discarded only" do
+    thread_record.status = "resolved"
+    expect(thread_record).to be_closed
+    thread_record.status = "discarded"
+    expect(thread_record).to be_closed
+    thread_record.status = "pending"
+    expect(thread_record).not_to be_closed
+    thread_record.status = "todo"
+    expect(thread_record).not_to be_closed
   end
 
   it "open? returns false for resolved and discarded" do

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe "Api::V1::Comments", type: :request do
         as: :json
       expect(response).to have_http_status(:not_found)
     end
+
+    # The agent workflow that motivated this: reply to a batch of comments,
+    # then resolve them. Each resolve settles the rows it just generated
+    # instead of leaving a pile pointing at hidden highlights.
+    it "clears the thread's unread notifications" do
+      reviewer = create(:coplan_user)
+      notification = create(:notification, user: reviewer, plan: plan, comment_thread: thread_record, reason: "agent_response")
+
+      patch resolve_api_v1_plan_comment_path(plan, thread_record),
+        headers: headers,
+        as: :json
+
+      expect(notification.reload.read_at).to be_present
+    end
   end
 
   describe "PATCH discard" do

--- a/spec/requests/comment_threads_spec.rb
+++ b/spec/requests/comment_threads_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe "CommentThreads", type: :request do
     expect(thread.status).to eq("resolved")
   end
 
+  it "resolving a thread clears its unread notifications" do
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: bob)
+    notification = create(:notification, user: bob, plan: plan, comment_thread: thread, reason: "agent_response")
+
+    patch resolve_plan_comment_thread_path(plan, thread)
+
+    expect(notification.reload.read_at).to be_present
+  end
+
+  it "discarding a thread clears its unread notifications" do
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: bob)
+    notification = create(:notification, user: bob, plan: plan, comment_thread: thread)
+
+    patch discard_plan_comment_thread_path(plan, thread)
+
+    expect(notification.reload.read_at).to be_present
+  end
+
   it "accept thread as plan author" do
     thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: alice)
     patch accept_plan_comment_thread_path(plan, thread)

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -99,4 +99,58 @@ RSpec.describe "Notifications", type: :request do
       expect(user.notifications.unread.count).to eq(0)
     end
   end
+
+  describe "POST /notifications/mark_plan_read" do
+    let(:other_plan) { create(:plan, :considering) }
+    let(:other_thread) { create(:comment_thread, plan: other_plan, plan_version: other_plan.current_plan_version, created_by_user: user) }
+
+    it "clears one plan's unread rows and leaves the rest" do
+      mine = create(:notification, user: user, plan: plan, comment_thread: thread)
+      elsewhere = create(:notification, user: user, plan: other_plan, comment_thread: other_thread)
+
+      post mark_plan_read_notifications_path(plan_id: plan.id)
+
+      expect(mine.reload.read_at).to be_present
+      expect(elsewhere.reload.read_at).to be_nil
+    end
+
+    it "does not touch another user's rows for the same plan" do
+      other_user = create(:coplan_user)
+      theirs = create(:notification, user: other_user, plan: plan, comment_thread: thread)
+
+      post mark_plan_read_notifications_path(plan_id: plan.id)
+
+      expect(theirs.reload.read_at).to be_nil
+    end
+
+    it "responds with a turbo_stream that updates the badge and replaces the strip" do
+      create(:notification, user: user, plan: plan, comment_thread: thread)
+
+      post mark_plan_read_notifications_path(plan_id: plan.id),
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq(Mime[:turbo_stream])
+      expect(response.body).to include('target="inbox-badge"')
+      expect(response.body).to include('target="needs-attention"')
+      expect(response.body).to include(%(target="plan-unread-#{plan.id}"))
+      expect(user.notifications.unread.count).to eq(0)
+    end
+
+    it "redirects back for a non-turbo request" do
+      create(:notification, user: user, plan: plan, comment_thread: thread)
+
+      post mark_plan_read_notifications_path(plan_id: plan.id)
+
+      expect(response).to redirect_to(plans_path)
+    end
+
+    it "is a no-op without a plan_id" do
+      notification = create(:notification, user: user, plan: plan, comment_thread: thread)
+
+      post mark_plan_read_notifications_path
+
+      expect(notification.reload.read_at).to be_nil
+    end
+  end
 end

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -788,6 +788,20 @@ RSpec.describe "Plans", type: :request do
       expect(response.body).not_to include("Bobs Secret Draft")
     end
 
+    # A pagination frame renders rows and returns before the strip, so it
+    # should pay for the grouped badge count and nothing more.
+    it "is not built for a pagination frame" do
+      thread = create(:comment_thread, plan: plan, created_by_user: bob)
+      create(:notification, user: alice, plan: plan, comment_thread: thread)
+
+      expect(CoPlan::Notifications::NeedsAttention).not_to receive(:call)
+
+      get plans_path(group: "level", page: 1), headers: { "Turbo-Frame" => "plans-level-page-1" }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("1")
+    end
+
     it "offers a per-plan clear so the strip can be emptied without reading" do
       thread = create(:comment_thread, plan: plan, created_by_user: bob)
       create(:notification, user: alice, plan: plan, comment_thread: thread)

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -813,6 +813,75 @@ RSpec.describe "Plans", type: :request do
     end
   end
 
+  # The main way the strip empties: you go look at the plan.
+  describe "opening a plan clears its notifications" do
+    let(:thread) { create(:comment_thread, plan: plan, created_by_user: bob) }
+
+    it "marks the viewer's unread rows for that plan read" do
+      first = create(:notification, user: alice, plan: plan, comment_thread: thread)
+      second = create(:notification, user: alice, plan: plan, comment_thread: thread, reason: "agent_response")
+
+      get plan_path(plan)
+
+      expect(response).to have_http_status(:success)
+      expect(first.reload.read_at).to be_present
+      expect(second.reload.read_at).to be_present
+    end
+
+    it "renders the bell already cleared, not a stale count" do
+      create(:notification, user: alice, plan: plan, comment_thread: thread)
+
+      get plan_path(plan)
+
+      badge = Nokogiri::HTML(response.body).at_css("#inbox-badge")
+      expect(badge.text).to eq("0")
+      expect(badge["class"]).to include("inbox-badge--hidden")
+    end
+
+    it "leaves rows for other plans alone" do
+      other_plan = create(:plan, :considering, created_by_user: alice)
+      other_thread = create(:comment_thread, plan: other_plan, created_by_user: bob)
+      other = create(:notification, user: alice, plan: other_plan, comment_thread: other_thread)
+
+      get plan_path(plan)
+
+      expect(other.reload.read_at).to be_nil
+    end
+
+    it "leaves other people's rows for the same plan alone" do
+      bobs = create(:notification, user: bob, plan: plan, comment_thread: thread)
+
+      get plan_path(plan)
+
+      expect(bobs.reload.read_at).to be_nil
+    end
+
+    it "does not clear anything on the history page" do
+      notification = create(:notification, user: alice, plan: plan, comment_thread: thread)
+
+      get history_plan_path(plan)
+
+      expect(notification.reload.read_at).to be_nil
+    end
+
+    # Workspace rows prefetch on hover, so this GET fires for a cursor
+    # passing over a row. Nobody has looked at anything yet.
+    it "ignores a Turbo hover prefetch" do
+      notification = create(:notification, user: alice, plan: plan, comment_thread: thread)
+
+      get plan_path(plan), headers: { "X-Sec-Purpose" => "prefetch" }
+
+      expect(response).to have_http_status(:success)
+      expect(notification.reload.read_at).to be_nil
+    end
+
+    it "does not advance the last-seen mark on a prefetch either" do
+      get plan_path(plan), headers: { "X-Sec-Purpose" => "prefetch" }
+
+      expect(CoPlan::PlanViewer.where(plan: plan, user: alice)).not_to exist
+    end
+  end
+
   describe "PATCH /plans/:id/move_to_folder" do
     let(:folder) { create(:folder, name: "Infra", created_by_user: alice) }
 

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -787,6 +787,16 @@ RSpec.describe "Plans", type: :request do
       get plans_path
       expect(response.body).not_to include("Bobs Secret Draft")
     end
+
+    it "offers a per-plan clear so the strip can be emptied without reading" do
+      thread = create(:comment_thread, plan: plan, created_by_user: bob)
+      create(:notification, user: alice, plan: plan, comment_thread: thread)
+
+      get plans_path
+
+      clear_form = Nokogiri::HTML(response.body).at_css(".attention__clear-form")
+      expect(clear_form["action"]).to eq(mark_plan_read_notifications_path(plan_id: plan.id))
+    end
   end
 
   describe "PATCH /plans/:id/move_to_folder" do

--- a/spec/services/notifications/create_spec.rb
+++ b/spec/services/notifications/create_spec.rb
@@ -117,6 +117,46 @@ RSpec.describe CoPlan::Notifications::Create do
     end
   end
 
+  describe "closed threads" do
+    let(:resolved_thread) do
+      thread.tap { |t| t.update!(status: "resolved", resolved_by_user: plan_author) }
+    end
+
+    it "does not notify about an agent response on a resolved thread" do
+      expect {
+        described_class.call(comment_thread: resolved_thread, actor_id: create(:coplan_user).id, reason: "agent_response")
+      }.not_to change(CoPlan::Notification, :count)
+    end
+
+    it "does not notify about a status change into a closed status" do
+      expect {
+        described_class.call(comment_thread: resolved_thread, actor_id: plan_author.id, reason: "status_change")
+      }.not_to change(CoPlan::Notification, :count)
+    end
+
+    it "does not notify about an agent response on a discarded thread" do
+      thread.update!(status: "discarded", resolved_by_user: plan_author)
+
+      expect {
+        described_class.call(comment_thread: thread, actor_id: create(:coplan_user).id, reason: "agent_response")
+      }.not_to change(CoPlan::Notification, :count)
+    end
+
+    it "still notifies about a human reply — somebody reopening the conversation is news" do
+      expect {
+        described_class.call(comment_thread: resolved_thread, actor_id: create(:coplan_user).id, reason: "reply")
+      }.to change(CoPlan::Notification, :count).by(2)
+    end
+
+    it "still notifies about a status change when the thread was reopened" do
+      resolved_thread.update!(status: "pending", resolved_by_user: nil)
+
+      expect {
+        described_class.call(comment_thread: resolved_thread, actor_id: plan_author.id, reason: "status_change")
+      }.to change(CoPlan::Notification, :count).by(1)
+    end
+  end
+
   describe "broadcasting" do
     it "broadcasts badge updates to each notified user" do
       expect(CoPlan::Broadcaster).to receive(:update_to).with(

--- a/spec/services/notifications/create_spec.rb
+++ b/spec/services/notifications/create_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe CoPlan::Notifications::Create do
       }.to change(CoPlan::Notification, :count).by(2)
     end
 
+    # The reply-then-resolve race: the job is holding a thread it loaded
+    # while it was open, and the resolve has already committed (and swept)
+    # by the time it gets here. A row created now would never be swept —
+    # and would push. The lock reloads, so nothing is created.
+    it "sees a close that committed after the job loaded the thread" do
+      stale = CoPlan::CommentThread.find(thread.id)
+      CoPlan::CommentThread.find(thread.id).resolve!(plan_author)
+      expect(stale.status).to eq("pending") # in-memory copy is behind
+
+      expect {
+        described_class.call(comment_thread: stale, actor_id: create(:coplan_user).id, reason: "agent_response")
+      }.not_to change(CoPlan::Notification, :count)
+    end
+
     it "still notifies about a status change when the thread was reopened" do
       resolved_thread.update!(status: "pending", resolved_by_user: nil)
 

--- a/spec/services/notifications/mark_plan_read_spec.rb
+++ b/spec/services/notifications/mark_plan_read_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::Notifications::MarkPlanRead do
+  let(:author) { create(:coplan_user) }
+  let(:reviewer) { create(:coplan_user) }
+  let(:plan) { create(:plan, created_by_user: author) }
+  let(:thread) { create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: reviewer) }
+
+  before { allow(CoPlan::Broadcaster).to receive(:update_to) }
+
+  it "marks every unread row this person carries for the plan read" do
+    first = create(:notification, user: author, plan: plan, comment_thread: thread)
+    second = create(:notification, user: author, plan: plan, comment_thread: thread, reason: "agent_response")
+
+    expect(described_class.call(user: author, plan_id: plan.id)).to eq(2)
+    expect(first.reload.read_at).to be_present
+    expect(second.reload.read_at).to be_present
+  end
+
+  it "leaves rows for other plans alone" do
+    other_plan = create(:plan, created_by_user: author)
+    other_thread = create(:comment_thread, plan: other_plan, plan_version: other_plan.current_plan_version, created_by_user: reviewer)
+    other = create(:notification, user: author, plan: other_plan, comment_thread: other_thread)
+
+    described_class.call(user: author, plan_id: plan.id)
+
+    expect(other.reload.read_at).to be_nil
+  end
+
+  it "leaves other people's rows for the same plan alone" do
+    theirs = create(:notification, user: reviewer, plan: plan, comment_thread: thread)
+
+    described_class.call(user: author, plan_id: plan.id)
+
+    expect(theirs.reload.read_at).to be_nil
+  end
+
+  it "does not rewrite an already-read row's timestamp" do
+    read_at = 2.days.ago
+    already_read = create(:notification, user: author, plan: plan, comment_thread: thread, read_at: read_at)
+
+    described_class.call(user: author, plan_id: plan.id)
+
+    expect(already_read.reload.read_at).to be_within(1.second).of(read_at)
+  end
+
+  it "refreshes the badge" do
+    create(:notification, user: author, plan: plan, comment_thread: thread)
+
+    expect(CoPlan::Broadcaster).to receive(:update_to).with(
+      "coplan_notifications:#{author.id}",
+      target: "inbox-badge",
+      html: "0"
+    )
+
+    described_class.call(user: author, plan_id: plan.id)
+  end
+
+  # Every plan view calls this, and almost every view has nothing to clear.
+  it "broadcasts nothing when there was nothing unread" do
+    expect(CoPlan::Broadcaster).not_to receive(:update_to)
+    expect(described_class.call(user: author, plan_id: plan.id)).to eq(0)
+  end
+
+  it "does nothing without a plan id" do
+    unrelated = create(:notification, user: author, plan: plan, comment_thread: thread)
+
+    expect(described_class.call(user: author, plan_id: "")).to eq(0)
+    expect(unrelated.reload.read_at).to be_nil
+  end
+end

--- a/spec/services/notifications/mark_thread_read_spec.rb
+++ b/spec/services/notifications/mark_thread_read_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::Notifications::MarkThreadRead do
+  let(:author) { create(:coplan_user) }
+  let(:reviewer) { create(:coplan_user) }
+  let(:plan) { create(:plan, created_by_user: author) }
+  let(:thread) { create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: reviewer) }
+
+  before { allow(CoPlan::Broadcaster).to receive(:update_to) }
+
+  it "marks every unread row for the thread read" do
+    first = create(:notification, user: author, plan: plan, comment_thread: thread)
+    second = create(:notification, user: reviewer, plan: plan, comment_thread: thread, reason: "agent_response")
+
+    expect(described_class.call(comment_thread: thread)).to eq(2)
+    expect(first.reload.read_at).to be_present
+    expect(second.reload.read_at).to be_present
+  end
+
+  it "leaves rows for other threads alone" do
+    other_thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: reviewer)
+    other = create(:notification, user: author, plan: plan, comment_thread: other_thread)
+
+    described_class.call(comment_thread: thread)
+
+    expect(other.reload.read_at).to be_nil
+  end
+
+  it "does not rewrite an already-read row's timestamp" do
+    read_at = 2.days.ago
+    already_read = create(:notification, user: author, plan: plan, comment_thread: thread, read_at: read_at)
+
+    described_class.call(comment_thread: thread)
+
+    expect(already_read.reload.read_at).to be_within(1.second).of(read_at)
+  end
+
+  it "refreshes the badge for each affected person" do
+    create(:notification, user: author, plan: plan, comment_thread: thread)
+
+    expect(CoPlan::Broadcaster).to receive(:update_to).with(
+      "coplan_notifications:#{author.id}",
+      target: "inbox-badge",
+      html: "0"
+    )
+
+    described_class.call(comment_thread: thread)
+  end
+
+  it "broadcasts nothing when there was nothing unread" do
+    expect(CoPlan::Broadcaster).not_to receive(:update_to)
+    expect(described_class.call(comment_thread: thread)).to eq(0)
+  end
+end

--- a/spec/services/notifications/needs_attention_spec.rb
+++ b/spec/services/notifications/needs_attention_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe CoPlan::Notifications::NeedsAttention do
     expect(result.unread_counts).to be_empty
   end
 
+  # The workspace already grouped these counts for its per-row badges;
+  # passing them in saves the duplicate query. Counts that disagree with
+  # the database prove the hash was used rather than re-derived.
+  it "reuses counts the caller already grouped instead of re-querying" do
+    plan = create(:plan, :considering, created_by_user: user)
+    notify(plan, count: 2)
+
+    result = described_class.call(user: user, unread_counts: { plan.id => 99 })
+
+    expect(result.plans.map(&:id)).to eq([ plan.id ])
+    expect(result.unread_count_for(plan)).to eq(99)
+  end
+
   it "points each row at an unread notification for that plan" do
     plan = create(:plan, :considering, created_by_user: user)
     notify(plan)

--- a/spec/services/notifications/needs_attention_spec.rb
+++ b/spec/services/notifications/needs_attention_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe CoPlan::Notifications::NeedsAttention do
+  let(:user) { create(:coplan_user) }
+  let(:other_user) { create(:coplan_user) }
+
+  def notify(plan, count: 1, user: self.user, read: false)
+    thread = create(:comment_thread, plan: plan, plan_version: plan.current_plan_version, created_by_user: other_user)
+    count.times do
+      create(:notification, user: user, plan: plan, comment_thread: thread, read_at: read ? Time.current : nil)
+    end
+  end
+
+  it "counts unread rows per plan and orders plans most-unread first" do
+    quiet = create(:plan, :considering, created_by_user: user, title: "Quiet")
+    loud = create(:plan, :considering, created_by_user: user, title: "Loud")
+    notify(quiet, count: 1)
+    notify(loud, count: 3)
+
+    result = described_class.call(user: user)
+
+    expect(result.plans.map(&:title)).to eq([ "Loud", "Quiet" ])
+    expect(result.unread_count_for(loud)).to eq(3)
+    expect(result.unread_count_for(quiet)).to eq(1)
+    expect(result).to be_any
+  end
+
+  it "ignores read rows and other people's rows" do
+    plan = create(:plan, :considering, created_by_user: user)
+    notify(plan, read: true)
+    notify(plan, user: other_user)
+
+    result = described_class.call(user: user)
+
+    expect(result.plans).to be_empty
+    expect(result).not_to be_any
+    expect(result.unread_counts).to be_empty
+  end
+
+  it "points each row at an unread notification for that plan" do
+    plan = create(:plan, :considering, created_by_user: user)
+    notify(plan)
+
+    result = described_class.call(user: user)
+
+    notification = user.notifications.unread.first
+    expect(result.notification_id_for(plan)).to eq(notification.id)
+  end
+
+  it "caps the strip at LIMIT plans and reports the remainder" do
+    plans = Array.new(described_class::LIMIT + 2) { |i| create(:plan, :considering, created_by_user: user, title: "Plan #{i}") }
+    plans.each_with_index { |plan, i| notify(plan, count: i + 1) }
+
+    result = described_class.call(user: user)
+
+    expect(result.plans.size).to eq(described_class::LIMIT)
+    expect(result.remaining).to eq(2)
+  end
+
+  it "drops a plan whose rows were cleared between the count and the lookup" do
+    plan = create(:plan, :considering, created_by_user: user)
+    notify(plan)
+    # Simulates another tab clearing the plan mid-request: the grouped
+    # count still sees the row, the per-plan lookup no longer does.
+    allow_any_instance_of(ActiveRecord::Relation).to receive(:pick).and_return(nil)
+
+    result = described_class.call(user: user)
+
+    expect(result.plans).to be_empty
+  end
+
+  it "never surfaces a plan the viewer cannot see" do
+    hidden = create(:plan, :draft, created_by_user: other_user)
+    notify(hidden)
+
+    result = described_class.call(user: user)
+
+    expect(result.plans).to be_empty
+  end
+end


### PR DESCRIPTION
## The bug

Open the workspace in production today and the "Needs attention" strip claims eleven unread comments on one plan and twenty on another. Click through and the plan looks empty — because those comments were all resolved. An agent replied to a batch of threads and then resolved them, and each reply plus each resolve minted an inbox row that outlived the thread it pointed at. The doc view hides a closed thread's highlight (`.anchor-highlight--resolved` is `pointer-events: none` until you press `s`), so the rows sent you somewhere with nothing to act on.

## The rule

A closed thread — `resolved` or `discarded` — carries no unread notifications.

- **Closing sweeps.** `CommentThread` gained an `after_commit` that calls `Notifications::MarkThreadRead` when a status write lands in a closed status. It lives on the model rather than in the two controllers that resolve/discard (web + API), so seeds, admin, and any future path are covered too. Rows stay in the inbox history; they just stop counting as unread.
- **Nothing new gets minted.** `Notifications::Create::SILENT_ON_CLOSED_THREAD` drops `agent_response` and `status_change` on an already-closed thread. Human `reply` and `mention` still notify — somebody deliberately re-engaging with a settled thread is news, and that's the one signal I didn't want to swallow. **Flagging this as the judgement call in the PR:** the trade is that when an agent resolves a thread, you no longer get told. Say the word and I'll make `status_change`-on-resolve survive.
- **The existing pile gets cleared.** `MarkClosedThreadNotificationsRead` marks read every unread row whose thread is already closed. Data-only, idempotent, so `db/schema.rb` moves by one version line.
- **Reopening still notifies.** `reopen` sets `pending` before the job runs, so the thread is open and the `status_change` lands.

## Getting rid of the rest

**Opening a plan clears that plan's unread rows.** You looked; the nudge is done. `Notifications::MarkPlanRead`.

The signal for "opened" is `PlanPresenceChannel#subscribed`, not the `GET`. Workspace rows opt into Turbo 8 hover prefetch, which makes the request unreliable in both directions: resting the cursor on a row fetches the page (so clearing there would quietly empty the strip for a visit nobody made — I hit this in the browser), and a click within 10s is served from Turbo's prefetch cache without touching the server at all. The presence subscribe only happens when the page is live in front of somebody. `PlansController#show` clears too, for navigations Turbo didn't prefetch, and skips `X-Sec-Purpose: prefetch` — which also stops a hover from advancing your last-seen mark and burning the changed-section highlights, a pre-existing bug of the same shape.

**And a `✕` per row**, for plans you don't want to open. It:

- marks that plan's unread rows read
- re-renders the strip in place, because clearing one plan can promote the next one into the top five
- removes that plan row's own unread badge (a row still reading "3" under a cleared strip reads as a stale page)
- refreshes the bell

No navigation, no scroll jump, no full reload; the row hides the moment you press it rather than narrating "Clearing…". Verified in a browser against a seeded worktree DB: hover a row → nothing clears; click it → its rows clear and the bell drops live over the existing notifications stream; `✕` on the rest → strip empties and disappears rather than leaving an empty bordered box.

## Refactors this pulled in

- The strip moved out of `plans/index.html.erb` into `plans/_needs_attention.html.erb` behind `Notifications::NeedsAttention`, so the workspace and the Clear response render the same thing from the same query object. It also now drops a row whose notification vanished mid-request instead of raising on `fetch`.
- The badge-broadcast block that was copy-pasted in `Notifications::Create`, `Comments::ProcessMentions`, and `NotificationsController` is now `Notifications::BroadcastBadges`.

## Testing

`bundle exec rspec` — 1538 examples, 0 failures. New coverage: the close sweep (model, web resolve/discard, API resolve), the reply-then-resolve race (fails without the thread lock), the silencing rule including the reply/mention/reopen exceptions, `NeedsAttention` (ordering, cap, visibility predicate, mid-request clear, not built for pagination frames), clear-on-open (plan show clears the viewer's rows and nobody else's, ignores a prefetch, doesn't advance last-seen on a prefetch, presence subscribe clears, rejected subscription doesn't), `mark_plan_read` (scoping to the acting user, turbo-stream targets, no-op without a plan_id), and the migration (idempotent, leaves open threads and already-read rows alone). Also confirmed the reflected `plan_id` is escaped in the `turbo-stream` target attribute.

## Still open

The bigger question you raised — whether a local agent writing one comment should push at all — isn't touched here. Web Push still fans out per notification created; the only change is that fewer notifications exist to push. Worth its own pass on per-reason delivery rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
