### PR TITLE
Fix Slack unfurling for browsable URLs

### DIFF
--- a/engine/app/services/coplan/link_previews.rb
+++ b/engine/app/services/coplan/link_previews.rb
@@ -1,3 +1,4 @@
+require "cgi"
 require "uri"
 
 module CoPlan
@@ -34,8 +35,10 @@ module CoPlan
         # back to the legacy /plans/<id> path only when url_path is nil
         # (a plan with no library or slug, which shouldn't happen in
         # practice since both are NOT NULL after the backfill migration).
+        # Percent-encode each segment so Unicode slugs (Japanese, Arabic,
+        # accented Latin) don't raise URI::InvalidComponentError.
         path_suffix = plan.url_path || "plans/#{plan.id}"
-        canonical.path = join_path(base.path, path_suffix)
+        canonical.path = join_path(base.path, encode_path_segments(path_suffix))
         canonical.query = canonical.fragment = nil
         description = plan.summary.presence || plain_content(plan)
 
@@ -99,16 +102,48 @@ module CoPlan
         return if !mount.empty? && relative == path
         return unless relative.start_with?("/")
 
-        # Strip known sub-page tails: /edit, /history, /history/<rev>, /history/<rev>/diff
-        relative = relative.sub(%r{/(edit|history(/[^/]+)?(/diff)?)?/*\z}, "")
+        # Try the full path first — a plan's slug might literally be "edit"
+        # or "history" (see spec/requests/browse_spec.rb). Only when that
+        # fails do we strip known sub-page tails and try again, matching
+        # the route order the browse controller uses.
+        candidates = [ relative ]
+        stripped = relative.sub(%r{/(edit|history(/[^/]+)?(/diff)?)?/*\z}, "")
+        candidates << stripped if stripped != relative
 
+        candidates.each do |candidate|
+          plan = plan_from_browsable_candidate(candidate)
+          return plan if plan
+        end
+
+        nil
+      end
+
+      def plan_from_browsable_candidate(relative)
         match = relative.match(%r{\A/([a-z0-9][a-z0-9-]*)/(.+)/*\z})
         return unless match
 
         handle = match[1]
         return if Library::RESERVED_HANDLES.include?(handle)
 
-        result = Urls::Resolve.call(handle: handle, slug_path: match[2])
+        # Slack sends percent-encoded URLs; decode each segment to match
+        # the UTF-8 slugs stored in the database (Unicode slugs are
+        # explicitly supported — see CoPlan::Slug).
+        slug_path = decode_path_segments(match[2])
+
+        resolve_plan(handle, slug_path)
+      end
+
+      def resolve_plan(handle, slug_path)
+        result = Urls::Resolve.call(handle: handle, slug_path: slug_path)
+
+        # Follow alias redirects: a renamed plan, folder, or library
+        # still resolves via UrlAlias, but Urls::Resolve represents that
+        # as redirect_to_path with no plan. Re-resolve the rewritten path.
+        if result&.redirect_to_path
+          new_handle, _, new_slug_path = result.redirect_to_path.partition("/")
+          result = Urls::Resolve.call(handle: new_handle, slug_path: new_slug_path)
+        end
+
         return unless result&.found? && result.plan
 
         # Urls::Resolve doesn't preload the associations for_plan needs.
@@ -129,6 +164,19 @@ module CoPlan
 
       def join_path(base, suffix)
         "#{base.to_s.sub(%r{/+\z}, "")}/#{suffix}"
+      end
+
+      # Percent-encodes each path segment for safe assignment to URI#path=.
+      # URI#path= rejects raw non-ASCII (Japanese, Arabic, accented Latin),
+      # so Unicode slugs must be encoded on the way out.
+      def encode_path_segments(path)
+        path.split("/").map { |seg| CGI.escape(seg) }.join("/")
+      end
+
+      # Percent-decodes each path segment so encoded Unicode slugs from
+      # Slack match the UTF-8 slugs stored in the database.
+      def decode_path_segments(path)
+        path.split("/").map { |seg| CGI.unescape(seg) }.join("/")
       end
 
       def plain_content(plan)

--- a/engine/app/services/coplan/link_previews.rb
+++ b/engine/app/services/coplan/link_previews.rb
@@ -13,11 +13,11 @@ module CoPlan
         base = parse_url(base_url, enforce_https: true)
         return unless supplied && base && safe_origin?(supplied, base)
 
-        plan_id = plan_id_from(supplied.path, base.path)
-        return unless plan_id
+        plan = plan_from_legacy_path(supplied.path, base.path) ||
+               plan_from_browsable_path(supplied.path, base.path)
+        return unless plan
 
-        plan = Plan.includes(:created_by_user, :plan_type, :current_plan_version).find_by(id: plan_id)
-        for_plan(plan, base_url: base_url) if plan
+        for_plan(plan, base_url: base_url)
       rescue URI::InvalidURIError
         nil
       end
@@ -30,7 +30,12 @@ module CoPlan
         raise ArgumentError, "invalid base_url" unless base
 
         canonical = base.dup
-        canonical.path = join_path(base.path, "plans/#{plan.id}")
+        # The browsable URL is canonical — /<handle>/<slug-path> — falling
+        # back to the legacy /plans/<id> path only when url_path is nil
+        # (a plan with no library or slug, which shouldn't happen in
+        # practice since both are NOT NULL after the backfill migration).
+        path_suffix = plan.url_path || "plans/#{plan.id}"
+        canonical.path = join_path(base.path, path_suffix)
         canonical.query = canonical.fragment = nil
         description = plan.summary.presence || plain_content(plan)
 
@@ -79,6 +84,35 @@ module CoPlan
         uri.to_s if uri&.scheme == "https"
       rescue URI::InvalidURIError
         nil
+      end
+
+      def plan_from_legacy_path(path, mount_path)
+        plan_id = plan_id_from(path, mount_path)
+        return unless plan_id
+
+        Plan.includes(:created_by_user, :plan_type, :current_plan_version).find_by(id: plan_id)
+      end
+
+      def plan_from_browsable_path(path, mount_path)
+        mount = mount_path.to_s.sub(%r{/*\z}, "")
+        relative = mount.empty? ? path : path.delete_prefix(mount)
+        return if !mount.empty? && relative == path
+        return unless relative.start_with?("/")
+
+        # Strip known sub-page tails: /edit, /history, /history/<rev>, /history/<rev>/diff
+        relative = relative.sub(%r{/(edit|history(/[^/]+)?(/diff)?)?/*\z}, "")
+
+        match = relative.match(%r{\A/([a-z0-9][a-z0-9-]*)/(.+)/*\z})
+        return unless match
+
+        handle = match[1]
+        return if Library::RESERVED_HANDLES.include?(handle)
+
+        result = Urls::Resolve.call(handle: handle, slug_path: match[2])
+        return unless result&.found? && result.plan
+
+        # Urls::Resolve doesn't preload the associations for_plan needs.
+        Plan.includes(:created_by_user, :plan_type, :current_plan_version).find_by(id: result.plan.id)
       end
 
       def plan_id_from(path, mount_path)

--- a/spec/services/link_previews_spec.rb
+++ b/spec/services/link_previews_spec.rb
@@ -1,3 +1,4 @@
+require "cgi"
 require "rails_helper"
 
 RSpec.describe CoPlan::LinkPreviews do
@@ -68,6 +69,56 @@ RSpec.describe CoPlan::LinkPreviews do
     # resolve via the legacy matcher, not the browsable matcher.
     reserved_url = "#{base_url}/plans/#{plan.url_path.split('/').last}"
     expect(described_class.resolve(url: reserved_url, base_url: base_url)).to be_nil
+  end
+
+  it "resolves browsable URLs for plans whose slug is literally 'edit' or 'history'" do
+    author = plan.created_by_user
+    library = author.library
+
+    edit_plan = create(:plan, :published, created_by_user: author, title: "Edit")
+    create(:plan_placement, plan: edit_plan, folder: create(:folder, library: library, created_by_user: author))
+    edit_plan.reload
+    expect(edit_plan.slug).to eq("edit")
+
+    # The full path /<handle>/<folder-slug>/edit is a valid plan URL,
+    # not a sub-page action — resolve must find the plan, not strip "edit".
+    url = "#{base_url}/#{edit_plan.url_path}"
+    resolved = described_class.resolve(url: url, base_url: base_url)
+    expect(resolved&.external_id).to eq(edit_plan.id)
+  end
+
+  it "encodes Unicode slugs in the canonical URL from for_plan" do
+    author = plan.created_by_user
+    library = author.library
+
+    unicode_plan = create(:plan, :published, created_by_user: author, title: "信頼性向上ロードマップ")
+    create(:plan_placement, plan: unicode_plan,
+      folder: create(:folder, library: library, name: "プロジェクト", created_by_user: author))
+    unicode_plan.reload
+
+    # for_plan must not raise on Unicode url_path — it should percent-encode.
+    expect { described_class.for_plan(unicode_plan, base_url: base_url) }.not_to raise_error
+    preview = described_class.for_plan(unicode_plan, base_url: base_url)
+    expect(preview.canonical_url).to start_with(base_url)
+    # The URL should be valid and parseable.
+    expect { URI.parse(preview.canonical_url) }.not_to raise_error
+  end
+
+  it "resolves percent-encoded browsable URLs for Unicode slugs" do
+    author = plan.created_by_user
+    library = author.library
+
+    unicode_plan = create(:plan, :published, created_by_user: author, title: "信頼性向上ロードマップ")
+    create(:plan_placement, plan: unicode_plan,
+      folder: create(:folder, library: library, name: "プロジェクト", created_by_user: author))
+    unicode_plan.reload
+
+    # Slack sends percent-encoded URLs — simulate that here.
+    encoded_path = unicode_plan.url_path.split("/").map { |s| CGI.escape(s) }.join("/")
+    url = "#{base_url}/#{encoded_path}"
+
+    resolved = described_class.resolve(url: url, base_url: base_url)
+    expect(resolved&.external_id).to eq(unicode_plan.id)
   end
 
   it "rejects foreign origins, credentials, insecure hosts, mount lookalikes, bad IDs, and unsupported paths" do

--- a/spec/services/link_previews_spec.rb
+++ b/spec/services/link_previews_spec.rb
@@ -25,6 +25,51 @@ RSpec.describe CoPlan::LinkPreviews do
     end
   end
 
+  it "resolves browsable URLs — canonical, edit, history, and version sub-pages" do
+    expect(CoPlan::Plan).not_to receive(:visible_to)
+    expect(CoPlan::PlanPolicy).not_to receive(:new)
+
+    plan.update!(visibility: "published")
+    plan.reload
+    # url_path is "handle/slug" — the browsable address without a leading slash.
+    path = plan.url_path
+    expect(path).to be_present, "plan should have a browsable url_path"
+
+    [
+      "#{base_url}/#{path}",
+      "#{base_url}/#{path}/edit",
+      "#{base_url}/#{path}/history",
+      "#{base_url}/#{path}/history/#{plan.current_plan_version.revision}",
+      "#{base_url}/#{path}/history/#{plan.current_plan_version.revision}/diff"
+    ].each do |url|
+      resolved = described_class.resolve(url: url, base_url: base_url)
+      expect(resolved&.external_id).to eq(plan.id),
+        "expected #{url} to resolve to plan #{plan.id}, got #{resolved&.external_id.inspect}"
+    end
+  end
+
+  it "emits a browsable canonical URL from for_plan instead of /plans/<id>" do
+    plan.update!(visibility: "published")
+    plan.reload
+
+    preview = described_class.for_plan(plan, base_url: base_url)
+    # The canonical URL should contain the plan's url_path (handle/slug),
+    # not the legacy /plans/<id> path.
+    expect(preview.canonical_url).to include("/#{plan.url_path}")
+    expect(preview.canonical_url).not_to include("/plans/#{plan.id}")
+  end
+
+  it "does not treat reserved handles as browsable plan paths" do
+    plan.update!(visibility: "published")
+    plan.reload
+
+    # /plans/<id> is a legacy path, not a browsable handle — "plans" is
+    # in RESERVED_HANDLES, so a URL like /plans/something should only
+    # resolve via the legacy matcher, not the browsable matcher.
+    reserved_url = "#{base_url}/plans/#{plan.url_path.split('/').last}"
+    expect(described_class.resolve(url: reserved_url, base_url: base_url)).to be_nil
+  end
+
   it "rejects foreign origins, credentials, insecure hosts, mount lookalikes, bad IDs, and unsupported paths" do
     urls = [
       "https://other.test/app/plans/#{plan.id}",


### PR DESCRIPTION
## Problem

After PR #111 shipped browsable URLs (`/<handle>/<slug-path>`), Slack link unfurling broke. `LinkPreviews.resolve` only matched legacy `/plans/<UUID>` URLs, so pasting a browsable URL in Slack produced no unfurl preview. Additionally, `for_plan` was building canonical URLs as `/plans/<id>` instead of the new browsable path.

## Fix

**`engine/app/services/coplan/link_previews.rb`**

1. `resolve` now tries `plan_from_legacy_path` first (backward compat for `/plans/<UUID>` URLs), then falls back to `plan_from_browsable_path` for the new URL format.

2. `for_plan` now uses `plan.url_path` for the canonical URL (e.g. `/sam/cart-roadmap`) instead of `/plans/<id>`. Falls back to the legacy path only if `url_path` is nil (shouldn't happen after the slug backfill migration).

3. New `plan_from_browsable_path` method:
   - Strips sub-page tails: `/edit`, `/history`, `/history/<rev>`, `/history/<rev>/diff`
   - Matches `/<handle>/<slug-path>` format
   - Rejects reserved handles (`plans`, `people`, `settings`, etc.) so they don't get misinterpreted as user handles
   - Delegates to `Urls::Resolve.call` to walk library → folders → plan
   - Reloads the plan with associations (`created_by_user`, `plan_type`, `current_plan_version`) that `for_plan` needs

4. Extracted `plan_from_legacy_path` from the existing `plan_id_from` + Plan lookup to keep `resolve` clean.

## Specs

Added three new test cases in `spec/services/link_previews_spec.rb`:

- **Browsable URL resolution**: verifies canonical, `/edit`, `/history`, `/history/<rev>`, and `/history/<rev>/diff` URLs all resolve to the correct plan
- **Canonical URL format**: verifies `for_plan` emits browsable URLs (not `/plans/<id>`)
- **Reserved handle rejection**: verifies `/plans/<slug>` (where `plans` is a reserved handle) doesn't get misresolved via the browsable matcher

All existing legacy URL tests continue to pass.