### PR TITLE
HOOD-4391: Fix inline code layout in task lists

### DIFF
--- a/engine/app/assets/stylesheets/coplan/application.css
+++ b/engine/app/assets/stylesheets/coplan/application.css
@@ -1673,6 +1673,11 @@ img.avatar {
   cursor: pointer;
 }
 
+.markdown-rendered .task-list-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
 .markdown-rendered .task-list-item input[type="checkbox"] {
   cursor: pointer;
   flex-shrink: 0;

--- a/engine/app/helpers/coplan/markdown_helper.rb
+++ b/engine/app/helpers/coplan/markdown_helper.rb
@@ -34,7 +34,7 @@ module CoPlan
     # version. Bump it whenever the rendering pipeline changes output for the
     # same input (new tags, attribute changes, checkbox wiring, etc.), or
     # stale HTML will be served from cache.
-    RENDER_CACHE_VERSION = 11
+    RENDER_CACHE_VERSION = 12
 
     # Matches `[@username](mention:username)` where the bracket text and link
     # target encode the same username. Username allows letters, digits, dots,
@@ -218,9 +218,22 @@ module CoPlan
 
         li.add_class("task-list-item")
 
-        # Wrap li contents in a <label> so the whole text is clickable
+        # Wrap li contents in a <label> so the whole text is clickable. Keep
+        # the rendered task body in one flex item so inline elements such as
+        # <code> participate in normal inline flow instead of becoming
+        # separate columns alongside the checkbox.
         label = Nokogiri::XML::Node.new("label", doc)
-        li.children.each { |child| label.add_child(child) }
+        task_body = Nokogiri::XML::Node.new("span", doc)
+        task_body["class"] = "task-list-item-content"
+
+        li.children.to_a.each do |child|
+          if child == cb
+            label.add_child(child)
+          else
+            task_body.add_child(child)
+          end
+        end
+        label.add_child(task_body)
         li.add_child(label)
 
         ul = li.parent

--- a/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
+++ b/spec/helpers/coplan/markdown_helper_checkbox_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe CoPlan::MarkdownHelper, type: :helper do
       expect(label.at_css('input[type="checkbox"]')).to be_present
     end
 
+    it "groups task text and inline markup into a single flex item" do
+      html = helper.render_markdown("- [ ] Before `cards.buyer_id`, verify `CardService` behavior")
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      label = doc.at_css("li.task-list-item label")
+      task_body = label.at_css(".task-list-item-content")
+
+      expect(label.element_children.to_a).to eq([ label.at_css('input[type="checkbox"]'), task_body ])
+      expect(task_body.css("code").map(&:text)).to eq([ "cards.buyer_id", "CardService" ])
+      expect(task_body.text.squish).to eq("Before cards.buyer_id, verify CardService behavior")
+    end
+
     it "handles mixed task and non-task items" do
       md = "- [ ] Task item\n- Regular item"
       html = helper.render_markdown(md)


### PR DESCRIPTION
## Why

Task-list labels are flex containers, so inline-code nodes become separate flex items and split a checklist sentence into columns. HOOD-4391 tracks restoring normal inline wrapping for the full task text.

### Before the fix
<img width="1280" height="577" alt="Before" src="https://github.com/user-attachments/assets/a1c3360a-e34a-45d2-bbbb-49328f1d6981" />

### After the fix
<img width="1280" height="577" alt="After" src="https://github.com/user-attachments/assets/5e8a3f85-3f15-4bb3-b8ef-7cd1c4a61eb6" />

## What

- Group each task item's rendered body into one flex child alongside the checkbox.
- Allow wrapped task content to shrink within the row without changing checkbox behavior.
- Bump the render-cache version and add regression coverage for multiple inline-code spans.

## Risk Assessment

Low. The change is limited to task-list HTML and CSS rendering, and the cache-version bump prevents stale markup from being served.

## References

- [HOOD-4391](https://linear.app/squareup/issue/HOOD-4391/fix-coplan-checklist-layout-when-task-text-contains-inline-code)

Generated with Codex
