### PR TITLE
Present into the window, not over the screen

### DIFF
--- a/engine/app/assets/stylesheets/coplan/deck.css
+++ b/engine/app/assets/stylesheets/coplan/deck.css
@@ -473,11 +473,14 @@
   object-fit: contain;
 }
 
-/* ---- presenting — the deck takes the screen ---------------------------
+/* ---- presenting — the deck takes the window ---------------------------
    Present mode (coplan--deck-presenter) shows the deck as a top-layer
-   popover sized to the largest 16:9 canvas that fits the viewport — the
-   deck stays the size container, so every cqi measurement above scales to
-   the screen with no presentation-specific typography. Top layer matters:
+   popover sized to the largest 16:9 canvas that fits the viewport. That
+   is the whole mechanism, in a window and under native fullscreen alike:
+   viewport units mean pressing `f` needs no presentation-specific rule,
+   the canvas just grows into the screen. The deck stays the size
+   container, so every cqi measurement above scales with it and no
+   presentation-specific typography is needed. Top layer matters:
    fixed positioning alone resolves against any backdrop-filter ancestor
    (the host's glass card), while top-layer elements always position
    against the viewport. The spread shadow blacks out the letterbox bars

--- a/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
+++ b/engine/app/javascript/controllers/coplan/deck_presenter_controller.js
@@ -9,12 +9,20 @@ const DRAG_SLOP = 4
 /*
  * coplan--deck-presenter
  *
- * Present mode: the deck takes the screen as one 16:9 canvas — exactly what
- * a Zoom or Meet screen-share needs. One slide shows at a time; arrows,
- * space, page keys, and clicks advance; Escape (or leaving native
- * fullscreen) ends the show. Native fullscreen is requested on this
- * wrapper, with the fixed-overlay CSS as the fallback when the browser
- * refuses, so presenting works either way.
+ * Present mode: the deck takes the browser window as one 16:9 canvas. One
+ * slide shows at a time; arrows, space, page keys, and clicks advance;
+ * Escape ends the show.
+ *
+ * The window, not the screen, is the default on purpose. Presenting over
+ * Zoom or Meet means sharing a window, and on macOS native fullscreen moves
+ * the window onto its own Space — where screen-share pickers can no longer
+ * see it at all. Taking the screen also buries the call controls the
+ * presenter is talking through. So the show fills the window (the top-layer
+ * popover in _promoteDeck is what makes that airtight), and `f` takes the
+ * whole screen for the times there's a projector and no call. Fullscreen is
+ * a mode within the show, not the show itself: dropping out of it — by `f`,
+ * by Escape, by the browser's own chrome — leaves the deck presenting in
+ * the window.
  *
  * Two gestures mark up a slide without leaving the show. Dragging across
  * text highlights it in the deck's accent — the room's eyes follow the
@@ -78,10 +86,9 @@ export default class extends Controller {
     // Presenting borrows the URL fragment for #present-N; remember what
     // was there (a heading deep link, a footnote) to give back on exit.
     this._priorHash = resumed ? "" : window.location.hash
-    this._peeling = false
     this._show(resumed ? Number(resumed[1]) - 1 : 0)
-    // _show stops the show itself on a slideless deck — don't take the
-    // screen for nothing.
+    // _show stops the show itself on a slideless deck — don't black out
+    // the window for nothing.
     if (!this.presenting) return
 
     // Move focus into the show. Clicking the Present button leaves the
@@ -93,12 +100,18 @@ export default class extends Controller {
       deck.tabIndex = -1
       deck.focus({ preventScroll: true })
     }
+  }
 
-    // Native fullscreen when the browser grants it; the top-layer popover
-    // (see _promoteDeck) is what actually fills the screen either way.
-    // Re-promote once fullscreen resolves — the fullscreen wrapper enters
-    // the top layer above the already-shown popover and would cover it.
-    this.element.requestFullscreen?.().then(() => {
+  // `f` mid-show. Fullscreen is asked for on the wrapper rather than the
+  // deck so the deck stays free to be a popover; the top-layer popover is
+  // what fills the space either way, and re-promoting is what keeps it
+  // visible — the fullscreen wrapper enters the top layer ABOVE the
+  // already-shown popover and would otherwise cover it.
+  _toggleFullscreen() {
+    if (document.fullscreenElement === this.element) return document.exitFullscreen().catch(() => {})
+    if (!this.element.requestFullscreen) return
+
+    this.element.requestFullscreen().then(() => {
       // The grant can outlive a fast Escape: if the show already ended,
       // give the screen back instead of re-promoting a stopped deck.
       if (!this.presenting) {
@@ -237,18 +250,28 @@ export default class extends Controller {
         event.stopPropagation()
         this.ink.toggle()
         break
+      case "f":
+        // Full screen. For a projector in a room; a call wants the window
+        // (see the note at the top of this file), which is what the show
+        // gives back when this toggles off.
+        event.preventDefault()
+        event.stopPropagation()
+        this._toggleFullscreen()
+        break
       case "Escape":
         event.preventDefault()
         event.stopPropagation()
         // Escape peels one layer at a time: whatever is visibly in front of
         // the show goes first — a popover (a reference preview, a pinned
-        // thread), then the pen — and only a bare Escape ends the show. The
-        // browser may drop native fullscreen on the same keypress (that
-        // exit is uncancelable), so mark the peel: the resulting
-        // fullscreenchange is forgiven and the show continues on the
-        // top-layer fallback.
-        if (this._dismissForeignPopovers() || this._stowPen()) {
-          if (document.fullscreenElement === this.element) this._peeling = true
+        // thread), then the pen, then the screen — and only a bare Escape
+        // ends the show. Giving the screen back is its own step because
+        // full screen is the one layer the presenter took deliberately;
+        // Escape should undo that, not the whole show. (The browser drops
+        // fullscreen on this keypress anyway, uncancelably — exiting here
+        // just makes the same thing happen on purpose.)
+        if (this._dismissForeignPopovers() || this._stowPen()) return
+        if (document.fullscreenElement === this.element) {
+          document.exitFullscreen().catch(() => {})
           return
         }
         this.stop()
@@ -390,13 +413,13 @@ export default class extends Controller {
   _handleFullscreenChange() {
     if (!this.presenting || document.fullscreenElement) return
 
-    // One exit is forgiven when Escape was consumed dismissing a popover —
-    // the keypress was aimed at the popover, not the show.
-    if (this._peeling) {
-      this._peeling = false
-      return
-    }
-    this.stop()
+    // Losing the screen no longer ends the show — the presenter is back to
+    // the window they started in, which is the shape a call wants. However
+    // it happened (the `f` toggle, Escape, the browser's own chrome), the
+    // one thing to check is that the deck is still in the top layer: the
+    // fullscreen wrapper leaving it is the moment a promotion could be
+    // dropped, and a closed popover is a blank page.
+    this._promoteDeck()
   }
 
   _typing(target) {

--- a/engine/app/views/coplan/plans/show.html.erb
+++ b/engine/app/views/coplan/plans/show.html.erb
@@ -80,11 +80,13 @@
           anchored to diagram labels get their marks (and pending ?thread=
           deep links can resolve). %>
       <div class="plan-layout__content">
-        <%# Presentations present: `p` or the button starts a fullscreen
-            show (deck_presenter_controller). The wrapper sits outside the
-            live-update swap target so a collaborator's edit landing
-            mid-show doesn't disconnect the presenter — and the toolbar sits
-            outside the text-selection content target below, because its
+        <%# Presentations present: `p` or the button fills the window with
+            the deck (deck_presenter_controller) — a window is what a call
+            can screen-share, and `f` takes the whole screen for a room.
+            The wrapper sits outside the live-update swap target so a
+            collaborator's edit landing mid-show doesn't disconnect the
+            presenter — and the toolbar sits outside the text-selection
+            content target below, because its
             label is visible text and comment anchors count visible-text
             occurrences under that target. %>
         <% if @plan.presentation? %>
@@ -93,7 +95,7 @@
             <%# The only place the show's keys are advertised before it
                 starts — mid-show there is no room for a legend, and the pen
                 is the one gesture nobody would guess. %>
-            <button type="button" class="deck-toolbar__present" data-action="coplan--deck-presenter#start" title="Present (p) — mid-show, drag to highlight, d for the pen">
+            <button type="button" class="deck-toolbar__present" data-action="coplan--deck-presenter#start" title="Present (p) — mid-show, f for full screen, drag to highlight, d for the pen">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 4.8a1 1 0 0 1 1.53-.85l11.1 7.2a1 1 0 0 1 0 1.7l-11.1 7.2A1 1 0 0 1 7 19.2z"/></svg>
               Present <kbd>p</kbd>
             </button>

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 # Browser-level coverage for the deck's pointer and navigation behavior:
-# the two ways a presenter marks up a live slide (selecting text, and the
-# pen), the Mermaid expand chip staying chip-sized on a slide, and the
-# back-matter links jumping in place instead of refetching the page.
+# the show filling the window rather than taking the screen (a call shares
+# windows), the two ways a presenter marks up a live slide (selecting text,
+# and the pen), the Mermaid expand chip staying chip-sized on a slide, and
+# the back-matter links jumping in place instead of refetching the page.
 RSpec.describe "Deck UX", type: :system do
   let(:user) { create(:coplan_user, email: "presenter@example.com") }
   let(:deck_type) { create(:plan_type, name: "Presentation", behavior: "presentation") }
@@ -225,6 +226,40 @@ RSpec.describe "Deck UX", type: :system do
 
       find(".deck-slide--current").click
       expect(current_slide).to eq("2")
+    end
+
+    # A call shares a window; macOS moves a fullscreen window onto its own
+    # Space, where screen-share pickers can't see it. So starting the show
+    # must not take the screen — `f` is the presenter asking for it.
+    it "fills the window without taking the screen, and takes it on f" do
+      visit plan_path(plan)
+      start_show
+      expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
+
+      # The window is the canvas either way: the deck is in the top layer,
+      # so no glass card ancestor can trap or cover it.
+      expect(page.evaluate_script(<<~JS)).to be(true)
+        (() => {
+          const deck = document.querySelector(".deck--presenting");
+          if (!deck.matches(":popover-open")) return false;
+          const box = deck.getBoundingClientRect();
+          const fits = Math.min(window.innerWidth, window.innerHeight * 16 / 9);
+          return Math.abs(box.width - fits) < 2;
+        })()
+      JS
+
+      send_keys("f")
+      expect(page.evaluate_script("!!document.fullscreenElement")).to be(true)
+
+      # Escape gives the screen back and the show carries on in the window —
+      # full screen is a layer to peel, not the show itself.
+      send_keys(:escape)
+      expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
+      expect(page).to have_css(".deck--presenting")
+      expect(current_slide).to eq("1")
+
+      send_keys(:escape)
+      expect(page).to have_no_css(".deck--presenting")
     end
 
     it "puts the pen away on Escape without ending the show" do

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -114,11 +114,16 @@ RSpec.describe "Deck UX", type: :system do
       # transient server state; a second failure means something about this
       # request is genuinely different.
       asked = plan_path(plan)
-      recognized = begin
-        Rails.application.routes.recognize_path(asked, method: :get).inspect
+      recognize = lambda do |set|
+        set.recognize_path(asked, method: :get).inspect
       rescue StandardError => e
         "#{e.class}: #{e.message}"
       end
+      # The helper generated `asked`, so a route named `plan` exists. Ask
+      # both sets to recognize it, and dump what the engine actually has
+      # under /_/plans — locally both recognize it and the route is there.
+      routes = CoPlan::Engine.routes.routes.map { |r| r.path.spec.to_s }.grep(%r{^/_/plans}).first(4)
+      mounted = Rails.application.routes.routes.count { |r| r.app.respond_to?(:app) && r.app.app == CoPlan::Engine }
       first = "url=#{page.current_url} title=#{page.title.inspect}"
       visit asked
       retried = "url=#{page.current_url} deck=#{page.has_css?('.deck-slide', wait: 10)}"
@@ -129,7 +134,9 @@ RSpec.describe "Deck UX", type: :system do
           plan:       slug=#{plan.slug.inspect} suffix=#{plan.slug_suffix.inspect} \
         handle=#{plan.library_handle.inspect} url_path=#{plan.url_path.inspect} \
         visibility=#{plan.visibility.inspect}
-          recognized: #{recognized}
+          app recog:  #{recognize.call(Rails.application.routes)}
+          eng recog:  #{recognize.call(CoPlan::Engine.routes)}
+          eng routes: #{routes.inspect} (engine mounted #{mounted}x)
           first try:  #{first}
           retry:      #{retried}
           console:    #{page.driver.browser.logs.get(:browser).map(&:message).last(5).inspect}

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -104,45 +104,7 @@ RSpec.describe "Deck UX", type: :system do
   # button the server hasn't sent yet. (The examples below that don't
   # present already wait explicitly for the same reason.)
   def start_show
-    unless page.has_css?(".deck-slide", wait: 10)
-      # TEMPORARY: on CI this one example lands on a routing error for
-      # /_/plans/<uuid> — a path the other examples in this file fetch
-      # happily in the same process, so a static route table can't be the
-      # whole story. Report the record, the path asked for, whether the
-      # test process's own route set recognizes it, and — the discriminator
-      # — whether simply asking again works. A passing retry means
-      # transient server state; a second failure means something about this
-      # request is genuinely different.
-      asked = plan_path(plan)
-      recognize = lambda do |set|
-        set.recognize_path(asked, method: :get).inspect
-      rescue StandardError => e
-        "#{e.class}: #{e.message}"
-      end
-      # The helper generated `asked`, so a route named `plan` exists. Ask
-      # both sets to recognize it, and dump what the engine actually has
-      # under /_/plans — locally both recognize it and the route is there.
-      routes = CoPlan::Engine.routes.routes.map { |r| r.path.spec.to_s }.grep(%r{^/_/plans}).first(4)
-      mounted = Rails.application.routes.routes.count { |r| r.app.respond_to?(:app) && r.app.app == CoPlan::Engine }
-      first = "url=#{page.current_url} title=#{page.title.inspect}"
-      visit asked
-      retried = "url=#{page.current_url} deck=#{page.has_css?('.deck-slide', wait: 10)}"
-
-      raise <<~DIAG
-        No .deck-slide.
-          asked:      #{asked}
-          plan:       slug=#{plan.slug.inspect} suffix=#{plan.slug_suffix.inspect} \
-        handle=#{plan.library_handle.inspect} url_path=#{plan.url_path.inspect} \
-        visibility=#{plan.visibility.inspect}
-          app recog:  #{recognize.call(Rails.application.routes)}
-          eng recog:  #{recognize.call(CoPlan::Engine.routes)}
-          eng routes: #{routes.inspect} (engine mounted #{mounted}x)
-          first try:  #{first}
-          retry:      #{retried}
-          console:    #{page.driver.browser.logs.get(:browser).map(&:message).last(5).inspect}
-          body:       #{page.find('body').text[0, 300].inspect}
-      DIAG
-    end
+    expect(page).to have_css(".deck-slide", wait: 10)
     click_button "Present"
     expect(page).to have_css(".deck--presenting .deck-slide--current", wait: 5)
   end
@@ -205,8 +167,14 @@ RSpec.describe "Deck UX", type: :system do
     # A call shares a window; macOS moves a fullscreen window onto its own
     # Space, where screen-share pickers can't see it. So starting the show
     # must not take the screen — `f` is the presenter asking for it.
+    #
+    # Reached by its readable address rather than plan_path's /_/plans/<id>.
+    # That's the canonical URL — PlansController 301s the id form onto it —
+    # so it's the address a presenter actually opens. It also steps around
+    # a CI-only routing failure on the legacy id path that this example
+    # kept tripping (see the note on the issue filed alongside this).
     it "fills the window without taking the screen, and takes it on f" do
-      visit plan_path(plan)
+      visit "/#{plan.url_path}"
       start_show
       expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
 

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -97,7 +97,14 @@ RSpec.describe "Deck UX", type: :system do
     page.evaluate_script("window.__strokes")
   end
 
+  # Wait for the deck itself before reaching for the button. This page
+  # renders Mermaid, so it settles well past Capybara's 2s default on a
+  # loaded CI runner — and the toolbar only exists once the deck does, so
+  # a bare click_button spends that whole default budget looking for a
+  # button the server hasn't sent yet. (The examples below that don't
+  # present already wait explicitly for the same reason.)
   def start_show
+    expect(page).to have_css(".deck-slide", wait: 10)
     click_button "Present"
     expect(page).to have_css(".deck--presenting .deck-slide--current", wait: 5)
   end
@@ -155,6 +162,40 @@ RSpec.describe "Deck UX", type: :system do
       # click was swallowed and the box silently did not move.
       send_keys(:space)
       expect(checkbox).to be_checked
+    end
+
+    # A call shares a window; macOS moves a fullscreen window onto its own
+    # Space, where screen-share pickers can't see it. So starting the show
+    # must not take the screen — `f` is the presenter asking for it.
+    it "fills the window without taking the screen, and takes it on f" do
+      visit plan_path(plan)
+      start_show
+      expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
+
+      # The window is the canvas either way: the deck is in the top layer,
+      # so no glass card ancestor can trap or cover it.
+      expect(page.evaluate_script(<<~JS)).to be(true)
+        (() => {
+          const deck = document.querySelector(".deck--presenting");
+          if (!deck.matches(":popover-open")) return false;
+          const box = deck.getBoundingClientRect();
+          const fits = Math.min(window.innerWidth, window.innerHeight * 16 / 9);
+          return Math.abs(box.width - fits) < 2;
+        })()
+      JS
+
+      send_keys("f")
+      expect(page).to have_css(".deck-presenter:fullscreen", wait: 5)
+
+      # Escape gives the screen back and the show carries on in the window —
+      # full screen is a layer to peel, not the show itself.
+      send_keys(:escape)
+      expect(page).to have_no_css(".deck-presenter:fullscreen", wait: 5)
+      expect(page).to have_css(".deck--presenting")
+      expect(current_slide).to eq("1")
+
+      send_keys(:escape)
+      expect(page).to have_no_css(".deck--presenting")
     end
   end
 
@@ -226,40 +267,6 @@ RSpec.describe "Deck UX", type: :system do
 
       find(".deck-slide--current").click
       expect(current_slide).to eq("2")
-    end
-
-    # A call shares a window; macOS moves a fullscreen window onto its own
-    # Space, where screen-share pickers can't see it. So starting the show
-    # must not take the screen — `f` is the presenter asking for it.
-    it "fills the window without taking the screen, and takes it on f" do
-      visit plan_path(plan)
-      start_show
-      expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
-
-      # The window is the canvas either way: the deck is in the top layer,
-      # so no glass card ancestor can trap or cover it.
-      expect(page.evaluate_script(<<~JS)).to be(true)
-        (() => {
-          const deck = document.querySelector(".deck--presenting");
-          if (!deck.matches(":popover-open")) return false;
-          const box = deck.getBoundingClientRect();
-          const fits = Math.min(window.innerWidth, window.innerHeight * 16 / 9);
-          return Math.abs(box.width - fits) < 2;
-        })()
-      JS
-
-      send_keys("f")
-      expect(page.evaluate_script("!!document.fullscreenElement")).to be(true)
-
-      # Escape gives the screen back and the show carries on in the window —
-      # full screen is a layer to peel, not the show itself.
-      send_keys(:escape)
-      expect(page.evaluate_script("!!document.fullscreenElement")).to be(false)
-      expect(page).to have_css(".deck--presenting")
-      expect(current_slide).to eq("1")
-
-      send_keys(:escape)
-      expect(page).to have_no_css(".deck--presenting")
     end
 
     it "puts the pen away on Escape without ending the show" do

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -104,7 +104,21 @@ RSpec.describe "Deck UX", type: :system do
   # button the server hasn't sent yet. (The examples below that don't
   # present already wait explicitly for the same reason.)
   def start_show
-    expect(page).to have_css(".deck-slide", wait: 10)
+    unless page.has_css?(".deck-slide", wait: 10)
+      # TEMPORARY: one CI-only example loses its deck and the failure alone
+      # doesn't say why. Report what the browser is actually looking at.
+      raise <<~DIAG
+        No .deck-slide.
+          url:     #{page.current_url}
+          title:   #{page.title.inspect}
+          markers: presenter=#{page.has_css?('.deck-presenter', wait: 0)} \
+        toolbar=#{page.has_css?('.deck-toolbar', wait: 0)} \
+        deck=#{page.has_css?('.deck', wait: 0)} \
+        content=#{page.has_css?('#plan-content-body', wait: 0)}
+          console: #{page.driver.browser.logs.get(:browser).map(&:message).last(5).inspect}
+          body:    #{page.find('body').text[0, 400].inspect}
+      DIAG
+    end
     click_button "Present"
     expect(page).to have_css(".deck--presenting .deck-slide--current", wait: 5)
   end

--- a/spec/system/deck_ux_spec.rb
+++ b/spec/system/deck_ux_spec.rb
@@ -105,18 +105,35 @@ RSpec.describe "Deck UX", type: :system do
   # present already wait explicitly for the same reason.)
   def start_show
     unless page.has_css?(".deck-slide", wait: 10)
-      # TEMPORARY: one CI-only example loses its deck and the failure alone
-      # doesn't say why. Report what the browser is actually looking at.
+      # TEMPORARY: on CI this one example lands on a routing error for
+      # /_/plans/<uuid> — a path the other examples in this file fetch
+      # happily in the same process, so a static route table can't be the
+      # whole story. Report the record, the path asked for, whether the
+      # test process's own route set recognizes it, and — the discriminator
+      # — whether simply asking again works. A passing retry means
+      # transient server state; a second failure means something about this
+      # request is genuinely different.
+      asked = plan_path(plan)
+      recognized = begin
+        Rails.application.routes.recognize_path(asked, method: :get).inspect
+      rescue StandardError => e
+        "#{e.class}: #{e.message}"
+      end
+      first = "url=#{page.current_url} title=#{page.title.inspect}"
+      visit asked
+      retried = "url=#{page.current_url} deck=#{page.has_css?('.deck-slide', wait: 10)}"
+
       raise <<~DIAG
         No .deck-slide.
-          url:     #{page.current_url}
-          title:   #{page.title.inspect}
-          markers: presenter=#{page.has_css?('.deck-presenter', wait: 0)} \
-        toolbar=#{page.has_css?('.deck-toolbar', wait: 0)} \
-        deck=#{page.has_css?('.deck', wait: 0)} \
-        content=#{page.has_css?('#plan-content-body', wait: 0)}
-          console: #{page.driver.browser.logs.get(:browser).map(&:message).last(5).inspect}
-          body:    #{page.find('body').text[0, 400].inspect}
+          asked:      #{asked}
+          plan:       slug=#{plan.slug.inspect} suffix=#{plan.slug_suffix.inspect} \
+        handle=#{plan.library_handle.inspect} url_path=#{plan.url_path.inspect} \
+        visibility=#{plan.visibility.inspect}
+          recognized: #{recognized}
+          first try:  #{first}
+          retry:      #{retried}
+          console:    #{page.driver.browser.logs.get(:browser).map(&:message).last(5).inspect}
+          body:       #{page.find('body').text[0, 300].inspect}
       DIAG
     end
     click_button "Present"


### PR DESCRIPTION
Presenting a deck over Zoom didn't work, and native fullscreen was the reason.

On macOS a fullscreen window moves onto its own Space, and apps sitting in a fullscreen Space **drop out of screen-share pickers entirely** — so `requestFullscreen` was quietly removing the browser from Zoom's window list at the exact moment you wanted to share it. Taking the whole screen also buries the call controls the presenter is talking through.

## What changed

`start()` no longer requests fullscreen. The screen was never the mechanism anyway: the top-layer popover in `_promoteDeck` is what fills the space, and the deck canvas is already sized in viewport units. So the show now fills the **browser window**, which is exactly what you pick in a share dialog.

`f` mid-show toggles native fullscreen, for the times there's a projector and no call.

Fullscreen became a mode *within* the show rather than the show itself — losing it drops back to the window instead of ending the presentation. Two consequences:

- **Escape gained a rung.** It already peeled one layer at a time (popovers, then the pen); now the screen is a layer too, and only a bare Escape ends the show. Full screen is the one layer the presenter took deliberately, so Escape should undo *that*, not everything.
- **`_peeling` is gone.** It existed solely to forgive the uncancelable fullscreen exit that Escape used to trigger. There's nothing left to forgive.

No CSS rules changed — `min(100vw, 100vh * 16/9)` means the canvas just grows into the screen when `f` lands. Only the section comment and the Present button's key legend needed updating.

## Why not something cleverer

I looked for a web API that would hand Zoom a dedicated surface. There isn't one:

- **`navigator.presentation`** — Safari has never implemented it (no support on any version, macOS or iOS), and even in Chrome it hands a URL to a *second-screen receiver* (Chromecast, a presentation display). There's no macOS window for Zoom to pick up.
- **`getDisplayMedia`** — an input, not an output. A page can capture the screen; it cannot publish one. A `MediaStream`'s only sinks are `<video>`, `RTCPeerConnection`, and Web Audio. Feeding Zoom would need a native virtual camera (a CoreMedia I/O extension, the OBS Virtual Camera approach).
- **Element Capture / Region Capture** — Chromium-only, and they only apply to the page doing the capturing. Zoom is the capturer here.
- **Document Picture-in-Picture** — Chrome 130, Firefox 151, Safari never. Also moving the deck into another document would disconnect the Stimulus controllers and the live-update target, breaking the "a collaborator's edit lands mid-show" behavior.

So "make the window shareable" is the whole solution space, and it's a deletion.

## Testing

New spec in `spec/system/deck_ux_spec.rb` covers: no `fullscreenElement` on start; the deck sized to the window's largest 16:9 fit and genuinely in the top layer; `f` entering fullscreen; Escape returning to windowed **with the show still running on slide 1**; a second Escape ending it.

Deck suite plus the plans request specs: 119 examples, 0 failures.

## For the reviewer

- Verified in headless Chrome, not Safari. The mechanism is the Popover API plus viewport units — both solid in Safari 17+ — and this change *removes* the browser-specific API call rather than adding one. Still worth one manual Zoom-share confirmation.
- Windowed present means the browser window is a black 16:9 canvas with letterbox bars filling the remainder. Correct for sharing, but a visibly different feel from before.
- `f` is keyboard-only; there's deliberately no mid-show chrome. It's advertised in the Present button's title alongside `p` and `d`, which is the only place the show's keys are listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One thing a reviewer should question

The new example opens the plan at its readable address (`visit "/#{plan.url_path}"`) while its neighbours use `plan_path(plan)`. That inconsistency is deliberate but unresolved.

On CI — both DB jobs, deterministically — that one example got a Rails routing error for `/_/plans/<uuid>`, the path `plan_path` generates. Diagnostics showed the plan record intact (`slug="readout-deck"`, `handle="presenter"`, `visibility="published"`), both `Rails.application.routes` and `CoPlan::Engine.routes` failing to recognize that path, and the engine mounted once with its member routes (`publish`, `hide`, `archive`) present in the same set. Re-requesting failed identically.

What I could not explain: the two examples above it fetch that exact path successfully in the same process, and every example below passes. Moving it from sixth to third position in the file changed nothing. `engine/config/routes.rb` has no conditionals, the engine is a path gem, no spec redraws routes, and locally the path resolves under both lazy and eager loading.

Visiting the readable address is defensible on its own — it's the canonical URL, `PlansController#show` 301s the id form onto it, and it's what a presenter actually opens. But it's a step around the anomaly, not an explanation. The anomaly predates this branch and is filed for separate investigation.
