### PR TITLE
Extend agent session token lifetimes

### DIFF
--- a/engine/app/models/coplan/api_token.rb
+++ b/engine/app/models/coplan/api_token.rb
@@ -2,8 +2,8 @@ module CoPlan
   class ApiToken < ApplicationRecord
     HOLDER_TYPE = "local_agent"
 
-    DEFAULT_SESSION_TTL = 12.hours
-    MAX_SESSION_TTL = 7.days
+    DEFAULT_SESSION_TTL = 7.days
+    MAX_SESSION_TTL = 30.days
     MIN_SESSION_TTL = 1.minute
 
     # Matches the comment agent_name cap so a token's name can always be

--- a/engine/app/views/coplan/agent_instructions/show.text.erb
+++ b/engine/app/views/coplan/agent_instructions/show.text.erb
@@ -13,13 +13,13 @@ Mint one as your first call (this is the only endpoint that works on request aut
 ```bash
 <%= @curl %> -X POST \
   -H "Content-Type: application/json" \
-  -d '{"agent_name": "Claude", "name": "claude run", "ttl_seconds": 43200, "metadata": {"harness": "claude-code", "harness_version": "2.1.3", "model": "claude-fable-5"}}' \
+  -d '{"agent_name": "Claude", "name": "claude run", "metadata": {"harness": "claude-code", "harness_version": "2.1.3", "model": "claude-fable-5"}}' \
   "<%= @base %>/api/v1/tokens" | jq .
 ```
 
 - `agent_name`: who you are ("Claude", "Amp") — stamped on every version, event, and comment you write. Truncated past 20 characters.
 - `metadata`: optional JSON object of identity facts about this run — schemaless, like a User-Agent string. Suggested keys: `harness`, `harness_version`, `model`. Recorded on the token, and everything you write links back to it, so include whatever would help a human reading the history later understand what produced the edit. Capped at 4 KB.
-- `ttl_seconds`: optional, default 12 hours, max 7 days.
+- `ttl_seconds`: optional, default 7 days, max 30 days.
 - The response's `token` is shown once. Send it as `Authorization: Bearer <token>` on every subsequent call.
 - Mint once at the start of your run and reuse it — minting per call would give you a new identity every time.
 - When you finish, `DELETE <%= @base %>/api/v1/tokens/current` (authenticated with the token itself) so the credential dies with the run instead of waiting out its TTL.

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CoPlan::ApiToken, type: :model do
       expect(child.user_id).to eq(user.id)
       expect(child.parent_id).to eq(parent.id)
       expect(child.agent_name).to eq("Claude refactor")
-      expect(child.expires_at).to be_within(1.minute).of(12.hours.from_now)
+      expect(child.expires_at).to be_within(1.minute).of(described_class::DEFAULT_SESSION_TTL.from_now)
       expect(CoPlan::ApiToken.authenticate(raw)).to eq(child)
     end
 
@@ -82,7 +82,7 @@ RSpec.describe CoPlan::ApiToken, type: :model do
     end
 
     it "clamps the ttl to the maximum" do
-      child, = parent.mint_session_token!(ttl: 30.days)
+      child, = parent.mint_session_token!(ttl: 60.days)
       expect(child.expires_at).to be_within(1.minute).of(described_class::MAX_SESSION_TTL.from_now)
     end
 
@@ -156,7 +156,7 @@ RSpec.describe CoPlan::ApiToken, type: :model do
       expect(token.user_id).to eq(user.id)
       expect(token.parent_id).to be_nil
       expect(token.agent_name).to eq("Claude")
-      expect(token.expires_at).to be_within(1.minute).of(12.hours.from_now)
+      expect(token.expires_at).to be_within(1.minute).of(CoPlan::ApiToken::DEFAULT_SESSION_TTL.from_now)
       expect(CoPlan::ApiToken.authenticate(raw)).to eq(token)
     end
 


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_SESSION_TTL` from 12 hours to 7 days, and `MAX_SESSION_TTL` from 7 to 30 days in [`ApiToken`](engine/app/models/coplan/api_token.rb), so agent sessions don't expire mid-task.
- Update spec assertions that hardcoded the old durations to reference the constants instead, and bumped the clamp test's input TTL (30d → 60d) so it still exercises clamping against the new 30-day max.

## Test plan
- [x] `bundle exec rspec spec/models/api_token_spec.rb spec/requests/api/v1/tokens_spec.rb` — 37 examples, 0 failures