### PR TITLE
COPLAN-SQUARE-14: Direct agents to the API

### DIFF
--- a/engine/app/controllers/coplan/application_controller.rb
+++ b/engine/app/controllers/coplan/application_controller.rb
@@ -45,11 +45,14 @@ module CoPlan
     end
 
     def authenticate_coplan_user!
+      if request.get? && agent_request?
+        render plain: agent_redirect_instructions, content_type: "text/markdown", status: :unauthorized
+        return
+      end
+
       @current_coplan_user = CoPlan::Authentication.user_from_request(request)
       unless @current_coplan_user
-        if agent_request?
-          render plain: agent_redirect_instructions, content_type: "text/markdown", status: :unauthorized
-        elsif CoPlan.configuration.sign_in_path
+        if CoPlan.configuration.sign_in_path
           redirect_to CoPlan.configuration.sign_in_path, alert: "Please sign in."
         else
           head :unauthorized

--- a/spec/requests/browse_spec.rb
+++ b/spec/requests/browse_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe "Browsable library URLs", type: :request do
       expect(response).to have_http_status(:ok)
       expect(versioned.slug).to eq("pricing-v1-2")
     end
+
+    it "directs an authenticated non-browser client to the API instructions" do
+      get "/hampton/liveorder/q3/cart-roadmap", headers: {
+        "Accept" => "text/markdown",
+        "User-Agent" => "curl/8.11.0"
+      }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.media_type).to eq("text/markdown")
+      expect(response.body).to include("# CoPlan API")
+      expect(response.body).to include("/agent-instructions")
+    end
   end
 
   describe "the owner's own library" do


### PR DESCRIPTION
## Why

Authenticated non-browser GETs could bypass the CoPlan agent redirect and fall through to web rendering. A curl request negotiating Markdown then caused an ActionView::MissingTemplate error instead of directing the caller to the API.

## What

- Return the existing Markdown API-instructions response for non-browser GETs before web authentication
- Preserve authenticated non-GET requests such as Web Push registration
- Cover the production failure mode with an authenticated curl regression test

## Risk Assessment

Low. The change is limited to GET requests whose user agent is not browser-like; browser traffic and API controllers are unchanged.

## References

- [Sentry COPLAN-SQUARE-14](https://square-inc.sentry.io/issues/7695610894/)

Generated with Amp
