### PR TITLE
Support long reference URLs

### DIFF
--- a/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
+++ b/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
@@ -1,32 +1,43 @@
 # This migration comes from co_plan (originally 20260827000000)
-require "digest"
-
 class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
-  class MigrationReference < ActiveRecord::Base
-    self.table_name = "coplan_references"
-  end
-
   def up
-    add_column :coplan_references, :url_digest, :string, limit: 64
-
-    MigrationReference.reset_column_information
-    MigrationReference.find_each do |reference|
-      reference.update_column(:url_digest, Digest::SHA256.hexdigest(reference.url))
+    if connection.adapter_name == "PostgreSQL"
+      remove_url_index_and_expand_column
+      add_digest_column
+    else
+      add_digest_column
+      remove_url_index_and_expand_column
     end
 
-    # Keep this nullable for rolling-deploy compatibility: old application
-    # processes do not populate the digest. The new model fills any missing
-    # digest before validation, including rows written during this migration.
-    remove_index :coplan_references, column: [ :plan_id, :url ]
-    change_column :coplan_references, :url, :text, null: false
     add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
       name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def down
-    remove_index :coplan_references, name: "index_coplan_references_on_plan_id_and_url_digest"
-    change_column :coplan_references, :url, :string, null: false
-    add_index :coplan_references, [ :plan_id, :url ], unique: true
-    remove_column :coplan_references, :url_digest
+    raise ActiveRecord::IrreversibleMigration,
+      "reference URLs may exceed the former 255-character limit"
+  end
+
+  private
+
+  def add_digest_column
+    add_column :coplan_references, :url_digest, :virtual, type: :string, limit: 64,
+      as: digest_expression, stored: true
+  end
+
+  def remove_url_index_and_expand_column
+    remove_index :coplan_references, column: [ :plan_id, :url ]
+    change_column :coplan_references, :url, :text, null: false
+  end
+
+  def digest_expression
+    case connection.adapter_name
+    when "Mysql2"
+      "SHA2(url, 256)"
+    when "PostgreSQL"
+      "encode(sha256(url::bytea), 'hex')"
+    else
+      raise "Unsupported database adapter: #{connection.adapter_name}"
+    end
   end
 end

--- a/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
+++ b/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
@@ -1,0 +1,32 @@
+# This migration comes from co_plan (originally 20260827000000)
+require "digest"
+
+class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
+  class MigrationReference < ActiveRecord::Base
+    self.table_name = "coplan_references"
+  end
+
+  def up
+    add_column :coplan_references, :url_digest, :string, limit: 64
+
+    MigrationReference.reset_column_information
+    MigrationReference.find_each do |reference|
+      reference.update_column(:url_digest, Digest::SHA256.hexdigest(reference.url))
+    end
+
+    # Keep this nullable for rolling-deploy compatibility: old application
+    # processes do not populate the digest. The new model fills any missing
+    # digest before validation, including rows written during this migration.
+    remove_index :coplan_references, column: [ :plan_id, :url ]
+    change_column :coplan_references, :url, :text, null: false
+    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
+      name: "index_coplan_references_on_plan_id_and_url_digest"
+  end
+
+  def down
+    remove_index :coplan_references, name: "index_coplan_references_on_plan_id_and_url_digest"
+    change_column :coplan_references, :url, :string, null: false
+    add_index :coplan_references, [ :plan_id, :url ], unique: true
+    remove_column :coplan_references, :url_digest
+  end
+end

--- a/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
+++ b/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
@@ -31,7 +31,11 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
 
   def remove_url_index_and_expand_column
     remove_index :coplan_references, column: [ :plan_id, :url ]
-    change_column :coplan_references, :url, :text, null: false
+    if connection.adapter_name == "Mysql2"
+      execute "ALTER TABLE coplan_references MODIFY url TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL"
+    else
+      change_column :coplan_references, :url, :text, null: false
+    end
   end
 
   def digest_expression

--- a/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
+++ b/db/migrate/20260827134208_expand_coplan_reference_urls.co_plan.rb
@@ -4,13 +4,12 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
     if connection.adapter_name == "PostgreSQL"
       remove_url_index_and_expand_column
       add_digest_column
+      add_digest_index
     else
       add_digest_column
+      add_digest_index
       remove_url_index_and_expand_column
     end
-
-    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
-      name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def down
@@ -23,6 +22,11 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
   def add_digest_column
     add_column :coplan_references, :url_digest, :virtual, type: :string, limit: 64,
       as: digest_expression, stored: true
+  end
+
+  def add_digest_index
+    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
+      name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def remove_url_index_and_expand_column

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -386,7 +386,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_134208) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.text "url", null: false
-    t.string "url_digest", limit: 64
+    t.virtual "url_digest", type: :string, limit: 64, as: "sha2(`url`,256)", stored: true
     t.index ["plan_id", "key"], name: "index_coplan_references_on_plan_id_and_key", unique: true
     t.index ["plan_id", "url_digest"], name: "index_coplan_references_on_plan_id_and_url_digest", unique: true
     t.index ["source"], name: "index_coplan_references_on_source"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_134208) do
   create_table "active_admin_comments", id: { type: :string, limit: 36 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "author_id"
     t.string "author_type"
@@ -385,9 +385,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
     t.string "target_plan_id", limit: 36
     t.string "title"
     t.datetime "updated_at", null: false
-    t.string "url", null: false
+    t.text "url", null: false
+    t.string "url_digest", limit: 64
     t.index ["plan_id", "key"], name: "index_coplan_references_on_plan_id_and_key", unique: true
-    t.index ["plan_id", "url"], name: "index_coplan_references_on_plan_id_and_url", unique: true
+    t.index ["plan_id", "url_digest"], name: "index_coplan_references_on_plan_id_and_url_digest", unique: true
     t.index ["source"], name: "index_coplan_references_on_source"
     t.index ["target_plan_id"], name: "index_coplan_references_on_target_plan_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -385,7 +385,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_27_134208) do
     t.string "target_plan_id", limit: 36
     t.string "title"
     t.datetime "updated_at", null: false
-    t.text "url", null: false
+    t.text "url", null: false, collation: "utf8mb4_bin"
     t.virtual "url_digest", type: :string, limit: 64, as: "sha2(`url`,256)", stored: true
     t.index ["plan_id", "key"], name: "index_coplan_references_on_plan_id_and_key", unique: true
     t.index ["plan_id", "url_digest"], name: "index_coplan_references_on_plan_id_and_url_digest", unique: true

--- a/engine/app/models/coplan/reference.rb
+++ b/engine/app/models/coplan/reference.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 module CoPlan
   class Reference < ApplicationRecord
     SOURCES = %w[extracted explicit].freeze
@@ -7,10 +9,13 @@ module CoPlan
     belongs_to :target_plan, class_name: "CoPlan::Plan", optional: true
 
     validates :url, presence: true, uniqueness: { scope: :plan_id }, format: { with: /\Ahttps?:\/\//i, message: "must start with http:// or https://" }
+    validates :url_digest, presence: true, uniqueness: { scope: :plan_id }
     validates :key, uniqueness: { scope: :plan_id }, allow_nil: true,
       format: { with: /\A[a-z0-9][a-z0-9_-]*\z/, message: "must be lowercase alphanumeric with hyphens/underscores" }, length: { maximum: 64 }
     validates :reference_type, presence: true, inclusion: { in: REFERENCE_TYPES }
     validates :source, presence: true, inclusion: { in: SOURCES }
+
+    before_validation :compute_url_digest, if: -> { url_digest.blank? || url_changed? }
 
     scope :extracted, -> { where(source: "extracted") }
     scope :explicit, -> { where(source: "explicit") }
@@ -138,6 +143,12 @@ module CoPlan
 
     def self.ransackable_associations(auth_object = nil)
       %w[plan target_plan]
+    end
+
+    private
+
+    def compute_url_digest
+      self.url_digest = Digest::SHA256.hexdigest(url) if url.present?
     end
   end
 end

--- a/engine/app/models/coplan/reference.rb
+++ b/engine/app/models/coplan/reference.rb
@@ -1,5 +1,3 @@
-require "digest"
-
 module CoPlan
   class Reference < ApplicationRecord
     SOURCES = %w[extracted explicit].freeze
@@ -9,13 +7,10 @@ module CoPlan
     belongs_to :target_plan, class_name: "CoPlan::Plan", optional: true
 
     validates :url, presence: true, uniqueness: { scope: :plan_id }, format: { with: /\Ahttps?:\/\//i, message: "must start with http:// or https://" }
-    validates :url_digest, presence: true, uniqueness: { scope: :plan_id }
     validates :key, uniqueness: { scope: :plan_id }, allow_nil: true,
       format: { with: /\A[a-z0-9][a-z0-9_-]*\z/, message: "must be lowercase alphanumeric with hyphens/underscores" }, length: { maximum: 64 }
     validates :reference_type, presence: true, inclusion: { in: REFERENCE_TYPES }
     validates :source, presence: true, inclusion: { in: SOURCES }
-
-    before_validation :compute_url_digest, if: -> { url_digest.blank? || url_changed? }
 
     scope :extracted, -> { where(source: "extracted") }
     scope :explicit, -> { where(source: "explicit") }
@@ -143,12 +138,6 @@ module CoPlan
 
     def self.ransackable_associations(auth_object = nil)
       %w[plan target_plan]
-    end
-
-    private
-
-    def compute_url_digest
-      self.url_digest = Digest::SHA256.hexdigest(url) if url.present?
     end
   end
 end

--- a/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
+++ b/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
@@ -1,0 +1,31 @@
+require "digest"
+
+class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
+  class MigrationReference < ActiveRecord::Base
+    self.table_name = "coplan_references"
+  end
+
+  def up
+    add_column :coplan_references, :url_digest, :string, limit: 64
+
+    MigrationReference.reset_column_information
+    MigrationReference.find_each do |reference|
+      reference.update_column(:url_digest, Digest::SHA256.hexdigest(reference.url))
+    end
+
+    # Keep this nullable for rolling-deploy compatibility: old application
+    # processes do not populate the digest. The new model fills any missing
+    # digest before validation, including rows written during this migration.
+    remove_index :coplan_references, column: [ :plan_id, :url ]
+    change_column :coplan_references, :url, :text, null: false
+    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
+      name: "index_coplan_references_on_plan_id_and_url_digest"
+  end
+
+  def down
+    remove_index :coplan_references, name: "index_coplan_references_on_plan_id_and_url_digest"
+    change_column :coplan_references, :url, :string, null: false
+    add_index :coplan_references, [ :plan_id, :url ], unique: true
+    remove_column :coplan_references, :url_digest
+  end
+end

--- a/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
+++ b/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
@@ -1,31 +1,42 @@
-require "digest"
-
 class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
-  class MigrationReference < ActiveRecord::Base
-    self.table_name = "coplan_references"
-  end
-
   def up
-    add_column :coplan_references, :url_digest, :string, limit: 64
-
-    MigrationReference.reset_column_information
-    MigrationReference.find_each do |reference|
-      reference.update_column(:url_digest, Digest::SHA256.hexdigest(reference.url))
+    if connection.adapter_name == "PostgreSQL"
+      remove_url_index_and_expand_column
+      add_digest_column
+    else
+      add_digest_column
+      remove_url_index_and_expand_column
     end
 
-    # Keep this nullable for rolling-deploy compatibility: old application
-    # processes do not populate the digest. The new model fills any missing
-    # digest before validation, including rows written during this migration.
-    remove_index :coplan_references, column: [ :plan_id, :url ]
-    change_column :coplan_references, :url, :text, null: false
     add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
       name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def down
-    remove_index :coplan_references, name: "index_coplan_references_on_plan_id_and_url_digest"
-    change_column :coplan_references, :url, :string, null: false
-    add_index :coplan_references, [ :plan_id, :url ], unique: true
-    remove_column :coplan_references, :url_digest
+    raise ActiveRecord::IrreversibleMigration,
+      "reference URLs may exceed the former 255-character limit"
+  end
+
+  private
+
+  def add_digest_column
+    add_column :coplan_references, :url_digest, :virtual, type: :string, limit: 64,
+      as: digest_expression, stored: true
+  end
+
+  def remove_url_index_and_expand_column
+    remove_index :coplan_references, column: [ :plan_id, :url ]
+    change_column :coplan_references, :url, :text, null: false
+  end
+
+  def digest_expression
+    case connection.adapter_name
+    when "Mysql2"
+      "SHA2(url, 256)"
+    when "PostgreSQL"
+      "encode(sha256(url::bytea), 'hex')"
+    else
+      raise "Unsupported database adapter: #{connection.adapter_name}"
+    end
   end
 end

--- a/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
+++ b/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
@@ -30,7 +30,11 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
 
   def remove_url_index_and_expand_column
     remove_index :coplan_references, column: [ :plan_id, :url ]
-    change_column :coplan_references, :url, :text, null: false
+    if connection.adapter_name == "Mysql2"
+      execute "ALTER TABLE coplan_references MODIFY url TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL"
+    else
+      change_column :coplan_references, :url, :text, null: false
+    end
   end
 
   def digest_expression

--- a/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
+++ b/engine/db/migrate/20260827000000_expand_coplan_reference_urls.rb
@@ -3,13 +3,12 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
     if connection.adapter_name == "PostgreSQL"
       remove_url_index_and_expand_column
       add_digest_column
+      add_digest_index
     else
       add_digest_column
+      add_digest_index
       remove_url_index_and_expand_column
     end
-
-    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
-      name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def down
@@ -22,6 +21,11 @@ class ExpandCoplanReferenceUrls < ActiveRecord::Migration[8.1]
   def add_digest_column
     add_column :coplan_references, :url_digest, :virtual, type: :string, limit: 64,
       as: digest_expression, stored: true
+  end
+
+  def add_digest_index
+    add_index :coplan_references, [ :plan_id, :url_digest ], unique: true,
+      name: "index_coplan_references_on_plan_id_and_url_digest"
   end
 
   def remove_url_index_and_expand_column

--- a/spec/models/coplan/reference_spec.rb
+++ b/spec/models/coplan/reference_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe CoPlan::Reference, type: :model do
       expect(ref).not_to be_valid
     end
 
+    it "stores URLs longer than a database string" do
+      url = "https://example.com/?query=#{"x" * 500}"
+      ref = create(:reference, plan: plan, url: url)
+
+      expect(ref.reload.url).to eq(url)
+      expect(ref.url_digest).to eq(Digest::SHA256.hexdigest(url))
+    end
+
+    it "fills a digest omitted by an older application process" do
+      ref = create(:reference, plan: plan)
+      ref.update_column(:url_digest, nil)
+
+      expect { ref.update!(title: "Updated") }.to change(ref, :url_digest).from(nil)
+    end
+
     it "allows same url on different plans" do
       other_plan = create(:plan)
       create(:reference, plan: plan, url: "https://example.com")

--- a/spec/models/coplan/reference_spec.rb
+++ b/spec/models/coplan/reference_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe CoPlan::Reference, type: :model do
       expect(ref).not_to be_valid
     end
 
+    it "enforces database uniqueness when a writer omits the generated digest" do
+      create(:reference, plan: plan, url: "https://example.com")
+      attributes = {
+        id: SecureRandom.uuid,
+        plan_id: plan.id,
+        url: "https://example.com",
+        reference_type: "link",
+        source: "extracted",
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+
+      expect { described_class.insert_all!([ attributes ]) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
     it "stores URLs longer than a database string" do
       url = "https://example.com/?query=#{"x" * 500}"
       ref = create(:reference, plan: plan, url: url)
@@ -44,11 +59,12 @@ RSpec.describe CoPlan::Reference, type: :model do
       expect(ref.url_digest).to eq(Digest::SHA256.hexdigest(url))
     end
 
-    it "fills a digest omitted by an older application process" do
-      ref = create(:reference, plan: plan)
-      ref.update_column(:url_digest, nil)
+    it "updates the database-generated digest when the URL changes" do
+      ref = create(:reference, plan: plan, url: "https://example.com/old")
 
-      expect { ref.update!(title: "Updated") }.to change(ref, :url_digest).from(nil)
+      ref.update!(url: "https://example.com/new")
+
+      expect(ref.reload.url_digest).to eq(Digest::SHA256.hexdigest(ref.url))
     end
 
     it "allows same url on different plans" do

--- a/spec/models/coplan/reference_spec.rb
+++ b/spec/models/coplan/reference_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe CoPlan::Reference, type: :model do
       ref = build(:reference, plan: other_plan, url: "https://example.com")
       expect(ref).to be_valid
     end
+
+    it "treats case-sensitive URL paths as distinct" do
+      create(:reference, plan: plan, url: "https://example.com/Report")
+
+      expect {
+        create(:reference, plan: plan, url: "https://example.com/report")
+      }.to change(described_class, :count).by(1)
+    end
   end
 
   describe ".classify_url" do

--- a/spec/requests/api/v1/operations_spec.rb
+++ b/spec/requests/api/v1/operations_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe "Api::V1::Operations", type: :request do
     expect(body["revision"]).to eq(plan.current_revision + 1)
   end
 
+  it "applies content containing a URL longer than a database string" do
+    url = "https://example.com/?query=#{"x" * 500}"
+
+    post api_v1_plan_operations_path(plan),
+      params: {
+        lease_token: lease_token,
+        base_revision: plan.current_revision,
+        operations: [
+          { op: "replace_exact", old_text: "Some content here.", new_text: "Read [the report](#{url}).", count: 1 }
+        ]
+      },
+      headers: headers,
+      as: :json
+
+    expect(response).to have_http_status(:created)
+    expect(plan.references.find_by!(url: url).source).to eq("extracted")
+  end
+
   it "apply operations fails without lease" do
     CoPlan::EditLease.find_by(plan_id: plan.id)&.destroy
 

--- a/spec/services/coplan/references/extract_from_content_spec.rb
+++ b/spec/services/coplan/references/extract_from_content_spec.rb
@@ -116,5 +116,13 @@ RSpec.describe CoPlan::References::ExtractFromContent do
       expect(plan.references.count).to eq(1)
       expect(plan.references.first.url).to eq("https://example.com")
     end
+
+    it "extracts URLs longer than a database string" do
+      url = "https://example.com/?query=#{"x" * 500}"
+      update_content(plan, "Visit [the report](#{url}) for more info.")
+
+      expect { described_class.call(plan: plan) }.to change(plan.references, :count).by(1)
+      expect(plan.references.first.url).to eq(url)
+    end
   end
 end


### PR DESCRIPTION
## Why
A Markdown URL longer than 255 characters can overflow `coplan_references.url` during post-commit reference extraction, returning a 500 after an otherwise successful plan edit.

## What
- Store full reference URLs as text and enforce per-plan uniqueness through a database-generated SHA-256 digest
- Generate digests for old and new application processes throughout rolling deploys on MySQL and PostgreSQL
- Use case-sensitive URL comparison so path semantics, validation, and byte-based digests agree
- Cover long URLs and database-level uniqueness at the model, extraction service, and operations API boundaries

## Risk Assessment
Medium — this changes the live references table and uniqueness index. The database-generated digest preserves uniqueness throughout rollout; the migration is explicitly irreversible because narrowing back to 255 characters could truncate newly stored URLs.

## Testing
- MySQL: full suite — 1,837 examples, 0 failures; fresh migration and schema-load targeted suites — 54 examples, 0 failures each
- PostgreSQL: fresh migration plus 54 targeted examples, 0 failures
- Targeted RuboCop — no offenses

Generated with Amp
