### PR TITLE
Markdown slideshows: the deck design system and present mode

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -106,6 +106,10 @@ module CoPlan
         key: "launch-deck", author: "priya", type: "Presentation", title: "Shared workspaces launch — readout deck",
         tags: %w[collaboration launch], visibility: "published", folder: "Product/Launches/Shared workspace", fixture: :slideshow_deck
       },
+      {
+        key: "pattern-showcase", author: "sam", type: "Presentation", title: "Slide layout patterns — a tour of the deck design system",
+        tags: %w[design slides], visibility: "published", folder: "Engineering/Active projects", fixture: :pattern_showcase
+      },
       # A folder whose documents all repeat its name — the shape that makes
       # a real library unreadable, and exactly what URL slugs strip. These
       # land at /<handle>/liveorder/{cart-state-machine,…}, with
@@ -400,6 +404,98 @@ module CoPlan
 
         [dash]: https://observability.example.com/d/workspace-adoption
         [^presence]: Presence reuses the comment-notification channel, so it ships with no new infrastructure.
+      MARKDOWN
+      # One slide per layout pattern in docs/SLIDE_SPEC.md, in catalog
+      # order — the visual regression corpus for the deck design system.
+      # Layout is inferred from content shape; nothing here is a directive.
+      pattern_showcase: <<~'MARKDOWN',
+        Every slide in this deck earns its layout from its shape alone.
+
+        ---
+
+        ## What the classifier sees
+
+        - A lone heading becomes a title slide
+        - Two lists sit side by side
+        - One image or diagram takes the whole stage
+        - Code gets the stage, not a text box
+
+        ---
+
+        ## Writing a deck / designing a deck
+
+        - pick the words
+        - split with `---`
+        - share the plan link
+
+        * no theme CSS
+        * no layout directives
+        * no ugly slides
+
+        ---
+
+        ## The decision list
+
+        ```ruby
+        return :title if lead && body.empty?
+        return :stage if media_block?(featured)
+        return :split if media_at_edge?(body)
+        ```
+
+        ---
+
+        ## How a slide finds its shape
+
+        ```mermaid
+        flowchart LR
+          MD[markdown] --> Split --> Classify
+          Classify --> T[title]
+          Classify --> C[columns]
+          Classify --> S[stage]
+        ```
+
+        ---
+
+        ## Reviewed like a document
+
+        - Comment on any bullet, on any slide
+        - Every edit is a version with provenance
+        - Present from the same link
+
+        ![CoPlan](/coplan-logo.png)
+
+        <!-- notes: This split slide is why decks live in CoPlan at all. -->
+
+        ---
+
+        > The default output has to be genuinely beautiful with zero effort.
+
+        — the design plan
+
+        ---
+
+        ## Type steps, not shrink-to-fit
+
+        | Units | Step | Feels like |
+        |---|---|---|
+        | ≤ 5 | 1 | a poster |
+        | 6–9 | 2 | a slide |
+        | 10–14 | 3 | a dense slide |
+        | 15+ | 4 | time to split it |
+
+        ---
+
+        ## A dense slide steps down
+
+        - the type scale drops one discrete step at a time
+        - so sparse slides look intentional, not zoomed in
+        - and dense slides fit without shrink-to-fit soup
+        - seven or more lines lands on step two
+        - past fourteen you get step four, the floor
+        - past the floor, content scrolls instead of clipping
+        - and the fit report will tell the agent to split the slide
+        - which is the honest fix anyway
+        - one idea per slide beats one slide per idea
       MARKDOWN
       spanish: "## Problema\n\nLas personas nuevas necesitan saber qué paso completar.\n\n## Resultado\n\nUna lista breve muestra el siguiente paso.",
       japanese: "## 目標\n\n障害の影響を小さくし、復旧までの時間を短縮します。\n\n## 次のステップ\n\n復旧手順を自動で検証します。",
@@ -743,7 +839,7 @@ module CoPlan
       parts = [ "# #{definition.fetch(:title)}" ]
 
       # Fixtures that are complete document bodies — no lorem filler around them.
-      if %i[spanish japanese arabic code_walkthrough collab_showcase slideshow_deck].include?(definition[:fixture])
+      if %i[spanish japanese arabic code_walkthrough collab_showcase slideshow_deck pattern_showcase].include?(definition[:fixture])
         parts << fixture
         return parts.join("\n\n")
       end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -496,6 +496,63 @@ module CoPlan
         - and the fit report will tell the agent to split the slide
         - which is the honest fix anyway
         - one idea per slide beats one slide per idea
+
+        ---
+
+        ## When a slide is mostly words
+
+        Some slides are paragraphs, not bullets — the narrative beat in the middle of a readout, the decision memo an exec will actually read, the part you'd deliver word for word. The classifier doesn't blink: prose is billed line for line, the type scale steps down, and the slide stays a slide.
+
+        Nothing past the smallest step gets clipped. The card scrolls, and the fit report will tell the author — human or agent — exactly which slide burst its budget and by how much, so too much text becomes an editing decision instead of a rendering accident.
+
+        Steps are discrete on purpose. Sparse slides look intentional at full size instead of zoomed in, dense slides stay readable at the floor, and nothing wobbles between the two while you type.
+
+        ---
+
+        ## Every project in flight
+
+        - **Atlas** — payment routing rewrite
+        - **Beacon** — merchant onboarding funnel
+        - **Cairn** — ledger archival tier
+        - **Delta** — settlement diff tooling
+        - **Ember** — incident review workflow
+        - **Fathom** — search relevance overhaul
+        - **Garnet** — receipts rendering service
+        - **Harbor** — sandbox environment refresh
+        - **Ivory** — design token consolidation
+        - **Juniper** — notification digest engine
+        - **Keel** — schema migration guardrails
+        - **Lumen** — dashboard latency budget
+        - **Mesa** — reporting warehouse sync
+        - **Nimbus** — mobile offline cache
+        - **Onyx** — audit log retention
+        - **Prism** — experiment analysis pipeline
+        - **Quarry** — data extraction contracts
+        - **Rudder** — feature flag hygiene
+        - **Sable** — dark mode rollout
+        - **Tundra** — cold storage pricing
+        - **Umber** — brand refresh implementation
+        - **Vessel** — container base images
+        - **Wharf** — deploy queue fairness
+        - **Xenon** — load test harness
+        - **Yarrow** — accessibility audit fixes
+        - **Zephyr** — websocket connection pooling
+        - **Anvil** — build cache warming
+        - **Bramble** — dependency update automation
+        - **Cobalt** — API version sunset
+        - **Drift** — config drift detection
+        - **Ellipse** — chart rendering library
+        - **Fresco** — image pipeline thumbnails
+        - **Gully** — log ingestion sampling
+        - **Hollow** — orphaned record cleanup
+        - **Ingot** — billing proration engine
+        - **Jetty** — edge routing rules
+        - **Kite** — status page automation
+        - **Ledger** — double-entry backfill
+        - **Moss** — test flake quarantine
+        - **Nectar** — customer feedback tagging
+
+        <!-- notes: The deliberately-too-much slide. Forty entries land on the floor step and the card scrolls — the fit report will tell the author to split it, or to make it two lists and get columns. -->
       MARKDOWN
       spanish: "## Problema\n\nLas personas nuevas necesitan saber qué paso completar.\n\n## Resultado\n\nUna lista breve muestra el siguiente paso.",
       japanese: "## 目標\n\n障害の影響を小さくし、復旧までの時間を短縮します。\n\n## 次のステップ\n\n復旧手順を自動で検証します。",

--- a/docs/SLIDE_SPEC.md
+++ b/docs/SLIDE_SPEC.md
@@ -78,7 +78,7 @@ blocks. Classify the same string the renderer renders — in CoPlan that
 includes the hoisted definition preamble, so reference-style images
 (`![chart][q3]`) resolve to image nodes here exactly as they do on screen.
 
-Four derived terms:
+Five derived terms:
 
 - **lead heading** — the first block of the content sequence, if it is a
   heading (any level). The **body** is the sequence minus the lead heading.
@@ -96,6 +96,12 @@ Four derived terms:
   whitespace and comments, or a code block whose info string's **first
   word** is `mermaid` (the rest of the info string is renderer options,
   which is also how the rendered `lang` attribute treats it).
+- **short entry** — a list item holding exactly one paragraph, with no
+  images and no hard line breaks, whose plain text is at most 60
+  characters: one rendered line, an inventory row. An item carrying more
+  structure than that — a nested list, a second paragraph, a long line —
+  is an argument, not an entry. Comment-only HTML blocks inside the item
+  don't count as structure (comments never influence layout).
 
 ## The pattern catalog
 
@@ -111,15 +117,16 @@ body (the sequence after the lead heading, which any pattern may carry).
 | 5 | one blockquote ± one adjacent short paragraph | `quote` |
 | 6 | one table ± one adjacent short paragraph | `table` |
 | 7 | exactly two lists | `columns` |
-| 8 | exactly one media block, first or last, plus anything else | `split` |
-| 9 | anything else (including an empty sequence) | `content` |
+| 8 | one list of at least 15 short entries | `directory` |
+| 9 | exactly one media block, first or last, plus anything else | `split` |
+| 10 | anything else (including an empty sequence) | `content` |
 
 "± one adjacent short paragraph" means the body is either the block alone,
 or the block plus one short paragraph immediately before or after it —
 a kicker line or a caption. Anything more is a `content` or `split` slide.
 
 Rule 3 sits above rule 4, so a `mermaid` fence is always media, never code.
-Rule 8 requires at least one non-media block, so a lone image lands on
+Rule 9 requires at least one non-media block, so a lone image lands on
 `stage`, and requires exactly one media block, so two images fall through to
 `content` rather than guessing which one gets the pane.
 
@@ -334,6 +341,122 @@ And a closing thought that keeps this a document section.
 pattern: content
 ```
 
+### `directory` — one long inventory flows into two columns
+
+One list of at least fifteen short entries and nothing else. That shape is
+an inventory — every project in flight, the full roster, an API surface —
+not an argument, and a single column of it runs off the canvas while half
+the slide sits empty. The list flows into two balanced columns; an ordered
+list keeps counting down the first column and into the second.
+
+Because the list renders in two columns it also bills at half for the
+type scale (see below) — the pattern doesn't just fit the inventory, it
+keeps the type readable while doing it:
+
+```conformance
+## Every project in flight
+
+- Atlas — payment routing
+- Beacon — status page
+- Cedar — ledger exports
+- Delta — dispute intake
+- Ember — fraud scoring
+- Flint — invoice search
+- Grove — seller onboarding
+- Harbor — webhook retries
+- Iris — receipt redesign
+- Juniper — tax engine
+- Keel — capacity planning
+- Lumen — audit trails
+- Maple — payout scheduling
+- Nectar — feedback tagging
+- Onyx — rate limiting
+- Pine — sandbox reset
+.
+pattern: directory
+step: 2
+```
+
+Fourteen entries is a long content slide, not a directory — below the
+threshold the list stays one column and bills in full:
+
+```conformance
+## Every project in flight
+
+- Atlas — payment routing
+- Beacon — status page
+- Cedar — ledger exports
+- Delta — dispute intake
+- Ember — fraud scoring
+- Flint — invoice search
+- Grove — seller onboarding
+- Harbor — webhook retries
+- Iris — receipt redesign
+- Juniper — tax engine
+- Keel — capacity planning
+- Lumen — audit trails
+- Maple — payout scheduling
+- Nectar — feedback tagging
+.
+pattern: content
+step: 4
+```
+
+A speaker note tucked inside an entry is still a comment — it neither
+breaks the entry's shape nor bills:
+
+```conformance
+## Every project in flight
+
+- Atlas — payment routing
+- Beacon — status page
+- Cedar — ledger exports
+- Delta — dispute intake
+
+  <!-- double-check the owner with Maya -->
+
+- Ember — fraud scoring
+- Flint — invoice search
+- Grove — seller onboarding
+- Harbor — webhook retries
+- Iris — receipt redesign
+- Juniper — tax engine
+- Keel — capacity planning
+- Lumen — audit trails
+- Maple — payout scheduling
+- Nectar — feedback tagging
+- Onyx — rate limiting
+.
+pattern: directory
+step: 2
+```
+
+Every item must be a short entry. One entry carrying real prose means the
+list is an argument, and arguments read top to bottom:
+
+```conformance
+## Every project in flight
+
+- Atlas — payment routing
+- Beacon — status page
+- Cedar — ledger exports
+- Delta — dispute intake
+- Ember — fraud scoring
+- Flint — invoice search
+- Grove — seller onboarding
+- Harbor — webhook retries
+- Iris — receipt redesign
+- Juniper — tax engine
+- Keel — capacity planning
+- Lumen — audit trails
+- Maple — payout scheduling
+- Nectar — feedback tagging
+- Meridian — the cross-region failover rehearsal program we keep deferring
+.
+pattern: content
+step: 4
+```
+
 ### `split` — media pane beside content
 
 Exactly one media block at the body's edge, with real content beside it.
@@ -419,7 +542,9 @@ code renders at 0.8 em with 1.55 line-height — about ⅚ of a body line per
 code line, not half of one. A mermaid fence renders as a fit-to-box
 diagram, so it bills like media, not like its source line count.
 
-The slide's units are the sum over its content sequence. The step:
+The slide's units are the sum over its content sequence, with one
+pattern-aware adjustment: a `directory` slide's list renders across two
+columns, so it bills at ⌈its units / 2⌉. The step:
 
 | Units | Step |
 |---|---|

--- a/docs/SLIDE_SPEC.md
+++ b/docs/SLIDE_SPEC.md
@@ -593,9 +593,12 @@ Launch themes: **coplan** (light, Lexend, blue accent — the default),
 **graphite** (near-black canvas, cool ink, sky accent), **poster** (warm
 paper, heavy display type, red-orange accent; title slides go full-accent).
 
-Code block interiors keep the syntax highlighter's own palette in every
-theme — fighting inline highlight styles is a losing game, and code
-legibility beats theme purity.
+Code panels are part of the artifact: one fixed dark panel and one fixed
+highlight palette in every theme and every reader color scheme. A host
+whose highlighter palette follows its own light/dark mode must pin the
+palette inside slides — a deck renders the same on every screen. The same
+rule governs diagrams: a rendered diagram takes its colors from the deck
+theme, never from the reader's scheme.
 
 ## Out of scope here
 

--- a/docs/SLIDE_SPEC.md
+++ b/docs/SLIDE_SPEC.md
@@ -1,0 +1,606 @@
+# SLIDE_SPEC — the deck layout contract
+
+This document is the product boundary of CoPlan's deck design system. On one
+side: plain CommonMark and a deterministic classifier that assigns every slide
+a layout pattern. On the other: a markup contract and a stylesheet
+(`deck.css` + `deck-theme-*.css`) that render those patterns. Anything that
+implements this spec — CoPlan's Ruby renderer today, a JS implementation
+later — produces the same deck from the same markdown.
+
+Two properties are non-negotiable and every rule below serves them:
+
+1. **Determinism.** The same content produces the same deck on every render.
+   No measurement, no AI, no randomness in the layout path.
+2. **No layout syntax.** Layout is a function of content shape. Authors and
+   agents control layout the same way they control everything else: by
+   editing the markdown.
+
+## Conformance examples are the test suite
+
+Fenced blocks labeled `conformance` in this document are executable fixtures.
+Each contains a slide's markdown, then a line holding a single `.`, then the
+expected classification as `key: value` lines:
+
+    ```conformance
+    ## Heading
+
+    Some text.
+    .
+    pattern: content
+    step: 1
+    ```
+
+A conformance runner turns every block into a test case
+(`spec/services/slideshows/conformance_spec.rb`). `pattern` is always
+asserted; `step` and `media` are asserted when present. The spec cannot drift
+from the implementation, and a future implementation in another language
+proves itself against the same fixtures.
+
+## Input: the content sequence
+
+Classification operates on one slide's markdown (boundaries and definition
+hoisting are upstream concerns; see `Slideshows::Split`). Parse it as
+CommonMark with the host's extensions (CoPlan: footnotes, tables,
+strikethrough, autolink, tasklist). The **content sequence** is the slide's
+top-level blocks, excluding:
+
+- HTML blocks that consist entirely of comments — speaker notes and other
+  comments never influence layout;
+- footnote definitions — they render in the document's back matter, not on
+  the slide.
+
+Comment boundaries follow the HTML parser that decides what renders:
+`<!-->` and `<!--->` are complete (empty) comments, a normal comment runs
+to the next `-->`, and a comment opened but never closed swallows the rest
+of the block. What renders as nothing classifies as nothing:
+
+```conformance
+## The plan
+
+![roadmap](map.png)
+
+<!-- todo: tighten this caption
+.
+pattern: stage
+step: 1
+```
+
+```conformance
+## Q3 review
+
+<!--> This sentence is visible on screen, framed by two empty comments. <!-->
+.
+pattern: content
+```
+
+Link-reference definitions are consumed by the parser and contribute no
+blocks. Classify the same string the renderer renders — in CoPlan that
+includes the hoisted definition preamble, so reference-style images
+(`![chart][q3]`) resolve to image nodes here exactly as they do on screen.
+
+Four derived terms:
+
+- **lead heading** — the first block of the content sequence, if it is a
+  heading (any level). The **body** is the sequence minus the lead heading.
+- **plain text** — a block's visible characters: its text and inline code.
+  Image alt text renders as an attribute, zero glyphs on the canvas, so it
+  never counts — an image's cost is exactly its image units, however it is
+  described.
+- **short paragraph** — a paragraph containing no images whose plain text
+  is at most 160 characters, counting each hard line break as a full
+  line's worth (60 characters). Long enough for a subtitle, a caption, or
+  an attribution; too short to be the point of the slide — an image is
+  never a subtitle, and neither is a stack of hard-broken lines.
+- **media block** — either a paragraph whose inline content is exactly one
+  image (optionally wrapped in a single link) and nothing else but
+  whitespace and comments, or a code block whose info string's **first
+  word** is `mermaid` (the rest of the info string is renderer options,
+  which is also how the rendered `lang` attribute treats it).
+
+## The pattern catalog
+
+Evaluate the rules **in this order; first match wins.** All rules test the
+body (the sequence after the lead heading, which any pattern may carry).
+
+| # | Rule (on the body) | Pattern |
+|---|---|---|
+| 1 | empty, with a lead heading | `title` |
+| 2 | one short paragraph, with a lead heading | `title` |
+| 3 | one media block ± one adjacent short paragraph | `stage` |
+| 4 | one code block ± one adjacent short paragraph | `code` |
+| 5 | one blockquote ± one adjacent short paragraph | `quote` |
+| 6 | one table ± one adjacent short paragraph | `table` |
+| 7 | exactly two lists | `columns` |
+| 8 | exactly one media block, first or last, plus anything else | `split` |
+| 9 | anything else (including an empty sequence) | `content` |
+
+"± one adjacent short paragraph" means the body is either the block alone,
+or the block plus one short paragraph immediately before or after it —
+a kicker line or a caption. Anything more is a `content` or `split` slide.
+
+Rule 3 sits above rule 4, so a `mermaid` fence is always media, never code.
+Rule 8 requires at least one non-media block, so a lone image lands on
+`stage`, and requires exactly one media block, so two images fall through to
+`content` rather than guessing which one gets the pane.
+
+### `title` — a heading is the slide
+
+The opening slide, a section divider, a one-line claim. Big, confident,
+generously inset. The optional short paragraph renders as a subtitle.
+
+```conformance
+# Q3 Orders Review
+
+Hampton · August 2026
+.
+pattern: title
+step: 1
+```
+
+```conformance
+## Part two: what we learned
+.
+pattern: title
+step: 1
+```
+
+A long paragraph under a heading is prose, not a subtitle:
+
+```conformance
+# Background
+
+This project began as a request from the platform team to consolidate the
+four different rendering pipelines that had accumulated over the years into
+one well-tested path with a single owner.
+.
+pattern: content
+```
+
+Images are never a subtitle — a paragraph of images under a heading is the
+point of the slide, not a caption for the heading:
+
+```conformance
+## Before and after
+
+![before](a.png) ![after](b.png)
+.
+pattern: content
+```
+
+### `stage` — one visual gets the whole canvas
+
+A lone image or mermaid diagram, centered large. A short paragraph beside it
+becomes the caption; the lead heading becomes a small kicker above.
+
+```conformance
+![conversion funnel](funnel.png)
+.
+pattern: stage
+step: 1
+```
+
+Alt text is invisible, so it moves nothing — a thorough accessibility
+description classifies exactly like a terse one, and an inline comment
+beside the image is a speaker note, not content:
+
+```conformance
+![A line chart of checkout conversion, trailing twelve months, showing the recovery after the August incident and the plateau near six percent](chart.png)
+.
+pattern: stage
+step: 1
+```
+
+```conformance
+![chart](c.png) <!-- swap for the final export -->
+.
+pattern: stage
+step: 1
+```
+
+```conformance
+## The one chart that matters
+
+![conversion](chart.png)
+
+Checkout conversion, trailing 12 months.
+.
+pattern: stage
+```
+
+````conformance
+## How rendering flows
+
+```mermaid
+flowchart LR
+  MD --> Split --> Deck
+```
+.
+pattern: stage
+````
+
+Only the info string's first word decides — options after it don't turn
+the diagram back into code:
+
+````conformance
+```mermaid theme=dark
+flowchart LR
+  A --> B
+```
+.
+pattern: stage
+step: 1
+````
+
+### `code` — code gets the stage, not a text box
+
+One code block, near-full-bleed, syntax highlighted. The lead heading
+renders as a kicker; one short paragraph may sit with it.
+
+````conformance
+## The whole classifier
+
+```ruby
+def pattern_for(body)
+  return :title if body.empty?
+end
+```
+.
+pattern: code
+````
+
+### `quote` — a pull quote, oversized
+
+One blockquote, with an optional short attribution paragraph.
+
+```conformance
+> The default output has to be genuinely beautiful with zero effort.
+
+— the design plan
+.
+pattern: quote
+step: 1
+```
+
+### `table` — scaled tabular typography
+
+One table, full width, with an optional short paragraph.
+
+```conformance
+## Latency by region
+
+| Region | p50 | p99 |
+|---|---|---|
+| us-east | 12ms | 80ms |
+| eu-west | 19ms | 104ms |
+.
+pattern: table
+```
+
+### `columns` — two lists sit side by side
+
+Exactly two consecutive lists. The universal before/after, pro/con,
+this-vs-that shape.
+
+CommonMark merges same-marker lists across blank lines into one list, so
+two lists are written the way CommonMark makes them: change the bullet
+marker, or put a bare comment between them (the standard list-splitting
+idiom — and comments are excluded from the content sequence, so
+`list, comment, list` classifies as two lists).
+
+```conformance
+## Before and after
+
+- four render pipelines
+- three owners
+- no tests
+
+* one pipeline
+* one owner
+* conformance suite
+.
+pattern: columns
+step: 2
+```
+
+```conformance
+## Ship / hold
+
+1. deck view
+2. themes
+
+<!-- -->
+
+1. presenter
+2. fit report
+.
+pattern: columns
+step: 1
+```
+
+A third list, or trailing prose, means the author is writing a document
+section, not a comparison — fall through:
+
+```conformance
+## Everything at once
+
+- one
+- two
+
+* three
+* four
+
+And a closing thought that keeps this a document section.
+.
+pattern: content
+```
+
+### `split` — media pane beside content
+
+Exactly one media block at the body's edge, with real content beside it.
+The media's position is part of the classification: first block →
+`media: leading` (pane leads), last block → `media: trailing` (pane
+trails). Authors move the image in the source to move it on the slide.
+
+```conformance
+![dashboard](dash.png)
+
+## What reviewers see
+
+Every slide is a card. Comments anchor to slide text exactly as they do in
+documents, so the review loop needs no new tooling.
+.
+pattern: split
+media: leading
+```
+
+```conformance
+## Rollout status
+
+- beta cohort live
+- pricing page updated
+- survey drafted
+
+![status board](board.png)
+.
+pattern: split
+media: trailing
+```
+
+An image in the middle of the content is illustration flow, not a pane:
+
+```conformance
+Intro paragraph.
+
+![figure](fig.png)
+
+Closing paragraph.
+.
+pattern: content
+```
+
+### `content` — the workhorse
+
+Heading plus bullets or prose. No special structure; the type scale does
+the design work.
+
+```conformance
+## What shipped
+
+- Agent identity & attribution
+- Library rethink
+- Voice comments
+.
+pattern: content
+step: 1
+```
+
+## The type scale: steps, not shrink-to-fit
+
+Content volume picks one of four discrete type-scale steps. Sparse slides
+render big and intentional; dense slides step down and fit. Steps are
+computed from **units** — a deterministic estimate of rendered lines:
+
+| Block | Units |
+|---|---|
+| heading | 1 |
+| paragraph | ⌈plain-text length / 60⌉, minimum 1, plus 1 per hard line break, plus 3 per image |
+| list / list item / blockquote | sum of children, minimum 1 |
+| code block | ⌈code lines / 1.2⌉, minimum 1 |
+| media code block (mermaid) | 4 |
+| table | number of rows (header included) |
+| thematic break | 1 |
+| HTML block (non-comment) | 2 |
+| comment HTML block, footnote definition | 0 |
+
+The formulas estimate what the stylesheet actually renders. Plain text
+excludes alt text (invisible), and a hard line break forces a rendered
+line just as sixty characters do. The code divisor comes from `deck.css`:
+code renders at 0.8 em with 1.55 line-height — about ⅚ of a body line per
+code line, not half of one. A mermaid fence renders as a fit-to-box
+diagram, so it bills like media, not like its source line count.
+
+The slide's units are the sum over its content sequence. The step:
+
+| Units | Step |
+|---|---|
+| ≤ 5 | 1 |
+| 6–9 | 2 |
+| 10–14 | 3 |
+| ≥ 15 | 4 |
+
+Step 4 is the floor. Content past what step 4 fits is **reported, not
+clipped** — the deck view scrolls the slide and the fit report (phase 5)
+flags it to the authoring agent.
+
+```conformance
+## Seven points
+
+- alpha
+- bravo
+- charlie
+- delta
+- echo
+- foxtrot
+- golf
+.
+pattern: content
+step: 2
+```
+
+```conformance
+## Dense
+
+- a1
+- a2
+- a3
+- a4
+- a5
+- a6
+- a7
+- a8
+- a9
+- b1
+- b2
+- b3
+- b4
+.
+pattern: content
+step: 3
+```
+
+Hard-broken lines count like list lines — the same content can't dodge a
+step by swapping bullets for line breaks:
+
+```conformance
+## Agenda
+
+welcome\
+retro on the rollout\
+the fit report demo\
+open floor\
+next milestones\
+wrap-up
+.
+pattern: content
+step: 2
+```
+
+Twenty code lines land on the floor — at step 3 the canvas fits about
+seventeen:
+
+````conformance
+## The renderer
+
+```ruby
+line_01 = compute(1)
+line_02 = compute(2)
+line_03 = compute(3)
+line_04 = compute(4)
+line_05 = compute(5)
+line_06 = compute(6)
+line_07 = compute(7)
+line_08 = compute(8)
+line_09 = compute(9)
+line_10 = compute(10)
+line_11 = compute(11)
+line_12 = compute(12)
+line_13 = compute(13)
+line_14 = compute(14)
+line_15 = compute(15)
+line_16 = compute(16)
+line_17 = compute(17)
+line_18 = compute(18)
+line_19 = compute(19)
+line_20 = compute(20)
+```
+.
+pattern: code
+step: 4
+````
+
+## The markup contract
+
+What the renderer must produce; what the stylesheet may rely on. All
+classes live under the `deck-` namespace and everything is scoped beneath
+`.deck` — the design system touches nothing else on the page.
+
+```html
+<div class="deck" data-deck-theme="coplan">
+  <section class="deck-slide deck-slide--content deck-step-2"
+           data-slide="4" data-pattern="content">
+    <div class="deck-content">
+      <!-- the slide's rendered markdown blocks, in source order -->
+    </div>
+  </section>
+</div>
+```
+
+- Every slide is a `section.deck-slide` with modifier class
+  `deck-slide--<pattern>`, step class `deck-step-<n>`, `data-slide`
+  (1-based index) and `data-pattern`.
+- The rendered blocks sit inside one `div.deck-content`.
+- `split` slides additionally carry `data-media="leading|trailing"`, and
+  inside `.deck-content` the media block is wrapped in `div.deck-media` and
+  the remaining body blocks in `div.deck-body`, both in source order. The
+  lead heading, if any, stays a direct child and spans the panes — and
+  lead-ness is the classifier's call, not the DOM's: a raw-HTML heading is
+  body content and belongs inside `.deck-body`. If the rendered DOM does
+  not match the classified shape — sanitize can delete a raw-HTML block
+  wholesale or reduce it to loose text outside any element — the renderer
+  must skip the wrappers rather than wrap the wrong nodes or reorder
+  visible text around them; the stylesheet degrades to the content layout.
+
+Three invariants protect CoPlan's review loop and hold for every pattern:
+
+1. **No added visible text.** Slide numbers, quote marks, kicker rules —
+   all chrome is CSS-generated or structural. Comment anchors count
+   visible-text occurrences; deck view must count the same as document view.
+2. **No reordering.** DOM order is source order, always. Visual placement
+   (a trailing image pane on the left, a spanning heading) is grid/flex
+   placement, never node movement across content.
+3. **No reliance on host CSS.** `deck.css` styles everything under
+   `.deck-slide` from its own tokens. The page around the cards (gaps,
+   card borders, the rail) belongs to the host view.
+
+## Themes: validated tokens, never CSS
+
+A theme is a named set of custom-property values, applied by
+`data-deck-theme` on `.deck`. Slide canvases take their colors from the
+theme, not from the app's light/dark scheme — a deck is a fixed artifact
+that looks the same on every screen; only the page around it follows the
+app. Users and agents never author CSS; hosts may register additional theme
+files at deploy time.
+
+Every theme defines all of:
+
+| Token | Meaning |
+|---|---|
+| `--deck-bg` | slide canvas background |
+| `--deck-ink` | primary text |
+| `--deck-muted` | secondary text: captions, kickers, slide numbers |
+| `--deck-accent` | headings' companion color: rules, markers, links |
+| `--deck-accent-ink` | text placed on accent surfaces |
+| `--deck-rule` | hairlines: table rules, quote bars |
+| `--deck-title-bg` | title-slide canvas (lets a theme art-direct openers) |
+| `--deck-title-ink` | text on the title canvas |
+| `--deck-title-accent` | accent on the title canvas (a theme whose title canvas is the accent color must pick a visible one) |
+| `--deck-font-display` | headings |
+| `--deck-font-text` | body |
+| `--deck-font-mono` | code |
+| `--deck-display-weight` | heading weight |
+
+Launch themes: **coplan** (light, Lexend, blue accent — the default),
+**graphite** (near-black canvas, cool ink, sky accent), **poster** (warm
+paper, heavy display type, red-orange accent; title slides go full-accent).
+
+Code block interiors keep the syntax highlighter's own palette in every
+theme — fighting inline highlight styles is a losing game, and code
+legibility beats theme purity.
+
+## Out of scope here
+
+Slide splitting and definition hoisting (`Slideshows::Split`), speaker
+notes, the fit report's budgets, and presenter-mode chrome are CoPlan
+concerns documented with their implementations. This spec owns exactly:
+the content sequence, the catalog, the steps, the markup contract, and the
+theme tokens.

--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -2956,6 +2956,43 @@ img.avatar {
   display: block;
 }
 
+/* The Present control above a slideshow's deck. The show itself is
+   deck.css territory (.deck--presenting); this is host chrome. */
+.deck-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--space-sm);
+}
+
+.deck-toolbar__present {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  transition: color 0.15s, box-shadow 0.15s;
+}
+
+.deck-toolbar__present:hover {
+  color: var(--color-text);
+  box-shadow: var(--shadow-pop);
+}
+
+.deck-toolbar__present kbd {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0 4px;
+  color: var(--color-text-muted);
+}
+
 /* Add scroll-margin to headings — and the plan's own masthead header — so
    they clear the sticky nav. The nav-title control scrolls to the very top
    in JS; this keeps a no-JS #plan-header jump landing below the bar too. */

--- a/engine/app/assets/stylesheets/coplan/deck-theme-coplan.css
+++ b/engine/app/assets/stylesheets/coplan/deck-theme-coplan.css
@@ -1,0 +1,23 @@
+/* Deck theme: coplan — the default. Light, Lexend, the app's blue.
+   A theme is exactly the tokens in SLIDE_SPEC.md's table, nothing else.
+   Declared on bare .deck too so a deck with no data-deck-theme is this
+   theme. Canvas colors deliberately do NOT follow the app's light/dark
+   scheme: a deck is a fixed artifact that looks the same on every screen;
+   only the page around it follows the app. */
+
+.deck,
+.deck[data-deck-theme="coplan"] {
+  --deck-bg: #ffffff;
+  --deck-ink: #1c1e24;
+  --deck-muted: #697080;
+  --deck-accent: #2563eb;
+  --deck-accent-ink: #ffffff;
+  --deck-rule: #e5e8ef;
+  --deck-title-bg: #f6f8fc;
+  --deck-title-ink: #16181f;
+  --deck-title-accent: #2563eb;
+  --deck-font-display: "Lexend", system-ui, sans-serif;
+  --deck-font-text: "Lexend", system-ui, sans-serif;
+  --deck-font-mono: "Hack", ui-monospace, "SF Mono", Menlo, monospace;
+  --deck-display-weight: 700;
+}

--- a/engine/app/assets/stylesheets/coplan/deck-theme-graphite.css
+++ b/engine/app/assets/stylesheets/coplan/deck-theme-graphite.css
@@ -1,0 +1,19 @@
+/* Deck theme: graphite — near-black canvas, cool ink, sky accent.
+   The dark deck for rooms with the lights down. Token contract:
+   docs/SLIDE_SPEC.md "Themes". */
+
+.deck[data-deck-theme="graphite"] {
+  --deck-bg: #17191f;
+  --deck-ink: #e8eaf0;
+  --deck-muted: #99a2b3;
+  --deck-accent: #6ea8fe;
+  --deck-accent-ink: #0d0f14;
+  --deck-rule: #2b2f3a;
+  --deck-title-bg: #101218;
+  --deck-title-ink: #f2f4f9;
+  --deck-title-accent: #6ea8fe;
+  --deck-font-display: "Lexend", system-ui, sans-serif;
+  --deck-font-text: "Lexend", system-ui, sans-serif;
+  --deck-font-mono: "Hack", ui-monospace, "SF Mono", Menlo, monospace;
+  --deck-display-weight: 600;
+}

--- a/engine/app/assets/stylesheets/coplan/deck-theme-poster.css
+++ b/engine/app/assets/stylesheets/coplan/deck-theme-poster.css
@@ -1,0 +1,19 @@
+/* Deck theme: poster — warm paper, heavy display type, vermilion accent.
+   Title slides go full-accent: the opener is a poster. Token contract:
+   docs/SLIDE_SPEC.md "Themes". */
+
+.deck[data-deck-theme="poster"] {
+  --deck-bg: #faf6ef;
+  --deck-ink: #191713;
+  --deck-muted: #7a7266;
+  --deck-accent: #d94f30;
+  --deck-accent-ink: #fff6ee;
+  --deck-rule: #e7dfd2;
+  --deck-title-bg: #d94f30;
+  --deck-title-ink: #fff6ee;
+  --deck-title-accent: #fff6ee;
+  --deck-font-display: "Lexend", system-ui, sans-serif;
+  --deck-font-text: "Lexend", system-ui, sans-serif;
+  --deck-font-mono: "Hack", ui-monospace, "SF Mono", Menlo, monospace;
+  --deck-display-weight: 800;
+}

--- a/engine/app/assets/stylesheets/coplan/deck.css
+++ b/engine/app/assets/stylesheets/coplan/deck.css
@@ -130,10 +130,32 @@
   border-radius: 0.4em;
 }
 
+/* Code panels are part of the artifact: one fixed dark panel and one
+   fixed highlight palette (One Dark) in every deck theme and every app
+   scheme. The host flips its --code-* variables with the app's
+   light/dark mode — inside a deck that painted deck-ink text on a
+   near-black panel — so the panel pins every variable the host's code
+   chrome reads (panel, header, hairlines, highlight tokens). */
 .deck-slide .deck-content pre {
   font-size: 0.8em;
   line-height: 1.55;
   margin: 0.8em 0;
+  background: #0d1117;
+  color: #e6edf3;
+  border: 1px solid rgb(255 255 255 / 0.09);
+  --color-border: rgb(255 255 255 / 0.09);
+  --code-header-bg: #161b22;
+  --code-header-text: #8b8f98;
+  --code-comment: #7f848e;
+  --code-keyword: #c678dd;
+  --code-entity: #61afef;
+  --code-constant: #d19a66;
+  --code-string: #98c379;
+  --code-tag: #e06c75;
+  --code-addition-fg: #98c379;
+  --code-addition-bg: rgb(152 195 121 / 0.14);
+  --code-deletion-fg: #e06c75;
+  --code-deletion-bg: rgb(224 108 117 / 0.14);
 }
 
 .deck-slide .deck-content :not(pre) > code {

--- a/engine/app/assets/stylesheets/coplan/deck.css
+++ b/engine/app/assets/stylesheets/coplan/deck.css
@@ -252,12 +252,18 @@
 
 /* ---- stage — one visual gets the whole canvas ------------------------ */
 
+.deck-slide--stage {
+  /* The visual is the slide; the frame is a thin margin, not a stage
+     apron. */
+  padding: 2.5cqi 3.5cqi;
+}
+
 .deck-slide--stage .deck-content {
   display: flex;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 0.9em;
+  gap: 0.7em;
 }
 
 .deck-slide--stage .deck-content > h1,
@@ -277,7 +283,21 @@
 }
 
 .deck-slide--stage .deck-content img {
-  max-height: 36cqi;
+  max-height: 44cqi;
+}
+
+/* Mermaid inlines a natural-size max-width on its SVGs, which pins a
+   small diagram at thumbnail size; the stage overrides it so the diagram
+   scales up to the canvas (preserveAspectRatio keeps it undistorted). */
+.deck-slide--stage .deck-content .mermaid-diagram {
+  width: 100%;
+}
+
+.deck-slide--stage .deck-content .mermaid-diagram svg {
+  width: 100%;
+  height: 44cqi;
+  max-width: none !important;
+  max-height: none;
 }
 
 .deck-slide--stage .deck-content > p:not(:has(img)) {
@@ -384,6 +404,23 @@
   margin: 0;
 }
 
+/* ---- directory — one long inventory flows into two columns ------------
+   The list is the slide's only body block, so CSS multi-column balances
+   it; an ordered list keeps continuous numbering down-then-across. */
+
+.deck-slide--directory .deck-content > ul,
+.deck-slide--directory .deck-content > ol {
+  columns: 2;
+  column-gap: 2.6em;
+  margin: 0;
+}
+
+.deck-slide--directory .deck-content li {
+  break-inside: avoid;
+  margin-bottom: 0.3em;
+  line-height: 1.4;
+}
+
 /* ---- split — media pane beside content --------------------------------
    DOM order is source order (media leading → left pane, trailing → right),
    so grid auto-placement does the layout with zero reordering. Guarded on
@@ -412,4 +449,61 @@
   width: 100%;
   max-height: 40cqi;
   object-fit: contain;
+}
+
+/* ---- presenting — the deck takes the screen ---------------------------
+   Present mode (coplan--deck-presenter) shows the deck as a top-layer
+   popover sized to the largest 16:9 canvas that fits the viewport — the
+   deck stays the size container, so every cqi measurement above scales to
+   the screen with no presentation-specific typography. Top layer matters:
+   fixed positioning alone resolves against any backdrop-filter ancestor
+   (the host's glass card), while top-layer elements always position
+   against the viewport. The spread shadow blacks out the letterbox bars
+   without extra DOM; ::backdrop does the same when the top layer is in
+   charge. The border/padding/overflow resets neutralize the UA's popover
+   styles. */
+
+.deck--presenting {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  /* For the no-popover-API fallback: above every piece of app chrome
+     (the host tops out around 300). Irrelevant in the top layer. */
+  z-index: 1000;
+  width: min(100vw, calc(100vh * 16 / 9));
+  height: min(100vh, calc(100vw * 9 / 16));
+  gap: 0;
+  border: none;
+  padding: 0;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 0 0 100vmax #000;
+}
+
+.deck--presenting::backdrop {
+  background: #000;
+}
+
+/* Fullscreen is requested on the presenter wrapper (it survives
+   live-update swaps of the deck inside it); paint it black so nothing of
+   the page shows around the canvas. */
+.deck-presenter:fullscreen {
+  background: #000;
+}
+
+.deck--presenting .deck-slide {
+  display: none;
+}
+
+.deck--presenting .deck-slide--current {
+  display: flex;
+  height: 100%;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  overscroll-behavior: contain;
+}
+
+.deck--presenting .deck-slide--current::after {
+  content: attr(data-slide) " / " attr(data-slide-total);
 }

--- a/engine/app/assets/stylesheets/coplan/deck.css
+++ b/engine/app/assets/stylesheets/coplan/deck.css
@@ -478,10 +478,24 @@
   overflow: hidden;
   background: #000;
   box-shadow: 0 0 0 100vmax #000;
+  /* The presenter focuses the deck on start (tabindex="-1") so stray
+     focus can't soak up the navigation keys — no ring for that. */
+  outline: none;
 }
 
 .deck--presenting::backdrop {
   background: #000;
+}
+
+/* Presenting is the audience view: comment anchors keep their text but
+   drop their chrome — no tint, no underline. pointer-events: none means
+   hovering or clicking anchored text can't raise a thread popover over
+   the show; the click falls through to slide navigation. (The extra
+   .deck-slide level outranks the status variants' :hover rules.) */
+.deck--presenting .deck-slide .anchor-highlight {
+  background: none;
+  border-bottom: none;
+  pointer-events: none;
 }
 
 /* Fullscreen is requested on the presenter wrapper (it survives

--- a/engine/app/assets/stylesheets/coplan/deck.css
+++ b/engine/app/assets/stylesheets/coplan/deck.css
@@ -1,60 +1,393 @@
-/* Deck rendering for presentation-behavior plans.
+/* The deck design system — layout for docs/SLIDE_SPEC.md's markup contract.
 
-   Provisional review-view styling only: the real slide design system —
-   layout classifier, type scale steps, themes — arrives with SLIDE_SPEC.md
-   and replaces most of this file. Two rules are load-bearing already:
-   everything deck-scoped lives under .deck / .deck-* (so the design system
-   can be extracted as a standalone stylesheet later), and slide chrome is
-   structure around the content, never text inside it (comment anchors
-   count visible-text occurrences). */
+   Two rules are load-bearing:
+   - Everything lives under .deck / .deck-* and colors come only from the
+     --deck-* theme tokens (deck-theme-*.css), so spec + stylesheets can be
+     extracted as a standalone package post-v1. The only host tokens used
+     are for the card chrome AROUND the canvas (border), which stays with
+     the host view on extraction.
+   - Slide chrome is structure around the content, never text inside it:
+     slide numbers, kickers, quote marks are CSS-generated (pseudo-element
+     text is invisible to innerText, so comment anchors that count
+     visible-text occurrences never see it).
+
+   Geometry: .deck is a size container; everything inside a slide is sized
+   in cqi (1% of deck width) and em, so a slide is the same design at any
+   width — the deck view today, the presenter's scaled canvas later. */
 
 .deck {
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 2rem;
 }
 
 .deck-slide {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   aspect-ratio: 16 / 9;
-  padding: 40px 56px;
-  background: var(--color-surface);
+  padding: 4.5cqi 6cqi;
+  background: var(--deck-bg);
+  color: var(--deck-ink);
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: 14px;
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
-  /* Content that doesn't fit scrolls rather than clips — the visible cue
-     the fit report will later formalize. */
+  font-family: var(--deck-font-text);
+  font-size: calc(2.5cqi * var(--deck-scale, 1));
+  /* Content past the smallest type step scrolls rather than clips — the
+     visible cue the fit report will formalize. */
   overflow-y: auto;
 }
 
+/* The type scale: content volume picks a discrete step (SLIDE_SPEC.md).
+   Steps, not shrink-to-fit — sparse slides look intentional, dense slides
+   fit. */
+.deck-step-1 { --deck-scale: 1; }
+.deck-step-2 { --deck-scale: 0.86; }
+.deck-step-3 { --deck-scale: 0.74; }
+.deck-step-4 { --deck-scale: 0.63; }
+
+/* Slide number, bottom right. attr() content — chrome, not text. */
 .deck-slide::after {
   content: attr(data-slide);
   position: absolute;
-  right: 16px;
-  bottom: 10px;
-  font-size: 12px;
-  color: var(--color-text-muted);
+  right: 1.6cqi;
+  bottom: 1.1cqi;
+  font-size: 1.5cqi;
+  color: var(--deck-muted);
 }
 
-/* A slide reads from across the room, not at document scale. Flat bumps
-   until the classifier assigns real type-scale steps per layout. */
-.deck-slide .markdown-rendered h1 {
-  font-size: 2.2em;
+.deck-content {
+  width: 100%;
+  /* Vertical centering that stays safe under overflow: auto margins
+     collapse to zero once content exceeds the card, so a too-tall slide
+     scrolls from its top (justify-content: center would push the start of
+     the content above the card, unreachable by any scroll). */
+  margin-block: auto;
+}
+
+/* ---- Base typography: slide scale, not document scale ----------------
+   Overrides the app's .markdown-rendered reading styles (px sizes, 1.9
+   line-height) with em sizes hanging off the slide's cqi base. */
+
+.deck-slide .deck-content h1,
+.deck-slide .deck-content h2,
+.deck-slide .deck-content h3,
+.deck-slide .deck-content h4,
+.deck-slide .deck-content h5,
+.deck-slide .deck-content h6 {
+  font-family: var(--deck-font-display);
+  font-weight: var(--deck-display-weight);
   line-height: 1.15;
-  border: none;
+  letter-spacing: -0.015em;
+  margin: 0.9em 0 0.5em;
 }
 
-.deck-slide .markdown-rendered h2 {
-  font-size: 1.6em;
-  line-height: 1.2;
-  border: none;
-}
+.deck-slide .deck-content h1 { font-size: 2.2em; }
+.deck-slide .deck-content h2 { font-size: 1.75em; }
+.deck-slide .deck-content h3 { font-size: 1.3em; }
+.deck-slide .deck-content h4,
+.deck-slide .deck-content h5,
+.deck-slide .deck-content h6 { font-size: 1.05em; }
 
-.deck-slide .markdown-rendered p,
-.deck-slide .markdown-rendered li {
-  font-size: 1.12em;
+.deck-slide .deck-content > :first-child { margin-top: 0; }
+.deck-slide .deck-content > :last-child { margin-bottom: 0; }
+
+.deck-slide .deck-content p {
+  margin: 0 0 0.7em;
   line-height: 1.5;
+}
+
+.deck-slide .deck-content ul,
+.deck-slide .deck-content ol {
+  margin: 0 0 0.7em;
+  padding-left: 1.15em;
+}
+
+.deck-slide .deck-content li {
+  margin-bottom: 0.4em;
+  line-height: 1.45;
+}
+
+.deck-slide .deck-content li::marker {
+  color: var(--deck-accent);
+}
+
+.deck-slide .deck-content a {
+  color: var(--deck-accent);
+}
+
+.deck-slide .deck-content hr {
+  border: none;
+  border-top: 1px solid var(--deck-rule);
+  margin: 1.2em 0;
+}
+
+.deck-slide .deck-content img {
+  max-width: 100%;
+  max-height: 26cqi;
+  border-radius: 0.4em;
+}
+
+.deck-slide .deck-content pre {
+  font-size: 0.8em;
+  line-height: 1.55;
+  margin: 0.8em 0;
+}
+
+.deck-slide .deck-content :not(pre) > code {
+  background: color-mix(in srgb, var(--deck-ink) 9%, transparent);
+  font-family: var(--deck-font-mono);
+}
+
+.deck-slide .deck-content blockquote {
+  border-left: 3px solid var(--deck-accent);
+  padding-left: 0.8em;
+  color: var(--deck-muted);
+  margin: 0 0 0.7em;
+}
+
+.deck-slide .deck-content table {
+  font-size: 0.82em;
+  margin: 0 0 0.7em;
+}
+
+.deck-slide .deck-content th {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid var(--deck-accent);
+  padding: 0.45em 0.7em;
+}
+
+.deck-slide .deck-content td {
+  border: none;
+  border-bottom: 1px solid var(--deck-rule);
+  padding: 0.45em 0.7em;
+}
+
+.deck-slide .deck-content input[type="checkbox"] {
+  width: 0.85em;
+  height: 0.85em;
+}
+
+.deck-slide .deck-content .mermaid-diagram {
+  display: flex;
+  justify-content: center;
+}
+
+.deck-slide .deck-content .mermaid-diagram svg {
+  max-width: 100%;
+  max-height: 34cqi;
+}
+
+/* ---- title — a heading is the slide ---------------------------------- */
+
+.deck-slide--title {
+  padding-inline: 8cqi;
+  background: var(--deck-title-bg);
+  color: var(--deck-title-ink);
+}
+
+.deck-slide--title::after {
+  color: var(--deck-title-ink);
+  opacity: 0.55;
+}
+
+.deck-slide--title .deck-content h1,
+.deck-slide--title .deck-content h2,
+.deck-slide--title .deck-content h3 {
+  font-size: 2.8em;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+/* The accent bar: the one piece of pure art direction every deck opens
+   with. */
+.deck-slide--title .deck-content > h1::before,
+.deck-slide--title .deck-content > h2::before,
+.deck-slide--title .deck-content > h3::before {
+  content: "";
+  display: block;
+  width: 1.6em;
+  height: 0.16em;
+  border-radius: 0.08em;
+  background: var(--deck-title-accent, var(--deck-accent));
+  margin-bottom: 0.55em;
+}
+
+.deck-slide--title .deck-content p {
+  font-size: 1.2em;
+  margin: 1em 0 0;
+  color: var(--deck-title-ink);
+  opacity: 0.75;
+}
+
+.deck-slide--title .deck-content a {
+  color: inherit;
+}
+
+/* ---- stage — one visual gets the whole canvas ------------------------ */
+
+.deck-slide--stage .deck-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.9em;
+}
+
+.deck-slide--stage .deck-content > h1,
+.deck-slide--stage .deck-content > h2,
+.deck-slide--stage .deck-content > h3,
+.deck-slide--stage .deck-content > h4 {
+  font-size: 0.95em;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--deck-muted);
+  margin: 0;
+}
+
+.deck-slide--stage .deck-content > p {
+  margin: 0;
+}
+
+.deck-slide--stage .deck-content img {
+  max-height: 36cqi;
+}
+
+.deck-slide--stage .deck-content > p:not(:has(img)) {
+  font-size: 0.9em;
+  color: var(--deck-muted);
+}
+
+/* ---- code — code gets the stage, not a text box ----------------------- */
+
+.deck-slide--code {
+  padding-inline: 5cqi;
+}
+
+.deck-slide--code .deck-content > h1,
+.deck-slide--code .deck-content > h2,
+.deck-slide--code .deck-content > h3,
+.deck-slide--code .deck-content > h4 {
+  font-size: 0.95em;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--deck-muted);
+  margin: 0 0 1em;
+}
+
+.deck-slide--code .deck-content > p {
+  font-size: 0.9em;
+  color: var(--deck-muted);
+}
+
+/* ---- quote — a pull quote, oversized ---------------------------------- */
+
+.deck-slide--quote {
+  padding-inline: 8cqi;
+}
+
+.deck-slide--quote .deck-content blockquote {
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: var(--deck-ink);
+  font-family: var(--deck-font-display);
+  font-size: 1.55em;
+  font-weight: 500;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+
+.deck-slide--quote .deck-content blockquote::before {
+  content: "\201C";
+  display: block;
+  font-size: 2.4em;
+  line-height: 0.55;
+  color: var(--deck-accent);
+  margin-bottom: 0.25em;
+}
+
+.deck-slide--quote .deck-content blockquote p {
+  margin: 0 0 0.4em;
+  line-height: inherit;
+}
+
+.deck-slide--quote .deck-content > p {
+  font-size: 0.95em;
+  color: var(--deck-muted);
+  margin: 1.2em 0 0;
+}
+
+/* ---- table — scaled tabular typography -------------------------------- */
+
+.deck-slide--table .deck-content table {
+  width: 100%;
+  font-size: 0.78em;
+}
+
+.deck-slide--table .deck-content th {
+  font-weight: 650;
+  letter-spacing: 0.03em;
+}
+
+.deck-slide--table .deck-content > p {
+  font-size: 0.9em;
+  color: var(--deck-muted);
+}
+
+/* ---- columns — two lists sit side by side ----------------------------- */
+
+.deck-slide--columns .deck-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  column-gap: 2.6em;
+  align-items: start;
+}
+
+.deck-slide--columns .deck-content > h1,
+.deck-slide--columns .deck-content > h2,
+.deck-slide--columns .deck-content > h3,
+.deck-slide--columns .deck-content > h4 {
+  grid-column: 1 / -1;
+}
+
+.deck-slide--columns .deck-content > ul,
+.deck-slide--columns .deck-content > ol {
+  margin: 0;
+}
+
+/* ---- split — media pane beside content --------------------------------
+   DOM order is source order (media leading → left pane, trailing → right),
+   so grid auto-placement does the layout with zero reordering. Guarded on
+   the wrappers: when the renderer skipped them (sanitized-away shape
+   mismatch), the slide keeps the content layout. */
+
+.deck-slide--split .deck-content:has(> .deck-media) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  column-gap: 2.6em;
+  align-items: center;
+}
+
+.deck-slide--split .deck-content > h1,
+.deck-slide--split .deck-content > h2,
+.deck-slide--split .deck-content > h3,
+.deck-slide--split .deck-content > h4 {
+  grid-column: 1 / -1;
+}
+
+.deck-slide--split .deck-media > p {
+  margin: 0;
+}
+
+.deck-slide--split .deck-media img {
+  width: 100%;
+  max-height: 40cqi;
+  object-fit: contain;
 }

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 8
+    RENDER_CACHE_VERSION = 10
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 10
+    RENDER_CACHE_VERSION = 11
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,

--- a/engine/app/helpers/coplan/slideshows_helper.rb
+++ b/engine/app/helpers/coplan/slideshows_helper.rb
@@ -18,14 +18,25 @@ module CoPlan
     # to every fragment so references still resolve); footnotes render once,
     # document-wide, in the plan's References back matter, exactly as they
     # do for documents.
-    def render_slideshow(content, interactive: true)
+    def render_slideshow(content, interactive: true, theme: "coplan")
       result = Slideshows::Split.call(content)
 
+      lead_by_slide = {}
       sections = result.slides.map do |slide|
         preamble = deck_preamble(result.definition_blocks, slide)
+        # Classify the exact string being rendered — with the preamble,
+        # reference-style images resolve to image nodes here the same way
+        # they resolve on screen (the sentinel comment classifies as
+        # nothing, per SLIDE_SPEC.md's content-sequence rules).
+        classification = Slideshows::Classify.call(preamble + slide.source)
+        lead_by_slide[slide.index.to_s] = classification.lead
         inner = render_markdown(preamble + slide.source, interactive:, footnotes: :exclude,
                                 line_offset: slide.start_line - 1 - preamble.count("\n"))
-        tag.section(inner, class: "deck-slide", data: { slide: slide.index })
+        tag.section(inner,
+                    class: [ "deck-slide", "deck-slide--#{classification.pattern}",
+                             "deck-step-#{classification.step}" ],
+                    data: { slide: slide.index, pattern: classification.pattern,
+                            media: classification.media }.compact)
       end
 
       # Slides render in isolation, so anything numbered per document —
@@ -39,11 +50,72 @@ module CoPlan
       mirror_section_link_enhancement(deck, document)
       drop_misleading_ids(deck, document)
       strip_duplicate_ids(deck)
+      decorate_slide_content(deck, lead_by_slide)
 
-      tag.div(deck.to_html.html_safe, class: "deck")
+      tag.div(deck.to_html.html_safe, class: "deck", data: { deck_theme: theme })
     end
 
     private
+
+    # SLIDE_SPEC.md's markup contract on the rendered DOM: the slide's
+    # block container gets the spec's neutral .deck-content name (the
+    # design system must not know CoPlan's .markdown-rendered), and split
+    # slides get their two pane wrappers. Wrappers add structure only —
+    # no text, no reordering — so comment anchors and the parity passes
+    # above are unaffected.
+    def decorate_slide_content(deck, lead_by_slide)
+      deck.css("section.deck-slide > div.markdown-rendered").each { |div| div.add_class("deck-content") }
+      wrap_split_slides(deck, lead_by_slide)
+    end
+
+    # The classifier promised one media block at the body's edge; find it
+    # in the DOM and wrap it and the rest into the split panes. Rendered
+    # DOM can disagree with the classified shape (sanitize can delete raw
+    # HTML blocks wholesale, or reduce one to a bare text node), so the
+    # shape is verified before wrapping — on any mismatch the slide keeps
+    # flat markup and the stylesheet degrades to the content layout, per
+    # the spec.
+    def wrap_split_slides(deck, lead_by_slide)
+      deck.css("section.deck-slide--split").each do |section|
+        content = section.element_children.find { |el| el.classes.include?("deck-content") }
+        next unless content
+        # Loose visible text (a raw-HTML block sanitize stripped down to its
+        # text) can't be attributed to a pane; wrapping the elements around
+        # it would reorder what readers see (spec invariant 2).
+        next if content.children.any? { |node| node.text? && !node.text.strip.empty? }
+
+        children = content.element_children.to_a
+        # The lead heading is the classifier's lead, not whatever renders
+        # first: a raw-HTML heading in the body belongs inside .deck-body,
+        # not spanning the panes.
+        lead = lead_by_slide[section["data-slide"]]
+        next if lead && !children.first&.name&.match?(/\Ah[1-6]\z/)
+
+        pool = lead ? children.drop(1) : children
+        next if pool.size < 2
+
+        media = section["data-media"] == "leading" ? pool.first : pool.last
+        next unless media_element?(media)
+
+        rest = pool - [ media ]
+        media_wrap = content.document.create_element("div", class: "deck-media")
+        body_wrap = content.document.create_element("div", class: "deck-body")
+        media.add_previous_sibling(media_wrap)
+        media_wrap.add_child(media)
+        rest.first.add_previous_sibling(body_wrap)
+        rest.each { |el| body_wrap.add_child(el) }
+      end
+    end
+
+    # The DOM shape a classified media block renders to: a paragraph whose
+    # only content is an image (alt text is an attribute, so text is
+    # blank), or a mermaid fence (comrak carries the info string as lang).
+    def media_element?(el)
+      return false if el.nil?
+
+      (el.name == "p" && el.at_css("img") && el.text.strip.empty?) ||
+        (el.name == "pre" && el["lang"] == "mermaid")
+    end
 
     # Definitions are prepended, not appended: a slide ending in an unclosed
     # code fence would swallow an appended block into visible text, and

--- a/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
+++ b/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
@@ -152,9 +152,17 @@ export default class extends Controller {
   }
 
   _handleKeydown(event) {
-    if (event.metaKey || event.ctrlKey || event.altKey) return
     // A modal (the mermaid lightbox) owns its own keys.
     if (event.target.closest?.("dialog")) return
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      // Modifier chords aren't the show's to handle, but mid-show the
+      // page's own hotkeys must still be starved — Ctrl+Space (or held
+      // Alt) would start a voice recording invisibly behind the overlay.
+      // Text entry above the show keeps its shortcuts (Cmd+Enter submits
+      // a reply); browser chords (reload, find, copy) ignore propagation.
+      if (this.presenting && !this._typing(event.target)) event.stopPropagation()
+      return
+    }
 
     if (!this.presenting) {
       if (event.key !== "p" || this._typing(event.target)) return

--- a/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
+++ b/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
     this.index = 0
     this._onKeydown = this._handleKeydown.bind(this)
     this._onClick = this._handleClick.bind(this)
+    this._onMouseUp = this._handleMouseUp.bind(this)
     this._onFullscreenChange = this._handleFullscreenChange.bind(this)
     // Turbo snapshots the page before controllers disconnect; a cached
     // mid-show deck would restore wearing a closed popover attribute —
@@ -50,22 +51,48 @@ export default class extends Controller {
     this._pageOverflow = document.documentElement.style.overflow
     document.documentElement.style.overflow = "hidden"
     document.addEventListener("click", this._onClick, true)
+    document.addEventListener("mouseup", this._onMouseUp, true)
+    // A comment thread popover left open on the page must not float above
+    // the show.
+    this._dismissForeignPopovers()
     this.observer = new MutationObserver(() => {
       if (this.presenting && this.element.querySelector(".deck") !== this.deck) this._show(this.index)
     })
     this.observer.observe(this.element, { childList: true, subtree: true })
 
     const resumed = window.location.hash.match(/^#present-(\d+)$/)
+    // Presenting borrows the URL fragment for #present-N; remember what
+    // was there (a heading deep link, a footnote) to give back on exit.
+    this._priorHash = resumed ? "" : window.location.hash
+    this._peeling = false
     this._show(resumed ? Number(resumed[1]) - 1 : 0)
     // _show stops the show itself on a slideless deck — don't take the
     // screen for nothing.
     if (!this.presenting) return
 
+    // Move focus into the show. Clicking the Present button leaves the
+    // button focused, and a focused control outside the deck would
+    // otherwise soak up the navigation keys.
+    this._trigger = document.activeElement
+    const deck = this.element.querySelector(".deck")
+    if (deck) {
+      deck.tabIndex = -1
+      deck.focus({ preventScroll: true })
+    }
+
     // Native fullscreen when the browser grants it; the top-layer popover
     // (see _promoteDeck) is what actually fills the screen either way.
     // Re-promote once fullscreen resolves — the fullscreen wrapper enters
     // the top layer above the already-shown popover and would cover it.
-    this.element.requestFullscreen?.().then(() => this._promoteDeck(true)).catch(() => {})
+    this.element.requestFullscreen?.().then(() => {
+      // The grant can outlive a fast Escape: if the show already ended,
+      // give the screen back instead of re-promoting a stopped deck.
+      if (!this.presenting) {
+        if (document.fullscreenElement === this.element) document.exitFullscreen().catch(() => {})
+        return
+      }
+      this._promoteDeck(true)
+    }).catch(() => {})
   }
 
   stop() {
@@ -75,7 +102,7 @@ export default class extends Controller {
     this._teardown()
     if (document.fullscreenElement === this.element) document.exitFullscreen().catch(() => {})
     if (window.location.hash.startsWith("#present-")) {
-      history.replaceState(history.state, "", window.location.pathname + window.location.search)
+      history.replaceState(history.state, "", window.location.pathname + window.location.search + (this._priorHash || ""))
     }
   }
 
@@ -138,10 +165,10 @@ export default class extends Controller {
     }
 
     // The keyboard mirror of the click pass-through below: a focused
-    // control on a slide owns its keys, so Space toggles the checkbox it
-    // sits on instead of advancing. Escape stays the exit everywhere.
-    const tag = event.target.tagName
-    if (event.key !== "Escape" && (this._typing(event.target) || tag === "BUTTON" || tag === "SUMMARY")) return
+    // control owns the keys it actually responds to — Space toggles the
+    // checkbox it sits on — while keys a control ignores (arrows, paging)
+    // keep driving the show. Escape stays the exit everywhere.
+    if (event.key !== "Escape" && this._claimsKey(event.target, event.key)) return
 
     switch (event.key) {
       case "ArrowRight":
@@ -163,13 +190,40 @@ export default class extends Controller {
         this._navigate(event, Infinity)
         break
       case "Escape":
-        // Native fullscreen exits itself (we stop on fullscreenchange);
-        // this covers the fixed-overlay fallback.
         event.preventDefault()
         event.stopPropagation()
+        // A popover above the show (a reference preview, a pinned thread)
+        // is what Escape visibly targets — dismiss it and keep presenting;
+        // only a bare Escape ends the show. The browser may drop native
+        // fullscreen on this same keypress (that exit is uncancelable), so
+        // mark the peel: the resulting fullscreenchange is forgiven and
+        // the show continues on the top-layer fallback.
+        if (this._dismissForeignPopovers()) {
+          if (document.fullscreenElement === this.element) this._peeling = true
+          return
+        }
         this.stop()
         break
+      default:
+        // The page behind the show is invisible; its shortcut handlers
+        // (comment j/k navigation, section jumps) must not fire under the
+        // presentation. Propagation stops here — browser defaults (Tab,
+        // find, reload) are untouched.
+        event.stopPropagation()
     }
+  }
+
+  // Closes any open popover that isn't the presented deck. Returns whether
+  // anything was dismissed.
+  _dismissForeignPopovers() {
+    const deck = this.element.querySelector(".deck")
+    let dismissed = false
+    document.querySelectorAll(":popover-open").forEach(popover => {
+      if (popover === deck) return
+      try { popover.hidePopover() } catch {}
+      dismissed = true
+    })
+    return dismissed
   }
 
   _navigate(event, index) {
@@ -184,6 +238,11 @@ export default class extends Controller {
 
     const deck = this.element.querySelector(".deck")
     const onCanvas = deck && deck.contains(event.target)
+
+    // A popover above the show (reference preview, a pinned thread) is
+    // visible UI, not hidden page — its buttons and links keep working.
+    const popover = event.target.closest?.("[popover]")
+    if (popover && popover !== deck && popover.matches(":popover-open")) return
 
     // A same-document link mid-show: the target's slide is display: none,
     // so the browser's fragment jump would show nothing — and would clobber
@@ -215,8 +274,27 @@ export default class extends Controller {
     this._show(this.index + 1)
   }
 
+  // text-selection offers "comment on this selection" from mouseup on the
+  // content target — mid-show that affordance would pop over the deck.
+  // Starve the listener; native click synthesis is unaffected, so slide
+  // links and checkboxes still work.
+  _handleMouseUp(event) {
+    if (!this.presenting) return
+    if (event.target.closest?.("dialog")) return
+
+    event.stopPropagation()
+  }
+
   _handleFullscreenChange() {
-    if (this.presenting && !document.fullscreenElement) this.stop()
+    if (!this.presenting || document.fullscreenElement) return
+
+    // One exit is forgiven when Escape was consumed dismissing a popover —
+    // the keypress was aimed at the popover, not the show.
+    if (this._peeling) {
+      this._peeling = false
+      return
+    }
+    this.stop()
   }
 
   _typing(target) {
@@ -224,18 +302,45 @@ export default class extends Controller {
     return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable
   }
 
+  // Which keys a focused element keeps from the show, per what the control
+  // actually responds to. Text entry owns every key wherever it lives (the
+  // only text fields reachable mid-show sit in popovers above the deck);
+  // toggles own just their activation keys; buttons qualify only on the
+  // canvas — the Present button outside it owns nothing.
+  _claimsKey(target, key) {
+    if (target.isContentEditable) return true
+    const tag = target.tagName
+    if (tag === "TEXTAREA" || tag === "SELECT") return true
+    if (tag === "INPUT") {
+      const type = (target.type || "").toLowerCase()
+      if (type === "checkbox" || type === "radio") return key === " " || key === "Enter"
+      return true
+    }
+    if (tag === "BUTTON" || tag === "SUMMARY") {
+      return (key === " " || key === "Enter") && !!this.element.querySelector(".deck")?.contains(target)
+    }
+    return false
+  }
+
   _teardown() {
     document.removeEventListener("click", this._onClick, true)
+    document.removeEventListener("mouseup", this._onMouseUp, true)
     if (this._pageOverflow !== undefined) {
       document.documentElement.style.overflow = this._pageOverflow
       this._pageOverflow = undefined
     }
     this.observer?.disconnect()
     this.observer = null
+    // Hand focus back to whatever launched the show (usually the Present
+    // button) — before the deck lookup, because the one case where focus
+    // was forcibly lost is exactly the deck being swapped away.
+    if (this._trigger?.isConnected) this._trigger.focus?.({ preventScroll: true })
+    this._trigger = null
     const deck = this.element.querySelector(".deck")
     if (!deck) return
 
     deck.classList.remove("deck--presenting")
+    deck.removeAttribute("tabindex")
     deck.querySelectorAll(".deck-slide--current").forEach(slide => slide.classList.remove("deck-slide--current"))
     // A closed popover is display: none — the attribute must go too, or
     // the deck vanishes from the page after the show.

--- a/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
+++ b/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
@@ -137,6 +137,12 @@ export default class extends Controller {
       return
     }
 
+    // The keyboard mirror of the click pass-through below: a focused
+    // control on a slide owns its keys, so Space toggles the checkbox it
+    // sits on instead of advancing. Escape stays the exit everywhere.
+    const tag = event.target.tagName
+    if (event.key !== "Escape" && (this._typing(event.target) || tag === "BUTTON" || tag === "SUMMARY")) return
+
     switch (event.key) {
       case "ArrowRight":
       case "ArrowDown":
@@ -178,6 +184,27 @@ export default class extends Controller {
 
     const deck = this.element.querySelector(".deck")
     const onCanvas = deck && deck.contains(event.target)
+
+    // A same-document link mid-show: the target's slide is display: none,
+    // so the browser's fragment jump would show nothing — and would clobber
+    // the #present-N resume hash. Navigate the show to the slide that owns
+    // the target instead; targets outside the deck (the footnote back
+    // matter, hidden behind the overlay) are swallowed as no-ops.
+    const anchor = onCanvas && event.target.closest('a[href^="#"]')
+    if (anchor) {
+      event.preventDefault()
+      event.stopPropagation()
+      let id = anchor.getAttribute("href").slice(1)
+      try { id = decodeURIComponent(id) } catch {}
+      const target = id ? deck.querySelector(`#${CSS.escape(id)}`) : null
+      const slide = target?.closest("section.deck-slide")
+      if (slide) {
+        this._show(this._slides(deck).indexOf(slide))
+        target.scrollIntoView({ block: "nearest" })
+      }
+      return
+    }
+
     // Links, checkboxes, and buttons on a slide still work; everything
     // else — canvas, letterbox, the page hidden behind the overlay —
     // advances (and is swallowed so hidden controls can't be hit).

--- a/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
+++ b/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
@@ -1,0 +1,220 @@
+import { Controller } from "@hotwired/stimulus"
+
+/*
+ * coplan--deck-presenter
+ *
+ * Present mode: the deck takes the screen as one 16:9 canvas — exactly what
+ * a Zoom or Meet screen-share needs. One slide shows at a time; arrows,
+ * space, page keys, and clicks advance; Escape (or leaving native
+ * fullscreen) ends the show. Native fullscreen is requested on this
+ * wrapper, with the fixed-overlay CSS as the fallback when the browser
+ * refuses, so presenting works either way.
+ *
+ * The wrapper sits OUTSIDE the live-update swap target: an edit landing
+ * mid-presentation replaces the deck underneath without disconnecting this
+ * controller. Every entry point re-acquires the current deck by lookup, and
+ * a childList observer re-applies the presenting state to a freshly swapped
+ * deck so the show survives collaboration.
+ */
+export default class extends Controller {
+  connect() {
+    this.presenting = false
+    this.index = 0
+    this._onKeydown = this._handleKeydown.bind(this)
+    this._onClick = this._handleClick.bind(this)
+    this._onFullscreenChange = this._handleFullscreenChange.bind(this)
+    // Turbo snapshots the page before controllers disconnect; a cached
+    // mid-show deck would restore wearing a closed popover attribute —
+    // display: none, an invisible plan. End the show before the snapshot.
+    this._onBeforeCache = () => this.stop()
+    // Capture phase: while presenting, the show owns the keyboard —
+    // Backspace pages backward instead of triggering plan-keys' go-back.
+    document.addEventListener("keydown", this._onKeydown, true)
+    document.addEventListener("fullscreenchange", this._onFullscreenChange)
+    document.addEventListener("turbo:before-cache", this._onBeforeCache)
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this._onKeydown, true)
+    document.removeEventListener("fullscreenchange", this._onFullscreenChange)
+    document.removeEventListener("turbo:before-cache", this._onBeforeCache)
+    this._teardown()
+  }
+
+  start() {
+    if (this.presenting || !this._acquireDeck()) return
+
+    this.presenting = true
+    // Lock the page behind the show — a wheel over the letterbox must not
+    // scroll the plan out from under the presenter.
+    this._pageOverflow = document.documentElement.style.overflow
+    document.documentElement.style.overflow = "hidden"
+    document.addEventListener("click", this._onClick, true)
+    this.observer = new MutationObserver(() => {
+      if (this.presenting && this.element.querySelector(".deck") !== this.deck) this._show(this.index)
+    })
+    this.observer.observe(this.element, { childList: true, subtree: true })
+
+    const resumed = window.location.hash.match(/^#present-(\d+)$/)
+    this._show(resumed ? Number(resumed[1]) - 1 : 0)
+    // _show stops the show itself on a slideless deck — don't take the
+    // screen for nothing.
+    if (!this.presenting) return
+
+    // Native fullscreen when the browser grants it; the top-layer popover
+    // (see _promoteDeck) is what actually fills the screen either way.
+    // Re-promote once fullscreen resolves — the fullscreen wrapper enters
+    // the top layer above the already-shown popover and would cover it.
+    this.element.requestFullscreen?.().then(() => this._promoteDeck(true)).catch(() => {})
+  }
+
+  stop() {
+    if (!this.presenting) return
+
+    this.presenting = false
+    this._teardown()
+    if (document.fullscreenElement === this.element) document.exitFullscreen().catch(() => {})
+    if (window.location.hash.startsWith("#present-")) {
+      history.replaceState(history.state, "", window.location.pathname + window.location.search)
+    }
+  }
+
+  _show(index) {
+    const deck = this._acquireDeck()
+    const slides = deck ? this._slides(deck) : []
+    if (slides.length === 0) return this.stop()
+
+    this.index = Math.max(0, Math.min(index, slides.length - 1))
+    deck.classList.add("deck--presenting")
+    this._promoteDeck()
+    slides.forEach((slide, i) => slide.classList.toggle("deck-slide--current", i === this.index))
+    slides[this.index].scrollTop = 0
+    history.replaceState(history.state, "", `#present-${this.index + 1}`)
+  }
+
+  // The show must escape the page: an ancestor with backdrop-filter (the
+  // plan's glass .card) is the containing block for position: fixed, which
+  // would trap the overlay at the card's size and stacking level. Top-layer
+  // elements position against the viewport no matter their ancestors, so
+  // the deck presents as a manual popover — in the fallback path and under
+  // native fullscreen alike.
+  _promoteDeck(force = false) {
+    const deck = this.element.querySelector(".deck")
+    if (!deck || !this.presenting || !deck.showPopover) return
+
+    deck.popover = "manual"
+    if (deck.matches(":popover-open")) {
+      if (!force) return
+      deck.hidePopover()
+    }
+    deck.showPopover()
+  }
+
+  _acquireDeck() {
+    const deck = this.element.querySelector(".deck")
+    if (deck && deck !== this.deck) {
+      this.deck = deck
+      const slides = this._slides(deck)
+      slides.forEach(slide => (slide.dataset.slideTotal = slides.length))
+    }
+    return deck
+  }
+
+  _slides(deck) {
+    return Array.from(deck.querySelectorAll(":scope > section.deck-slide"))
+  }
+
+  _handleKeydown(event) {
+    if (event.metaKey || event.ctrlKey || event.altKey) return
+    // A modal (the mermaid lightbox) owns its own keys.
+    if (event.target.closest?.("dialog")) return
+
+    if (!this.presenting) {
+      if (event.key !== "p" || this._typing(event.target)) return
+      if (!this.element.querySelector(".deck")) return
+      event.preventDefault()
+      this.start()
+      return
+    }
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+      case "PageDown":
+      case " ":
+        this._navigate(event, this.index + 1)
+        break
+      case "ArrowLeft":
+      case "ArrowUp":
+      case "PageUp":
+      case "Backspace":
+        this._navigate(event, this.index - 1)
+        break
+      case "Home":
+        this._navigate(event, 0)
+        break
+      case "End":
+        this._navigate(event, Infinity)
+        break
+      case "Escape":
+        // Native fullscreen exits itself (we stop on fullscreenchange);
+        // this covers the fixed-overlay fallback.
+        event.preventDefault()
+        event.stopPropagation()
+        this.stop()
+        break
+    }
+  }
+
+  _navigate(event, index) {
+    event.preventDefault()
+    event.stopPropagation()
+    this._show(index)
+  }
+
+  _handleClick(event) {
+    if (!this.presenting) return
+    if (event.target.closest?.("dialog")) return
+
+    const deck = this.element.querySelector(".deck")
+    const onCanvas = deck && deck.contains(event.target)
+    // Links, checkboxes, and buttons on a slide still work; everything
+    // else — canvas, letterbox, the page hidden behind the overlay —
+    // advances (and is swallowed so hidden controls can't be hit).
+    if (onCanvas && event.target.closest("a, button, input, textarea, summary, [contenteditable]")) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    this._show(this.index + 1)
+  }
+
+  _handleFullscreenChange() {
+    if (this.presenting && !document.fullscreenElement) this.stop()
+  }
+
+  _typing(target) {
+    const tag = target.tagName
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable
+  }
+
+  _teardown() {
+    document.removeEventListener("click", this._onClick, true)
+    if (this._pageOverflow !== undefined) {
+      document.documentElement.style.overflow = this._pageOverflow
+      this._pageOverflow = undefined
+    }
+    this.observer?.disconnect()
+    this.observer = null
+    const deck = this.element.querySelector(".deck")
+    if (!deck) return
+
+    deck.classList.remove("deck--presenting")
+    deck.querySelectorAll(".deck-slide--current").forEach(slide => slide.classList.remove("deck-slide--current"))
+    // A closed popover is display: none — the attribute must go too, or
+    // the deck vanishes from the page after the show.
+    if (deck.matches("[popover]")) {
+      if (deck.matches(":popover-open")) deck.hidePopover()
+      deck.removeAttribute("popover")
+    }
+  }
+}

--- a/engine/app/javascript/controllers/coplan/mermaid_controller.js
+++ b/engine/app/javascript/controllers/coplan/mermaid_controller.js
@@ -40,8 +40,10 @@ export default class extends Controller {
       const mermaid = await loadMermaid()
       if (!this.element.isConnected || generation !== this.renderGeneration) return
 
-      const theme = configureMermaid(mermaid)
       for (const { container, source } of sources) {
+        // Sequential renders, so re-configuring per diagram is safe (and
+        // a no-op when the theme hasn't changed).
+        const theme = configureMermaid(mermaid, diagramDark(container))
         await this.renderDiagram(mermaid, container, source, theme, generation)
       }
     } catch {
@@ -166,10 +168,21 @@ function loadMermaid() {
   return mermaidPromise
 }
 
-function configureMermaid(mermaid) {
+// A deck is a fixed artifact — its diagrams follow the deck theme, not
+// the reader's app scheme, so a dark-mode reader sees the same slides as
+// a light-mode one. Outside a deck, diagrams follow the app. The theme
+// list is small enough to name here; when the theme picker lands, the
+// deck can carry scheme metadata instead.
+function diagramDark(container) {
+  const deck = container.closest(".deck")
+  if (deck) return deck.dataset.deckTheme === "graphite"
+
   const explicitTheme = document.documentElement.dataset.theme
-  const dark = explicitTheme === "dark" ||
+  return explicitTheme === "dark" ||
     (!explicitTheme && window.matchMedia("(prefers-color-scheme: dark)").matches)
+}
+
+function configureMermaid(mermaid, dark) {
   const theme = dark ? "dark" : "light"
   if (theme === configuredTheme) return theme
 

--- a/engine/app/services/coplan/slideshows/classify.rb
+++ b/engine/app/services/coplan/slideshows/classify.rb
@@ -36,6 +36,11 @@ module CoPlan
       # the floor — beyond it content is reported (fit report), not clipped.
       STEP_CEILINGS = [ 5, 9, 14 ].freeze
 
+      # A lone list this long is an inventory, not an argument — it flows
+      # into two columns (the directory pattern) instead of running one
+      # column off the canvas.
+      DIRECTORY_MIN_ENTRIES = 15
+
       def self.call(source)
         new(source).call
       end
@@ -47,7 +52,7 @@ module CoPlan
       def call
         blocks = content_sequence
         pattern, media = match_pattern(blocks)
-        Classification.new(pattern:, media:, step: step_for(blocks),
+        Classification.new(pattern:, media:, step: step_for(blocks, pattern),
                            lead: blocks.first&.type == :heading)
       end
 
@@ -90,6 +95,8 @@ module CoPlan
         end
 
         return [ :columns, nil ] if body.size == 2 && body.all? { |block| block.type == :list }
+
+        return [ :directory, nil ] if directory?(body)
 
         if body.size >= 2 && body.count { |block| media_block?(block) } == 1
           return [ :split, :leading ]  if media_block?(body.first)
@@ -140,6 +147,27 @@ module CoPlan
         images == 1
       end
 
+      # A directory is one long flat list of short entries — an inventory.
+      # Nested items, multi-paragraph items, images, or hard breaks mean
+      # the entries carry structure, and structure reads top-to-bottom.
+      def directory?(body)
+        return false unless body.size == 1 && body.first.type == :list
+
+        items = body.first.each.to_a
+        items.size >= DIRECTORY_MIN_ENTRIES && items.all? { |item| short_entry?(item) }
+      end
+
+      def short_entry?(item)
+        # Comments never influence layout — a speaker note tucked inside an
+        # entry must not flip the whole slide out of the directory.
+        children = item.each.reject { |node| node.type == :html_block && comment_only?(node) }
+        return false unless children.size == 1 && children.first.type == :paragraph
+
+        paragraph = children.first
+        image_count(paragraph).zero? && hard_break_count(paragraph).zero? &&
+          plain_text(paragraph).length <= CHARS_PER_UNIT
+      end
+
       # Hard breaks count as a full line's worth of characters: six
       # hard-broken agenda lines are not a subtitle however few glyphs
       # they hold.
@@ -166,8 +194,17 @@ module CoPlan
         node.each { |child| each_visible_inline(child, &block) }
       end
 
-      def step_for(blocks)
-        total = blocks.sum { |block| units(block) }
+      # Steps come from rendered lines, and some patterns render the same
+      # blocks in less vertical space than one column would — a directory
+      # flows its list across two columns, so its list bills at half.
+      def step_for(blocks, pattern)
+        total = blocks.sum do |block|
+          if pattern == :directory && block.type == :list
+            units(block).fdiv(2).ceil
+          else
+            units(block)
+          end
+        end
         index = STEP_CEILINGS.index { |ceiling| total <= ceiling }
         index ? index + 1 : STEP_CEILINGS.size + 1
       end

--- a/engine/app/services/coplan/slideshows/classify.rb
+++ b/engine/app/services/coplan/slideshows/classify.rb
@@ -1,0 +1,220 @@
+module CoPlan
+  module Slideshows
+    # Assigns one slide a layout pattern and a type-scale step, implementing
+    # docs/SLIDE_SPEC.md — the spec's conformance examples are this class's
+    # acceptance tests (spec/services/slideshows/conformance_spec.rb).
+    #
+    # A pure function: markdown in, classification out. No CoPlan models, no
+    # rendering, no measurement — layout must be deterministic so the same
+    # content produces the same deck on every render, and simple enough that
+    # an authoring agent can compose with the rules deliberately.
+    class Classify
+      Classification = Struct.new(:pattern, :step, :media, :lead, keyword_init: true)
+
+      # A paragraph at most this long can ride along with a featured block
+      # as a subtitle, kicker, caption, or attribution. Longer text is the
+      # slide's content, and the featured block loses the stage.
+      SHORT_TEXT = 160
+
+      # One unit approximates one rendered line of body text.
+      CHARS_PER_UNIT = 60
+      IMAGE_UNITS = 3
+      # A mermaid fence renders as a fit-to-box diagram, so it bills like
+      # media, not like its source line count.
+      MERMAID_UNITS = 4
+      # deck.css renders code at 0.8em with 1.55 line-height — about
+      # five-sixths of a 1.5-em body line per code line, not half of one.
+      CODE_LINES_PER_UNIT = 1.2
+      OPAQUE_HTML_UNITS = 2
+
+      # Comment boundaries follow the HTML parser that decides what renders:
+      # `<!-->` and `<!--->` are complete (empty) comments, a normal comment
+      # runs to the next `-->`.
+      HTML_COMMENT = /<!-->|<!--->|<!--.*?-->/m
+
+      # Cumulative unit ceilings for steps 1–3; past the last is step 4,
+      # the floor — beyond it content is reported (fit report), not clipped.
+      STEP_CEILINGS = [ 5, 9, 14 ].freeze
+
+      def self.call(source)
+        new(source).call
+      end
+
+      def initialize(source)
+        @source = source.to_s.encode("UTF-8").delete("\r")
+      end
+
+      def call
+        blocks = content_sequence
+        pattern, media = match_pattern(blocks)
+        Classification.new(pattern:, media:, step: step_for(blocks),
+                           lead: blocks.first&.type == :heading)
+      end
+
+      private
+
+      # The slide's top-level blocks minus what never influences layout:
+      # comment-only HTML blocks (speaker notes, the renderer's preamble
+      # sentinel) and footnote definitions (back matter, not slide content).
+      def content_sequence
+        doc = Commonmarker.parse(@source, options: { extension: MarkdownHelper::EXTENSION_OPTIONS })
+        doc.each.reject do |node|
+          node.type == :footnote_definition ||
+            (node.type == :html_block && comment_only?(node))
+        end
+      end
+
+      def comment_only?(node)
+        # to_commonmark: raw-HTML nodes have no string_content accessor,
+        # and for raw HTML the commonmark serialization IS the raw source.
+        # A comment opened but never closed swallows the rest of the block,
+        # exactly as it does in a browser — either way, nothing renders.
+        rest = node.to_commonmark.gsub(HTML_COMMENT, "")
+        rest.strip.empty? || rest.lstrip.start_with?("<!--")
+      end
+
+      # The catalog's decision list — SLIDE_SPEC.md "The pattern catalog",
+      # same order, first match wins.
+      def match_pattern(blocks)
+        lead = blocks.first if blocks.first&.type == :heading
+        body = lead ? blocks.drop(1) : blocks
+
+        return [ :title, nil ] if lead && body.empty?
+        return [ :title, nil ] if lead && body.size == 1 && short_paragraph?(body.first)
+
+        if (featured = featured_block(body))
+          return [ :stage, nil ] if media_block?(featured)
+          return [ :code,  nil ] if featured.type == :code_block
+          return [ :quote, nil ] if featured.type == :block_quote
+          return [ :table, nil ] if featured.type == :table
+        end
+
+        return [ :columns, nil ] if body.size == 2 && body.all? { |block| block.type == :list }
+
+        if body.size >= 2 && body.count { |block| media_block?(block) } == 1
+          return [ :split, :leading ]  if media_block?(body.first)
+          return [ :split, :trailing ] if media_block?(body.last)
+        end
+
+        [ :content, nil ]
+      end
+
+      # The body's single featured block, when the body is that block alone
+      # or that block plus one adjacent short paragraph (kicker or caption).
+      def featured_block(body)
+        case body.size
+        when 1 then body.first
+        when 2
+          return body.last if short_paragraph?(body.first)
+
+          body.first if short_paragraph?(body.last)
+        end
+      end
+
+      def media_block?(node)
+        return true if node.type == :code_block && node.fence_info.to_s.split.first == "mermaid"
+        return false unless node.type == :paragraph
+
+        images = 0
+        node.each do |inline|
+          case inline.type
+          when :image
+            images += 1
+          when :link
+            children = inline.each.to_a
+            return false unless children.size == 1 && children.first.type == :image
+
+            images += 1
+          when :text
+            return false unless inline.string_content.strip.empty?
+          when :softbreak, :linebreak
+            # whitespace between inlines
+          when :html_inline
+            # An inline comment beside the image is a speaker note, not
+            # content — comments never influence layout.
+            return false unless comment_only?(inline)
+          else
+            return false
+          end
+        end
+        images == 1
+      end
+
+      # Hard breaks count as a full line's worth of characters: six
+      # hard-broken agenda lines are not a subtitle however few glyphs
+      # they hold.
+      def short_paragraph?(node)
+        node.type == :paragraph && image_count(node).zero? &&
+          plain_text(node).length + CHARS_PER_UNIT * hard_break_count(node) <= SHORT_TEXT
+      end
+
+      # Visible characters only: image alt text renders as an attribute,
+      # zero glyphs on the canvas, so the walk never descends into an image
+      # (its rendered cost is exactly its IMAGE_UNITS).
+      def plain_text(node)
+        text = +""
+        each_visible_inline(node) do |inline|
+          text << inline.string_content if %i[text code].include?(inline.type)
+        end
+        text
+      end
+
+      def each_visible_inline(node, &block)
+        yield node
+        return if node.type == :image
+
+        node.each { |child| each_visible_inline(child, &block) }
+      end
+
+      def step_for(blocks)
+        total = blocks.sum { |block| units(block) }
+        index = STEP_CEILINGS.index { |ceiling| total <= ceiling }
+        index ? index + 1 : STEP_CEILINGS.size + 1
+      end
+
+      # One unit ≈ one rendered line — SLIDE_SPEC.md "The type scale".
+      def units(node)
+        case node.type
+        when :heading
+          1
+        when :paragraph
+          text_units(node) + hard_break_count(node) + IMAGE_UNITS * image_count(node)
+        when :code_block
+          return MERMAID_UNITS if media_block?(node)
+
+          [ node.string_content.count("\n"), 1 ].max.fdiv(CODE_LINES_PER_UNIT).ceil
+        when :table
+          node.each.count
+        when :thematic_break
+          1
+        when :html_block
+          comment_only?(node) ? 0 : OPAQUE_HTML_UNITS
+        when :footnote_definition
+          0
+        when :list, :item, :taskitem, :block_quote
+          [ node.each.sum { |child| units(child) }, 1 ].max
+        else
+          1
+        end
+      end
+
+      def text_units(node)
+        [ plain_text(node).length.fdiv(CHARS_PER_UNIT).ceil, 1 ].max
+      end
+
+      # A hard line break forces a rendered line just as CHARS_PER_UNIT
+      # characters do.
+      def hard_break_count(node)
+        count = 0
+        each_visible_inline(node) { |inline| count += 1 if inline.type == :linebreak }
+        count
+      end
+
+      def image_count(node)
+        count = 0
+        each_visible_inline(node) { |inline| count += 1 if inline.type == :image }
+        count
+      end
+    end
+  end
+end

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -74,6 +74,22 @@
           anchored to diagram labels get their marks (and pending ?thread=
           deep links can resolve). %>
       <div class="plan-layout__content">
+        <%# Presentations present: `p` or the button starts a fullscreen
+            show (deck_presenter_controller). The wrapper sits outside the
+            live-update swap target so a collaborator's edit landing
+            mid-show doesn't disconnect the presenter — and the toolbar sits
+            outside the text-selection content target below, because its
+            label is visible text and comment anchors count visible-text
+            occurrences under that target. %>
+        <% if @plan.presentation? %>
+        <div class="deck-presenter" data-controller="coplan--deck-presenter">
+          <div class="deck-toolbar">
+            <button type="button" class="deck-toolbar__present" data-action="coplan--deck-presenter#start" title="Present (p)">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 4.8a1 1 0 0 1 1.53-.85l11.1 7.2a1 1 0 0 1 0 1.7l-11.1 7.2A1 1 0 0 1 7 19.2z"/></svg>
+              Present <kbd>p</kbd>
+            </button>
+          </div>
+        <% end %>
         <%# Selection-to-comment is scoped to this inner wrapper: the back
             matter below shares the column but must not offer comment
             anchors — they'd never resolve against the document body. %>
@@ -93,6 +109,9 @@
 
           <%= render partial: "coplan/comment_threads/new_comment_form", locals: { plan: @plan } %>
         </div>
+        <% if @plan.presentation? %>
+        </div>
+        <% end %>
 
         <%= render partial: "coplan/plans/footnotes",
               locals: { plan: @plan, references: @references, attachments: @attachments } %>

--- a/engine/app/views/layouts/coplan/application.html.erb
+++ b/engine/app/views/layouts/coplan/application.html.erb
@@ -19,8 +19,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <%# Serves the Hack code font, highlight.js grammars, and Mermaid %>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <%= stylesheet_link_tag "coplan/application", "coplan/deck", "data-turbo-track": "reload" %>
+    <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <%= stylesheet_link_tag "coplan/application", "coplan/deck",
+          "coplan/deck-theme-coplan", "coplan/deck-theme-graphite", "coplan/deck-theme-poster",
+          "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
   <body>

--- a/spec/helpers/slideshows_helper_spec.rb
+++ b/spec/helpers/slideshows_helper_spec.rb
@@ -23,6 +23,77 @@ RSpec.describe CoPlan::SlideshowsHelper, type: :helper do
       expect(doc.css("script")).to be_empty
     end
 
+    it "stamps each slide with its classified pattern and type step" do
+      doc = deck("# Opener\n\nA subtitle\n\n---\n\n## Points\n\n- one\n- two")
+
+      title, content = doc.css("section.deck-slide")
+      expect(title.classes).to include("deck-slide--title", "deck-step-1")
+      expect(title["data-pattern"]).to eq("title")
+      expect(content.classes).to include("deck-slide--content", "deck-step-1")
+    end
+
+    it "names the deck content container and the theme on the deck root" do
+      doc = deck("# One")
+
+      expect(doc.at_css(".deck")["data-deck-theme"]).to eq("coplan")
+      expect(doc.at_css("section.deck-slide > .deck-content.markdown-rendered")).to be_present
+    end
+
+    it "wraps a trailing split image into panes with the heading spanning" do
+      doc = deck("## Status\n\n- beta live\n- survey drafted\n\n![board](board.png)")
+
+      slide = doc.at_css("section.deck-slide--split")
+      expect(slide["data-media"]).to eq("trailing")
+      children = slide.at_css(".deck-content").element_children
+      expect(children.map(&:name)).to eq(%w[h2 div div])
+      expect(children[1]["class"]).to eq("deck-body")
+      expect(children[1].at_css("ul")).to be_present
+      expect(children[2]["class"]).to eq("deck-media")
+      expect(children[2].at_css("img")["src"]).to eq("board.png")
+    end
+
+    it "wraps a leading split image with the pane first in source order" do
+      # Two text blocks so the image can't read as a stage caption's media.
+      doc = deck("![board](board.png)\n\nThe words beside the picture.\n\nMore words below them.")
+
+      children = doc.at_css("section.deck-slide--split .deck-content").element_children
+      expect(children.map { |el| el["class"] }).to eq(%w[deck-media deck-body])
+      expect(children.last.css("p").size).to eq(2)
+    end
+
+    it "skips split wrappers when sanitize deletes the classified shape" do
+      # The classifier sees [image, html_block] — split, media leading. The
+      # sanitizer then deletes the script wholesale, leaving one child; the
+      # renderer must not wrap the wrong element (per SLIDE_SPEC.md).
+      doc = deck("![art](a.png)\n\n<script>alert(1)</script>")
+
+      slide = doc.at_css("section.deck-slide--split")
+      expect(slide).to be_present
+      expect(slide.css(".deck-media, .deck-body")).to be_empty
+    end
+
+    it "skips split wrappers rather than reorder loose text sanitize left behind" do
+      # Sanitize reduces the <figure> block to a bare text node between two
+      # body blocks. Wrapping only the elements would move them past the
+      # text — a source-order violation — so the slide keeps flat markup.
+      doc = deck("## Latency\n\n- p99 alert added\n\n<figure><figcaption>Figure 3: p99 by region</figcaption></figure>\n\nNotes live in the appendix.\n\n![chart](p99.png)")
+
+      slide = doc.at_css("section.deck-slide--split")
+      expect(slide.css(".deck-media, .deck-body")).to be_empty
+      expect(slide.text.squish).to include("p99 alert added Figure 3: p99 by region Notes live in the appendix.")
+    end
+
+    it "keeps a raw-HTML heading inside the body pane instead of spanning it" do
+      # The classifier saw [html_block, paragraph, image]: no lead heading,
+      # so the rendered <h2> is body content — it must not take the
+      # spanning direct-child slot a markdown lead heading gets.
+      doc = deck("<h2>Pasted heading</h2>\n\nReal body prose, long enough that this cannot read as a caption riding along with the image on a stage slide under any of the catalog rules.\n\n![board](board.png)")
+
+      content = doc.at_css("section.deck-slide--split .deck-content")
+      expect(content.element_children.map { |el| el["class"] }).to eq(%w[deck-body deck-media])
+      expect(content.at_css(".deck-body h2").text).to eq("Pasted heading")
+    end
+
     it "keeps checkbox source lines document-absolute on later slides" do
       content = "# One\n\n- [ ] first task\n\n---\n\n# Two\n\n- [ ] second task"
       doc = deck(content)

--- a/spec/requests/plans_spec.rb
+++ b/spec/requests/plans_spec.rb
@@ -121,6 +121,22 @@ RSpec.describe "Plans", type: :request do
     expect(response.body).to include('data-coplan--text-selection-target="content"')
   end
 
+  it "show presentation plan wires up the deck presenter with a Present control" do
+    deck_type = create(:plan_type, name: "Presentation", behavior: "presentation")
+    deck_plan = create(:plan, plan_type: deck_type, created_by_user: alice)
+    get plan_page_path(deck_plan)
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('data-controller="coplan--deck-presenter"')
+    expect(response.body).to include('data-action="coplan--deck-presenter#start"')
+  end
+
+  it "show document plan renders no presenter chrome" do
+    get plan_page_path(plan)
+    expect(response).to have_http_status(:success)
+    expect(response.body).not_to include("deck-presenter")
+    expect(response.body).not_to include("deck-toolbar")
+  end
+
   it "show plan without content does not render content nav sidebar" do
     empty_plan = create(:plan, :considering, created_by_user: alice)
     empty_plan.current_plan_version.update_columns(content_markdown: "", content_sha256: Digest::SHA256.hexdigest(""))

--- a/spec/services/slideshows/conformance_spec.rb
+++ b/spec/services/slideshows/conformance_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+# SLIDE_SPEC.md's conformance blocks are the classifier's acceptance suite
+# (CommonMark's trick: the spec's examples ARE the tests, so spec text and
+# implementation cannot drift apart). Each ```conformance fence holds a
+# slide's markdown, a lone "." line, then expected `key: value` pairs.
+RSpec.describe "SLIDE_SPEC.md conformance", type: :service do
+  SPEC_PATH = File.expand_path("../../../docs/SLIDE_SPEC.md", __dir__)
+
+  Example = Struct.new(:label, :line, :markdown, :expected, keyword_init: true)
+
+  def self.conformance_examples
+    examples = []
+    heading = "top"
+    fence = nil
+
+    File.readlines(SPEC_PATH).each_with_index do |line, index|
+      if fence.nil?
+        heading = Regexp.last_match(1).strip if line =~ /\A#+\s+`?([^`\n]+)/
+        fence = { close: "#{Regexp.last_match(1)}\n", start: index + 1, lines: [] } if line =~ /\A(`{3,})conformance\s*\z/
+      elsif line == fence[:close]
+        examples << build_example(heading, fence, examples)
+        fence = nil
+      else
+        fence[:lines] << line
+      end
+    end
+
+    raise "unclosed conformance fence at SLIDE_SPEC.md:#{fence[:start]}" if fence
+    examples
+  end
+
+  def self.build_example(heading, fence, examples)
+    separator = fence[:lines].index(".\n") || raise("conformance block at SLIDE_SPEC.md:#{fence[:start]} has no '.' separator")
+    expected = fence[:lines].drop(separator + 1).to_h do |line|
+      key, value = line.strip.split(":", 2)
+      raise "bad expectation #{line.inspect} at SLIDE_SPEC.md:#{fence[:start]}" if value.nil?
+
+      [ key, value.strip ]
+    end
+
+    ordinal = examples.count { |example| example.label.start_with?(heading) } + 1
+    Example.new(label: "#{heading} ##{ordinal}", line: fence[:start],
+                markdown: fence[:lines].take(separator).join, expected: expected)
+  end
+
+  examples = conformance_examples
+
+  it "extracts a healthy number of examples" do
+    expect(examples.size).to be >= 15
+  end
+
+  examples.each do |example|
+    it "#{example.label} (SLIDE_SPEC.md:#{example.line})" do
+      classification = CoPlan::Slideshows::Classify.call(example.markdown)
+
+      expect(classification.pattern.to_s).to eq(example.expected.fetch("pattern")),
+        "expected pattern #{example.expected["pattern"]}, got #{classification.pattern} (step #{classification.step})"
+      if example.expected["step"]
+        expect(classification.step).to eq(Integer(example.expected["step"]))
+      end
+      if example.expected["media"]
+        expect(classification.media.to_s).to eq(example.expected["media"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #189, which shipped the slideshow foundation (plan-type behavior, the deck split, per-slide rendering). This PR ships the layout engine and the way to actually give the talk: the deck design system and present mode. A deck stays a rendering convention over the plan's single markdown blob — nothing new is persisted, so versioning, diffs, and comment anchoring keep working unchanged. Design doc: CoPlan plan `01a01696-aad6-762b-ad66-7681bbadd98c` (rev 6).

## The deck design system

**`docs/SLIDE_SPEC.md` is the product boundary**, and its fenced `conformance` examples ARE the test suite: `spec/services/slideshows/conformance_spec.rb` executes every fixture in the document, so the spec cannot drift from the implementation, and a future implementation in another language proves itself against the same fixtures.

**`Slideshows::Classify`.** A pure function assigning each slide a layout pattern (`title`, `stage`, `code`, `quote`, `table`, `columns`, `directory`, `split`, `content`) and one of four type-scale steps, from content shape alone — no layout syntax, no measurement, no AI in the layout path. Authors and agents move an image in the source to move it on the slide.

**`deck.css` + three token themes** (`coplan`, `graphite`, `poster`): 16:9 cards sized in container-query units so a slide is the same design at any width, per-pattern art direction (title canvas + accent bar, staged media, oversized pull quotes, side-by-side panes via grid with zero DOM reordering), and discrete type steps instead of shrink-to-fit. Themes are validated custom-property sets applied by `data-deck-theme`; user CSS is never accepted. Slide chrome (numbers, kickers, quote marks) is CSS-generated, invisible to the visible-text counts comment anchoring relies on. Decks ignore the reader's color scheme — a theme is one design, not two — so code panels are pinned to the theme and mermaid diagrams render deck-themed.

**Markup decoration.** After the deck/document parity passes, the renderer applies the spec's markup contract: the neutral `.deck-content` name and, on split slides, the `.deck-media`/`.deck-body` panes — skipped entirely on any classified-shape/DOM mismatch (sanitized-away raw HTML), so the stylesheet degrades to the content layout rather than wrap the wrong node.

## Present mode, the directory pattern, and full-canvas stage media

**Present mode.** `p` or the Present button runs the deck as a fullscreen 16:9 show — what a Zoom/Meet screen-share needs. The deck itself is promoted to the top layer (popover API, plus native fullscreen on the wrapper), which is the load-bearing choice: the plan card's glass `backdrop-filter` makes it the containing block for `position: fixed`, so a merely-fixed overlay would render at card size inside the card's stacking context. Top-layer elements always position against the viewport. Arrows/space/page keys/Backspace/Home/End/clicks navigate (links and checkboxes on slides still work); Escape or leaving fullscreen ends the show; `#present-N` resumes; the "N / total" counter is CSS `attr()` chrome. The presenter wrapper sits outside the live-update swap target and re-applies show state via a childList observer, so a collaborator's edit landing mid-show swaps slides under the presenter without ending it. The show tears down on `turbo:before-cache` (a cached snapshot would otherwise restore a closed-popover, `display: none` deck), and the Present toolbar lives outside the text-selection content target so its label never enters the comment-anchor text model.

**`directory` pattern.** One list of ≥15 short entries (one paragraph, ≤60 chars, no images/breaks — comment-only blocks inside an entry don't count, comments never influence layout) is an inventory, not an argument: it flows into two balanced CSS columns and bills at ⌈units/2⌉ for the type scale, so a forty-project list lands as two readable columns instead of one column running off the canvas.

**Stage sizing.** Stage slides now give the visual the whole canvas: thinner padding, media up to 44cqi, and mermaid's inline natural-size `max-width` overridden so small diagrams scale up to the slide instead of rendering as thumbnails.

`RENDER_CACHE_VERSION` → 11.

## Notes for reviewers

- Deck-specific code is deliberately isolated (`Slideshows::` services, own helper, `deck-*` class namespace, spec + stylesheets with no host-CSS reliance) so the layout engine can be extracted as a standalone package later.
- Commonmarker quirk worth knowing: comment boundaries follow the HTML parser in both malformed directions (`<!-->` is a complete empty comment; an unclosed `<!--` swallows the rest of its block), and image alt text counts for nothing in the unit model — accessible descriptions never shrink type.
- Verified with three adversarial multi-agent review rounds (spec-drift, deck/document parity, and step-sanity attackers with in-browser geometry measurement; then classifier/presenter/CSS lenses with two independent refuters per finding for present mode). All confirmed findings are fixed and pinned as conformance fixtures or specs — among them the backdrop-filter containing-block trap, the Turbo snapshot restoring a mid-show deck as `display: none`, toolbar text entering the comment-anchor occurrence model, and a nested speaker note flipping a directory slide to single-column.
- These commits were originally built on the pre-#190 base and are cherry-picked onto current main; the seeds conflict with #191's showcase entries is resolved by keeping both.

Still to come (separate PRs): deck review loop (slide rail, changed-slides, theme picker), speaker-notes drawer + `/present` deep link, agent fit report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
